### PR TITLE
ci: Enabling job to run tests on Go 1.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,23 +1,47 @@
+---
 name: UnitTesting
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: '^1.14.4'
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.14.4'
 
-    - name: Running unit tests
-      run: make test
+      - name: Running unit tests
+        run: make test
 
+  build-centos5:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/github.com/newrelic/infrastructure-agent
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: src/github.com/newrelic/infrastructure-agent
+
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.14.4'
+
+      - name: Setup CentOS 5
+        run: make go-get-go-1_9
+
+      - name: Running unit tests
+        env:
+          GOPATH: "${{ github.workspace }}"
+        run: make test-centos-5

--- a/scripts/infra_build.mk
+++ b/scripts/infra_build.mk
@@ -94,6 +94,7 @@ dist-for-os:
 	done
 
 .PHONY: test-centos-5
+test-centos-5: go-get
 test-centos-5: TEST_FLAGS=
 test-centos-5:
 	@printf '\n================================================================\n'


### PR DESCRIPTION
#### Description of the changes

This PR enables running Infra agent test on Go 1.9 so we can check that we are still able to support older Linux OS such as CentOS 5.