### PR TITLE
feat(config): cherry-pick config to pass to integrations

### DIFF
--- a/internal/integrations/v4/constants/constants.go
+++ b/internal/integrations/v4/constants/constants.go
@@ -3,3 +3,5 @@
 package constants
 
 const EnableVerbose = "enable_verbose"
+const AgentDir = "AGENT_DIR"
+const AppDataDir = "APP_DATA_DIR"

--- a/internal/integrations/v4/executor/executor.go
+++ b/internal/integrations/v4/executor/executor.go
@@ -138,6 +138,16 @@ func (r *Executor) buildCommand(ctx context.Context) *exec.Cmd {
 		cmd.Env = append(cmd.Env, "VERBOSE=1")
 	}
 
+	agentDir, ok := ctx.Value(constants.AgentDir).(string)
+	if ok && agentDir != "" {
+		cmd.Env = append(cmd.Env, constants.AgentDir+"="+agentDir)
+	}
+
+	appDataDir, ok := ctx.Value(constants.AppDataDir).(string)
+	if ok && appDataDir != "" {
+		cmd.Env = append(cmd.Env, constants.AppDataDir+"="+appDataDir)
+	}
+
 	cmd.Dir = r.Cfg.Directory
 	return cmd
 }

--- a/pkg/integrations/v4/manager_test.go
+++ b/pkg/integrations/v4/manager_test.go
@@ -931,6 +931,34 @@ func TestManager_contextWithVerbose(t *testing.T) {
 	assert.Equal(t, actualContext.Value(constants.EnableVerbose), 1)
 }
 
+func TestManager_contextWithAgentConfig(t *testing.T) {
+
+	actualContext := contextWithAgentConfig(context.Background(),nil)
+	assert.Equal(t, actualContext.Value(constants.AppDataDir), nil)
+	assert.Equal(t, actualContext.Value(constants.AgentDir), nil)
+
+	mgr:= Manager{
+		config: NewConfig(1, nil, nil, nil, nil,
+			map[string]interface{}{
+			"feature_not_passed1": nil,
+			constants.AppDataDir: "test/appDir",
+			constants.AgentDir: "test/agentDir",
+			"feature_not_passed2": "test",
+			"feature_not_passed3": 15,
+		},
+		),
+	}
+
+	actualContext = contextWithAgentConfig(context.Background(), mgr.config.ConfigToIntegrations)
+	
+	assert.Equal(t, actualContext.Value(constants.AppDataDir), "test/appDir")
+	assert.Equal(t, actualContext.Value(constants.AgentDir), "test/agentDir")
+	assert.Equal(t, actualContext.Value("feature_not_passed1"), nil)
+	assert.Equal(t, actualContext.Value("feature_not_passed2"), nil)
+	assert.Equal(t, actualContext.Value("feature_not_passed3"), nil)
+
+}
+
 func tempFiles(pathContents map[string]string) (directory string, err error) {
 	dir, err := ioutil.TempDir("", "tempFiles")
 	if err != nil {


### PR DESCRIPTION
#### Description of the changes

Sometimes it is needed to pass some agent configurations down to integrations and it was not possible to do so.

I added a method to cherry pick those variables and pass them as EnvVariables.

This is useful for example if we need to save same cache data in an integration to retrieve the app_data_dir

#### PR Review Checklist
### Author

- [x] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
- [x] clean and format the code
- [x] add unit tests for your changes and make sure all unit tests are passing
- [ ] add a risk label after carefully considering the "blast radius" of your changes (not available)
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer
- [ ] address the feedback 
- [x] add a "ready for review" label. Only PRs with this label will be reviewed.

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
