### PR TITLE
fix: do not return early when mapping devices

### DIFF
--- a/pkg/metrics/storage/storage_sampler_linux.go
+++ b/pkg/metrics/storage/storage_sampler_linux.go
@@ -382,7 +382,6 @@ func CalculateDeviceMapping(activeDevices map[string]bool, isContainerized bool)
 				// mapped device name. ex: dm-x -> /dev/mapper/xxx
 				deviceKey := fmt.Sprintf("dm-%s", devNumbers[1])
 				devToFullDevicePath[deviceKey] = deviceName
-				break
 			}
 		} else {
 			match := deviceRegexp.FindStringSubmatch(deviceName)


### PR DESCRIPTION
CalculateDeviceMappings was returning early when it matched an lvm device and so it would not return all lvm matching devices and therefore not fetch IO disk counters for those devices