### PR TITLE
Process sampling disabled by default with feature-flag & config-option

### DIFF
--- a/cmd/newrelic-infra/newrelic-infra.go
+++ b/cmd/newrelic-infra/newrelic-infra.go
@@ -228,7 +228,7 @@ func initializeAgentAndRun(c *config.Config, logFwCfg config.LogForward) error {
 	// Basic initialization of the agent.
 	timedLog.WithField("version", buildVersion).Info("Initializing")
 
-	agt, err := agent.NewAgent(c, buildVersion)
+	agt, err := agent.NewAgent(c, buildVersion, ffManager)
 	if err != nil {
 		fatal(err, "Agent cannot initialize.")
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -8,6 +8,8 @@ import (
 	"github.com/newrelic/infrastructure-agent/internal/agent/cmdchannel/handler"
 	"github.com/newrelic/infrastructure-agent/internal/feature_flags"
 	"github.com/newrelic/infrastructure-agent/pkg/metrics/sampler"
+	"github.com/newrelic/infrastructure-agent/pkg/metrics/types"
+
 	"net"
 	"net/http"
 	"net/url"
@@ -291,8 +293,8 @@ func newSampleMatchFn(enableProcessMetrics *bool, includeMetricsMatchers config.
 			alog.Debug("EnableProcessMetrics is FALSE, process metrics will be DISABLED")
 			return func(sample interface{}) bool {
 				// no process samples are included
-				// TODO filter process
-				return false
+				_, ok := sample.(types.ProcessSample)
+				return ok
 			}
 		} else {
 			ec := sampler.NewMatcherChain(includeMetricsMatchers)
@@ -326,7 +328,8 @@ func newSampleMatchFn(enableProcessMetrics *bool, includeMetricsMatchers config.
 		if enabled, exists := ffRetriever.GetFeatureFlag(handler.FlagFullProcess); exists {
 			return enabled
 		}
-		return false
+		_, ok := sample.(types.ProcessSample)
+		return ok
 	}
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -290,7 +290,8 @@ func newSampleMatchFn(enableProcessMetrics *bool, includeMetricsMatchers config.
 		if *enableProcessMetrics == false {
 			alog.Debug("EnableProcessMetrics is FALSE, process metrics will be DISABLED")
 			return func(sample interface{}) bool {
-				// no process samples will be sent to backend
+				// no process samples are included
+				// TODO filter process
 				return false
 			}
 		} else {
@@ -302,9 +303,9 @@ func newSampleMatchFn(enableProcessMetrics *bool, includeMetricsMatchers config.
 				}
 			}
 
-			alog.Debug("EnableProcessMetrics is TRUE and no rules defined, ALL process metrics will be ENABLED")
+			alog.Debug("EnableProcessMetrics is TRUE and rules are NOT defined, ALL process metrics will be ENABLED")
 			return func(sample interface{}) bool {
-				// ALL process samples will be sent to backend
+				// all process samples are included
 				return true
 			}
 		}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -305,7 +305,7 @@ func newSampleMatcher(c *config.Config, ffRetriever feature_flags.Retriever) fun
 	// if config option is not set, check if we have rules defined. those take precedence over the FF
 	ec := sampler.NewMatcherChain(c.IncludeMetricsMatchers)
 	if ec.Enabled {
-		alog.Debug("EnableProcessMetrics is TRUE and rules ARE defined, process metrics will be ENABLED for matching processes")
+		alog.Debug("EnableProcessMetrics is EMPTY and rules ARE defined, process metrics will be ENABLED for matching processes")
 		return func(sample interface{}) bool {
 			return ec.Evaluate(sample)
 		}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -312,14 +312,11 @@ func newSampleMatcher(c *config.Config, ffRetriever feature_flags.Retriever) fun
 	}
 
 	// configuration option is not defined, check feature flag
-	if enabled, exists := ffRetriever.GetFeatureFlag(handler.FlagFullProcess); exists {
-		return func(sample interface{}) bool {
-			return enabled
-		}
-	}
-
 	// if nothing is configured, use back compat behaviour and include let every process sample
 	return func(sample interface{}) bool {
+		if enabled, exists := ffRetriever.GetFeatureFlag(handler.FlagFullProcess); exists {
+			return enabled
+		}
 		return true
 	}
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -311,13 +311,13 @@ func newSampleMatcher(c *config.Config, ffRetriever feature_flags.Retriever) fun
 		}
 	}
 
-	// configuration option is not defined, check feature flag
-	// if nothing is configured, use back compat behaviour and include let every process sample
+	// configuration option is not defined and feature flag is present, FF determines, otherwise
+	// all process samples will be excluded
 	return func(sample interface{}) bool {
 		if enabled, exists := ffRetriever.GetFeatureFlag(handler.FlagFullProcess); exists {
 			return enabled
 		}
-		return true
+		return false
 	}
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -18,10 +18,9 @@ import (
 
 	"github.com/newrelic/infrastructure-agent/internal/feature_flags"
 	"github.com/newrelic/infrastructure-agent/internal/feature_flags/test"
-	"github.com/newrelic/infrastructure-agent/pkg/ctl"
-	"github.com/newrelic/infrastructure-agent/pkg/sample"
-
 	"github.com/newrelic/infrastructure-agent/pkg/backend/backoff"
+	"github.com/newrelic/infrastructure-agent/pkg/ctl"
+	"github.com/newrelic/infrastructure-agent/pkg/metrics/types"
 
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo"
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/cloud"
@@ -730,18 +729,12 @@ func Test_ProcessSampling_FeatureFlagIsEnabled(t *testing.T) {
 	assert.Equal(t, true, actual)
 }
 
-// ProcessSample is mimicking the real ProcessSample which we can't reference from here due to import cycles.
-type ProcessSample struct {
-	sample.BaseEvent
-	ProcessDisplayName string
-}
-
 func getBooleanPtr(val bool) *bool {
 	return &val
 }
 
 func Test_ProcessSampling(t *testing.T) {
-	someSample := ProcessSample{
+	someSample := types.ProcessSample{
 		ProcessDisplayName: "some-process",
 	}
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -764,18 +764,11 @@ func Test_ProcessSampling(t *testing.T) {
 			want: true,
 		},
 		{
-			// if nothing is configured, the FF retriever is checked so it needs to not be nil
-			name: "ConfigurationOptionIsNotPresentAndNoMatcherPresentAndFeatureFlagIsNotConfigured",
-			c:    &config.Config{},
-			ff:   test.NewFFRetrieverReturning(false, false),
-			want: true,
-		},
-		{
 			// if the matchers are empty (corner case), the FF retriever is checked so it needs to not be nil
 			name: "ConfigurationOptionIsNotPresentAndMatchersAreEmptyAndFeatureFlagIsNotConfigured",
 			c:    &config.Config{IncludeMetricsMatchers: map[string][]string{}},
 			ff:   test.NewFFRetrieverReturning(false, false),
-			want: true,
+			want: false,
 		},
 		{
 			name: "ConfigurationOptionIsNotPresentAndMatchersConfiguredDoNotMatch",
@@ -803,13 +796,13 @@ func Test_ProcessSampling(t *testing.T) {
 			name: "ConfigurationOptionIsNotPresentAndMatchersAreNotConfiguredAndFeatureFlagIsNotFound",
 			c:    &config.Config{},
 			ff:   test.NewFFRetrieverReturning(false, false),
-			want: true,
+			want: false,
 		},
 		{
-			name: "BackwardsCompatibleBehaviour",
+			name: "DefaultBehaviourExcludesProcessSamples",
 			c:    &config.Config{},
 			ff:   test.NewFFRetrieverReturning(false, false),
-			want: true,
+			want: false,
 		},
 	}
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,5 +1,6 @@
 // Copyright 2020 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 package agent
 
 import (

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -735,7 +735,7 @@ func getBooleanPtr(val bool) *bool {
 }
 
 func Test_ProcessSampling(t *testing.T) {
-	someSample := types.ProcessSample{
+	someSample := &types.ProcessSample{
 		ProcessDisplayName: "some-process",
 	}
 
@@ -747,7 +747,6 @@ func Test_ProcessSampling(t *testing.T) {
 	}
 	testCases := []testCase{
 		{
-			// if config op
 			name: "ConfigurationOptionIsDisabled",
 			c:    &config.Config{EnableProcessMetrics: getBooleanPtr(false)},
 			want: false,

--- a/internal/agent/cmdchannel/handler/featureflag_handler.go
+++ b/internal/agent/cmdchannel/handler/featureflag_handler.go
@@ -18,10 +18,9 @@ const (
 	// FFs
 	FlagCategory     = "Infra_Agent"
 	FlagNameRegister = "register_enabled"
+	FlagProtocolV4   = "protocol_v4_enabled"
 	// Config
 	CfgYmlRegisterEnabled = "register_enabled"
-	// Protocol v4 for dimensional metrics
-	ProtocolV4Enabled = "protocol_v4_enabled"
 )
 
 var ffLogger = log.WithComponent("FeatureFlagHandler")
@@ -109,7 +108,7 @@ func (h *FFHandler) Handle(ffArgs commandapi.FFArgs, isInitialFetch bool) {
 	}
 
 	// this is where we handle normal feature flags that are not related to OHIs
-	if ffArgs.Flag == ProtocolV4Enabled {
+	if ffArgs.Flag == FlagProtocolV4 {
 		h.handleFeatureFlag(ffArgs.Flag, ffArgs.Enabled)
 		return
 	}

--- a/internal/agent/cmdchannel/service_test.go
+++ b/internal/agent/cmdchannel/service_test.go
@@ -223,7 +223,7 @@ func TestSrv_InitialFetch_EnablesDimensionalMetrics(t *testing.T) {
 	_, err := s.InitialFetch()
 	assert.NoError(t, err)
 
-	enabled, exists := ffManager.GetFeatureFlag(handler.ProtocolV4Enabled)
+	enabled, exists := ffManager.GetFeatureFlag(handler.FlagProtocolV4)
 	assert.True(t, exists)
 	assert.True(t, enabled)
 }
@@ -309,7 +309,7 @@ func TestSrv_Run(t *testing.T) {
 	wg.Wait()
 	assert.Equal(t, 2, s.pollDelaySecs, "minimum interval is 1sec")
 
-	enabled, exists := ffManager.GetFeatureFlag(handler.ProtocolV4Enabled)
+	enabled, exists := ffManager.GetFeatureFlag(handler.FlagProtocolV4)
 	assert.True(t, enabled)
 	assert.True(t, exists)
 }

--- a/internal/feature_flags/feature_flags.go
+++ b/internal/feature_flags/feature_flags.go
@@ -3,9 +3,8 @@
 package feature_flags
 
 import (
+	"errors"
 	"sync"
-
-	"github.com/pkg/errors"
 )
 
 var (
@@ -28,22 +27,26 @@ type Manager interface {
 }
 
 type FeatureFlags struct {
+	featuresFromCfg map[string]bool
 	features map[string]bool
 	lock     sync.Mutex
 }
 
 func NewManager(initialFeatureFlags map[string]bool) *FeatureFlags {
-	ff := map[string]bool{}
+	fInitial := map[string]bool{}
+	fFromCfg := map[string]bool{}
 
 	if initialFeatureFlags != nil {
 		for key, value := range initialFeatureFlags {
-			ff[key] = value
+			fInitial[key] = value
+			fFromCfg[key] = value
 		}
 	}
 
 	return &FeatureFlags{
-		features: ff,
-		lock:     sync.Mutex{},
+		featuresFromCfg: fFromCfg,
+		features:        fInitial,
+		lock:            sync.Mutex{},
 	}
 }
 
@@ -53,9 +56,13 @@ func (f *FeatureFlags) SetFeatureFlag(name string, enabled bool) error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
-	// if the FF exists, it means either it's in the config file or it has been set already by the CommandChannel.
-	// In either case, do not modify the previous value
-	if _, ok := f.features[name]; ok {
+	// if the FF was provided by user config, that one prevails
+	if _, ok := f.featuresFromCfg[name]; ok {
+		return ErrFeatureFlagAlreadyExists
+	}
+
+	// value from command-channel equals current state
+	if v, ok := f.features[name]; ok && v == enabled {
 		return ErrFeatureFlagAlreadyExists
 	}
 

--- a/internal/feature_flags/feature_flags.go
+++ b/internal/feature_flags/feature_flags.go
@@ -13,6 +13,7 @@ var (
 )
 
 type Setter interface {
+	// SetFeatureFlag enables or disables FF on the config if not already set.
 	SetFeatureFlag(name string, enabled bool) error
 }
 

--- a/internal/feature_flags/test/ff_fakes.go
+++ b/internal/feature_flags/test/ff_fakes.go
@@ -1,0 +1,29 @@
+package test
+
+import "github.com/newrelic/infrastructure-agent/internal/feature_flags"
+
+// EmptyFFRetriever retriever that always returns FFs as non existing.
+var EmptyFFRetriever = &emptyFFRetriever{}
+
+type emptyFFRetriever struct{}
+
+func (e *emptyFFRetriever) GetFeatureFlag(name string) (enabled bool, exists bool) {
+	return false, false
+}
+
+// NewFFRetrieverReturning creates a new FFRetriever mock returning provided values.
+func NewFFRetrieverReturning(enabled bool, exists bool) feature_flags.Retriever {
+	return &fakeFeatureFlagRetriever{
+		enabled: enabled,
+		exists:  exists,
+	}
+}
+
+type fakeFeatureFlagRetriever struct {
+	enabled bool
+	exists  bool
+}
+
+func (ff *fakeFeatureFlagRetriever) GetFeatureFlag(name string) (enabled bool, exists bool) {
+	return ff.enabled, ff.exists
+}

--- a/internal/feature_flags/test/ff_fakes.go
+++ b/internal/feature_flags/test/ff_fakes.go
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package test
 
 import "github.com/newrelic/infrastructure-agent/internal/feature_flags"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -969,6 +969,8 @@ type Config struct {
 	// Default: none
 	// Public: Yes
 	IncludeMetricsMatchers IncludeMetricsMap `yaml:"include_matching_metrics" envconfig:"include_matching_metrics"`
+
+	EnableProcessMetrics *bool `yaml:"enable_process_metrics" envconfig:"enable_process_metrics"`
 }
 
 // Troubleshoot trobleshoot mode configuration.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -970,6 +970,9 @@ type Config struct {
 	// Public: Yes
 	IncludeMetricsMatchers IncludeMetricsMap `yaml:"include_matching_metrics" envconfig:"include_matching_metrics"`
 
+	// EnableProcessMetrics enables/disables process metrics, it does not enforce when not set.
+	// Default: empty
+	// Public: Yes
 	EnableProcessMetrics *bool `yaml:"enable_process_metrics" envconfig:"enable_process_metrics"`
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -960,6 +960,11 @@ type Config struct {
 	// send this to the integrations for them to use for persisting data.
 	DefaultIntegrationsTempDir string
 
+	// EnableProcessMetrics enables/disables process metrics, it does not enforce when not set.
+	// Default: empty
+	// Public: Yes
+	EnableProcessMetrics *bool `yaml:"enable_process_metrics" envconfig:"enable_process_metrics"`
+
 	// IncludeMetricsMatchers Configuration of the metrics matchers that determine which metric data should the agent
 	// send to the New Relic backend.
 	// If no configuration is defined, the previous behaviour is maintained, i.e., every metric data captured is sent.
@@ -969,11 +974,6 @@ type Config struct {
 	// Default: none
 	// Public: Yes
 	IncludeMetricsMatchers IncludeMetricsMap `yaml:"include_matching_metrics" envconfig:"include_matching_metrics"`
-
-	// EnableProcessMetrics enables/disables process metrics, it does not enforce when not set.
-	// Default: empty
-	// Public: Yes
-	EnableProcessMetrics *bool `yaml:"enable_process_metrics" envconfig:"enable_process_metrics"`
 }
 
 // Troubleshoot trobleshoot mode configuration.

--- a/pkg/helpers/detection/detection.go
+++ b/pkg/helpers/detection/detection.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"github.com/newrelic/infrastructure-agent/pkg/log"
+	"github.com/newrelic/infrastructure-agent/pkg/metrics/types"
 	"github.com/sirupsen/logrus"
 
 	"github.com/newrelic/infrastructure-agent/pkg/metrics"
@@ -29,7 +30,7 @@ func GetInfraAgentProcess() (int32, error) {
 
 // IsContainerized is checking if a pid is running inside a docker container.
 func IsContainerized(pid int32, dockerAPIVersion string) (isContainerized bool, containerID string, err error) {
-	p := &metrics.ProcessSample{
+	p := &types.ProcessSample{
 		ProcessID: pid,
 	}
 	d := metrics.NewDockerSampler(60, dockerAPIVersion)

--- a/pkg/integrations/v4/emitter/emitter_test.go
+++ b/pkg/integrations/v4/emitter/emitter_test.go
@@ -421,7 +421,7 @@ func TestLegacy_Emit(t *testing.T) {
 
 			em := &Legacy{
 				Context:       ma,
-				FFRetriever:   feature_flags.NewManager(map[string]bool{handler.ProtocolV4Enabled: true}),
+				FFRetriever:   feature_flags.NewManager(map[string]bool{handler.FlagProtocolV4: true}),
 				MetricsSender: mockedMetricsSender,
 			}
 
@@ -456,7 +456,7 @@ func TestProtocolV4_Emit(t *testing.T) {
 
 	em := &Legacy{
 		Context:       ma,
-		FFRetriever:   feature_flags.NewManager(map[string]bool{handler.ProtocolV4Enabled: true}),
+		FFRetriever:   feature_flags.NewManager(map[string]bool{handler.FlagProtocolV4: true}),
 		MetricsSender: mockedMetricsSender,
 	}
 
@@ -506,7 +506,7 @@ func TestProtocolV4_Emit_WithFFDisabled(t *testing.T) {
 	ma := mockAgent()
 	em := &Legacy{
 		Context:     ma,
-		FFRetriever: feature_flags.NewManager(map[string]bool{handler.ProtocolV4Enabled: false}),
+		FFRetriever: feature_flags.NewManager(map[string]bool{handler.FlagProtocolV4: false}),
 	}
 
 	err := em.Emit(metadata, extraLabels, entityRewrite, integrationJSON)
@@ -514,7 +514,7 @@ func TestProtocolV4_Emit_WithFFDisabled(t *testing.T) {
 }
 
 func TestParsePayloadV4(t *testing.T) {
-	ffm := feature_flags.NewManager(map[string]bool{handler.ProtocolV4Enabled: true})
+	ffm := feature_flags.NewManager(map[string]bool{handler.FlagProtocolV4: true})
 
 	d, err := ParsePayloadV4(integrationFixture.ProtocolV4.Payload, ffm)
 	assert.NoError(t, err)

--- a/pkg/integrations/v4/emitter/emitter_v4.go
+++ b/pkg/integrations/v4/emitter/emitter_v4.go
@@ -118,7 +118,7 @@ func ParsePayloadV4(raw []byte, ffManager feature_flags.Retriever) (dataV4 proto
 		return
 	}
 
-	if enabled, ok := ffManager.GetFeatureFlag(handler.ProtocolV4Enabled); !ok || !enabled {
+	if enabled, ok := ffManager.GetFeatureFlag(handler.FlagProtocolV4); !ok || !enabled {
 		err = ProtocolV4NotEnabledErr
 		return
 	}

--- a/pkg/metrics/docker_sampler.go
+++ b/pkg/metrics/docker_sampler.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/newrelic/infrastructure-agent/pkg/log"
+	metricTypes "github.com/newrelic/infrastructure-agent/pkg/metrics/types"
 
 	"github.com/docker/docker/api/types"
 	"github.com/newrelic/infrastructure-agent/pkg/helpers"
@@ -78,7 +79,7 @@ func (d *DockerSampler) NewDecorator() (ProcessDecorator, error) {
 }
 
 type ProcessDecorator interface {
-	Decorate(process *ProcessSample)
+	Decorate(process *metricTypes.ProcessSample)
 }
 
 type decoratorImpl struct {
@@ -169,7 +170,7 @@ func (d *decoratorImpl) pidsContainers() (map[int32]types.Container, error) {
 }
 
 // DecorateProcesses adds container information to all the processes that belong to a container
-func (d *decoratorImpl) Decorate(process *ProcessSample) {
+func (d *decoratorImpl) Decorate(process *metricTypes.ProcessSample) {
 	if container, ok := d.pids[process.ProcessID]; ok {
 		imageIDComponents := strings.Split(container.ImageID, ":")
 		process.ContainerImage = imageIDComponents[len(imageIDComponents)-1]

--- a/pkg/metrics/docker_sampler_test.go
+++ b/pkg/metrics/docker_sampler_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	metricTypes "github.com/newrelic/infrastructure-agent/pkg/metrics/types"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/newrelic/infrastructure-agent/pkg/helpers"
@@ -70,7 +71,7 @@ func TestProcessDecoratorDecorateProcessSampleBadProcessID(t *testing.T) {
 	decorator, err := newDecoratorImpl(mock, pidsCache)
 	assert.NoError(t, err)
 
-	process := ProcessSample{ProcessID: 666, ContainerLabels: map[string]string{}}
+	process := metricTypes.ProcessSample{ProcessID: 666, ContainerLabels: map[string]string{}}
 	decorator.Decorate(&process)
 
 	assert.Equal(t, process.ContainerImage, "")
@@ -88,7 +89,7 @@ func TestProcessDecoratorDecorateProcessSample(t *testing.T) {
 	decorator, err := newDecoratorImpl(mock, pidsCache)
 	assert.NoError(t, err)
 
-	process := ProcessSample{ProcessID: 123}
+	process := metricTypes.ProcessSample{ProcessID: 123}
 	decorator.Decorate(&process)
 
 	assert.Equal(t, process.ContainerImage, "14.04")

--- a/pkg/metrics/docker_sampler_windows_test.go
+++ b/pkg/metrics/docker_sampler_windows_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/newrelic/infrastructure-agent/internal/agent/mocks"
 	"github.com/newrelic/infrastructure-agent/pkg/config"
+	metricTypes "github.com/newrelic/infrastructure-agent/pkg/metrics/types"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/net"
 	"github.com/shirou/gopsutil/process"
@@ -42,7 +43,7 @@ func TestDocker(t *testing.T) {
 
 	assert.Len(t, samples, 3)
 	for i, sample := range samples {
-		procSample, ok := sample.(*ProcessSample)
+		procSample, ok := sample.(*metricTypes.ProcessSample)
 		assert.True(t, ok)
 
 		switch i {
@@ -229,6 +230,6 @@ func (m *MockProcessInterrogator) NewProcess(pid int32) (ProcessWrapper, error) 
 	return &MockInternalProcess{p}, nil
 }
 
-func (m *MockProcessInterrogator) FillFromStatus(*ProcessSample) error {
+func (m *MockProcessInterrogator) FillFromStatus(*metricTypes.ProcessSample) error {
 	return nil
 }

--- a/pkg/metrics/process/cache.go
+++ b/pkg/metrics/process/cache.go
@@ -6,7 +6,7 @@ package process
 
 import (
 	"github.com/newrelic/infrastructure-agent/pkg/helpers/lru"
-	"github.com/newrelic/infrastructure-agent/pkg/metrics"
+	"github.com/newrelic/infrastructure-agent/pkg/metrics/types"
 )
 
 // processCache wraps the invocations to lru.Cache, enabling clearer code and type safety
@@ -16,7 +16,7 @@ type cache struct {
 
 type cacheEntry struct {
 	process    *linuxProcess
-	lastSample *metrics.ProcessSample // The last event we generated for this process, so we can re-use metadata which doesn't change
+	lastSample *types.ProcessSample // The last event we generated for this process, so we can re-use metadata which doesn't change
 }
 
 func newCache() cache {

--- a/pkg/metrics/process/sampler_linux.go
+++ b/pkg/metrics/process/sampler_linux.go
@@ -13,6 +13,7 @@ import (
 	"github.com/newrelic/infrastructure-agent/pkg/entity"
 	metrics "github.com/newrelic/infrastructure-agent/pkg/metrics"
 	sampler "github.com/newrelic/infrastructure-agent/pkg/metrics/sampler"
+	"github.com/newrelic/infrastructure-agent/pkg/metrics/types"
 	"github.com/newrelic/infrastructure-agent/pkg/sample"
 )
 
@@ -107,7 +108,7 @@ func (ps *processSampler) Sample() (results sample.EventBatch, err error) {
 	}
 
 	for _, pid := range pids {
-		var sample *metrics.ProcessSample
+		var sample *types.ProcessSample
 		var err error
 
 		sample, err = ps.harvest.Do(pid, elapsedSeconds)
@@ -128,7 +129,7 @@ func (ps *processSampler) Sample() (results sample.EventBatch, err error) {
 	return results, nil
 }
 
-func (self *processSampler) normalizeSample(s *metrics.ProcessSample) sample.Event {
+func (self *processSampler) normalizeSample(s *types.ProcessSample) sample.Event {
 	if len(s.ContainerLabels) > 0 {
 		sb, err := json.Marshal(s)
 		if err == nil {

--- a/pkg/metrics/process/sampler_linux_test.go
+++ b/pkg/metrics/process/sampler_linux_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/newrelic/infrastructure-agent/pkg/metrics/types"
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo"
 
 	"github.com/stretchr/testify/assert"
@@ -29,7 +30,7 @@ func TestProcessSampler_DockerDecorator(t *testing.T) {
 	ctx.On("Config").Return(&config.Config{})
 	ctx.On("GetServiceForPid", mock.Anything).Return("", false)
 	ps := NewProcessSampler(ctx).(*processSampler)
-	ps.harvest = &harvesterMock{samples: map[int32]*metrics.ProcessSample{
+	ps.harvest = &harvesterMock{samples: map[int32]*types.ProcessSample{
 		1: {
 			ProcessID:          1,
 			ProcessDisplayName: "Hello",
@@ -65,7 +66,7 @@ func TestProcessSampler_DockerDecorator(t *testing.T) {
 }
 
 type harvesterMock struct {
-	samples map[int32]*metrics.ProcessSample
+	samples map[int32]*types.ProcessSample
 }
 
 func (hm *harvesterMock) Pids() ([]int32, error) {
@@ -76,7 +77,7 @@ func (hm *harvesterMock) Pids() ([]int32, error) {
 	return keys, nil
 }
 
-func (hm *harvesterMock) Do(pid int32, elapsedSeconds float64) (*metrics.ProcessSample, error) {
+func (hm *harvesterMock) Do(pid int32, elapsedSeconds float64) (*types.ProcessSample, error) {
 	return hm.samples[pid], nil
 }
 
@@ -92,7 +93,7 @@ func (*fakeContainerSampler) NewDecorator() (metrics.ProcessDecorator, error) {
 
 type fakeDecorator struct{}
 
-func (pd *fakeDecorator) Decorate(process *metrics.ProcessSample) {
+func (pd *fakeDecorator) Decorate(process *types.ProcessSample) {
 	process.ContainerImage = "decorated"
 	process.ContainerLabels = map[string]string{
 		"label1": "value1",

--- a/pkg/metrics/procs.go
+++ b/pkg/metrics/procs.go
@@ -4,7 +4,7 @@ package metrics
 
 import (
 	"github.com/newrelic/infrastructure-agent/pkg/log"
-	"github.com/newrelic/infrastructure-agent/pkg/sample"
+	"github.com/newrelic/infrastructure-agent/pkg/metrics/types"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/process"
 	"github.com/sirupsen/logrus"
@@ -17,45 +17,8 @@ var pslog = log.WithFieldsF(func() logrus.Fields {
 	}
 })
 
-// We use pointers to floats instead of plain floats so that if we don't set one
-// of the values, it will not be sent to Dirac. (Not using pointers would mean
-// that Go would always send a default value of 0.)
-type ProcessSample struct {
-	sample.BaseEvent
-	ProcessDisplayName    string   `json:"processDisplayName"`
-	ProcessID             int32    `json:"processId"`
-	CommandName           string   `json:"commandName"`
-	User                  string   `json:"userName,omitempty"`
-	MemoryRSSBytes        int64    `json:"memoryResidentSizeBytes"`
-	MemoryVMSBytes        int64    `json:"memoryVirtualSizeBytes"`
-	CPUPercent            float64  `json:"cpuPercent"`
-	CPUUserPercent        float64  `json:"cpuUserPercent"`
-	CPUSystemPercent      float64  `json:"cpuSystemPercent"`
-	ContainerImage        string   `json:"containerImage,omitempty"`
-	ContainerImageName    string   `json:"containerImageName,omitempty"`
-	ContainerName         string   `json:"containerName,omitempty"`
-	ContainerID           string   `json:"containerId,omitempty"`
-	Contained             string   `json:"contained,omitempty"`
-	CmdLine               string   `json:"commandLine,omitempty"`
-	Status                string   `json:"state,omitempty"`
-	ParentProcessID       int32    `json:"parentProcessId,omitempty"`
-	ThreadCount           int32    `json:"threadCount,omitempty"`
-	FdCount               *int32   `json:"fileDescriptorCount,omitempty"`
-	IOReadCountPerSecond  *float64 `json:"ioReadCountPerSecond,omitempty"`
-	IOWriteCountPerSecond *float64 `json:"ioWriteCountPerSecond,omitempty"`
-	IOReadBytesPerSecond  *float64 `json:"ioReadBytesPerSecond,omitempty"`
-	IOWriteBytesPerSecond *float64 `json:"ioWriteBytesPerSecond,omitempty"`
-	IOTotalReadCount      *uint64  `json:"ioTotalReadCount,omitempty"`
-	IOTotalWriteCount     *uint64  `json:"ioTotalWriteCount,omitempty"`
-	IOTotalReadBytes      *uint64  `json:"ioTotalReadBytes,omitempty"`
-	IOTotalWriteBytes     *uint64  `json:"ioTotalWriteBytes,omitempty"`
-	// Auxiliary values, not to be reported
-	LastIOCounters  *process.IOCountersStat `json:"-"`
-	ContainerLabels map[string]string       `json:"-"`
-}
-
-func NewProcessSample(pid int32) *ProcessSample {
-	return &ProcessSample{
+func NewProcessSample(pid int32) *types.ProcessSample {
+	return &types.ProcessSample{
 		ProcessID: pid,
 		Contained: "false",
 	}
@@ -70,7 +33,7 @@ type ProcessWrapper interface {
 type ProcessCacheEntry struct {
 	process    ProcessWrapper
 	lastCPU    *cpu.TimesStat
-	lastSample *ProcessSample // The last event we generated for this process, so we can re-use metadata which doesn't change
+	lastSample *types.ProcessSample // The last event we generated for this process, so we can re-use metadata which doesn't change
 }
 
 // Deprecated (just for windows compatibility before we migrate it to the "process" package)

--- a/pkg/metrics/procs_windows.go
+++ b/pkg/metrics/procs_windows.go
@@ -14,6 +14,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/newrelic/infrastructure-agent/pkg/metrics/types"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/process"
 	"github.com/sirupsen/logrus"
@@ -91,7 +92,7 @@ func (st *SystemTimes) Sub(other *SystemTimes) *SystemTimes {
 	return &result
 }
 
-func (ip *InternalProcessInterrogator) FillFromStatus(sample *ProcessSample) error {
+func (ip *InternalProcessInterrogator) FillFromStatus(sample *types.ProcessSample) error {
 	return nil
 }
 
@@ -568,7 +569,7 @@ func (self *ProcsMonitor) Sample() (results sample.EventBatch, err error) {
 		for _, winProc := range processes {
 
 			var proc ProcessWrapper
-			var lastSample *ProcessSample
+			var lastSample *types.ProcessSample
 			pid := int32(winProc.ProcessID)
 			if pid == 0 {
 				continue
@@ -792,7 +793,7 @@ func (self *ProcsMonitor) Sample() (results sample.EventBatch, err error) {
 
 	if self.Debug() {
 		for _, sample := range results {
-			helpers.LogStructureDetails(pslog, sample.(*ProcessSample), "ProcessSample", "final", nil)
+			helpers.LogStructureDetails(pslog, sample.(*types.ProcessSample), "ProcessSample", "final", nil)
 		}
 	}
 	return

--- a/pkg/metrics/procs_windows_test.go
+++ b/pkg/metrics/procs_windows_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/StackExchange/wmi"
+	ffTest "github.com/newrelic/infrastructure-agent/internal/feature_flags/test"
 
 	"github.com/newrelic/infrastructure-agent/pkg/log"
 	"github.com/sirupsen/logrus"
@@ -37,7 +38,7 @@ func TestProcessAllowedList(t *testing.T) {
 
 	// this test assumes that go is running
 	config := config.Config{AllowedListProcessSample: []string{"go.exe"}}
-	testAgent, err := agent.NewAgent(&config, "1")
+	testAgent, err := agent.NewAgent(&config, "1", ffTest.EmptyFFRetriever)
 	assert.NoError(t, err)
 	testAgentConfig := testAgent.Context
 	pm := NewProcsMonitor(testAgentConfig)

--- a/pkg/metrics/sampler/matcher.go
+++ b/pkg/metrics/sampler/matcher.go
@@ -5,16 +5,24 @@ package sampler
 
 import (
 	"fmt"
-	"github.com/newrelic/infrastructure-agent/pkg/config"
-	"github.com/newrelic/infrastructure-agent/pkg/trace"
 	"reflect"
 	"regexp"
 	"strings"
+
+	"github.com/newrelic/infrastructure-agent/internal/agent/cmdchannel/handler"
+	"github.com/newrelic/infrastructure-agent/internal/feature_flags"
+	"github.com/newrelic/infrastructure-agent/pkg/config"
+	"github.com/newrelic/infrastructure-agent/pkg/metrics/types"
+	"github.com/newrelic/infrastructure-agent/pkg/trace"
 )
 
 var (
 	typesToEvaluate = map[string]bool{"ProcessSample": true}
 )
+
+// IncludeSampleMatchFn func that returns whether an event/sample should be included, it satisfies
+// the metrics matcher (processor.MatcherChain) interface.
+type IncludeSampleMatchFn func(sample interface{}) bool
 
 // ExpressionMatcher is an interface every evaluator must implement
 type ExpressionMatcher interface {
@@ -204,4 +212,53 @@ func (ne constantMatcher) Evaluate(_ interface{}) bool {
 }
 func (ne constantMatcher) String() string {
 	return fmt.Sprint(ne.value)
+}
+
+// NewSampleMatchFn creates new includeSampleMatchFn func, enableProcessMetrics might be nil when
+// value was not set.
+func NewSampleMatchFn(enableProcessMetrics *bool, includeMetricsMatchers config.IncludeMetricsMap, ffRetriever feature_flags.Retriever) IncludeSampleMatchFn {
+	// configuration option always takes precedence over FF and matchers configuration
+	if enableProcessMetrics != nil {
+		if *enableProcessMetrics == false {
+			trace.MetricMatch("EnableProcessMetrics is FALSE, process metrics will be DISABLED")
+			return func(sample interface{}) bool {
+				// no process samples are included
+				_, ok := sample.(types.ProcessSample)
+				return ok
+			}
+		} else {
+			ec := NewMatcherChain(includeMetricsMatchers)
+			if ec.Enabled {
+				trace.MetricMatch("EnableProcessMetrics is TRUE and rules ARE defined, process metrics will be ENABLED for matching processes")
+				return func(sample interface{}) bool {
+					return ec.Evaluate(sample)
+				}
+			}
+
+			trace.MetricMatch("EnableProcessMetrics is TRUE and rules are NOT defined, ALL process metrics will be ENABLED")
+			return func(sample interface{}) bool {
+				// all process samples are included
+				return true
+			}
+		}
+	}
+
+	// if config option is not set, check if we have rules defined. those take precedence over the FF
+	ec := NewMatcherChain(includeMetricsMatchers)
+	if ec.Enabled {
+		trace.MetricMatch("EnableProcessMetrics is EMPTY and rules ARE defined, process metrics will be ENABLED for matching processes")
+		return func(sample interface{}) bool {
+			return ec.Evaluate(sample)
+		}
+	}
+
+	// configuration option is not defined and feature flag is present, FF determines, otherwise
+	// all process samples will be excluded
+	return func(sample interface{}) bool {
+		if enabled, exists := ffRetriever.GetFeatureFlag(handler.FlagFullProcess); exists {
+			return enabled
+		}
+		_, ok := sample.(types.ProcessSample)
+		return ok
+	}
 }

--- a/pkg/metrics/sampler/matcher.go
+++ b/pkg/metrics/sampler/matcher.go
@@ -224,7 +224,7 @@ func NewSampleMatchFn(enableProcessMetrics *bool, includeMetricsMatchers config.
 			return func(sample interface{}) bool {
 				// no process samples are included
 				_, ok := sample.(types.ProcessSample)
-				return ok
+				return !ok
 			}
 		} else {
 			ec := NewMatcherChain(includeMetricsMatchers)
@@ -259,6 +259,6 @@ func NewSampleMatchFn(enableProcessMetrics *bool, includeMetricsMatchers config.
 			return enabled
 		}
 		_, ok := sample.(types.ProcessSample)
-		return ok
+		return !ok
 	}
 }

--- a/pkg/metrics/sampler/matcher.go
+++ b/pkg/metrics/sampler/matcher.go
@@ -223,7 +223,7 @@ func NewSampleMatchFn(enableProcessMetrics *bool, includeMetricsMatchers config.
 			trace.MetricMatch("EnableProcessMetrics is FALSE, process metrics will be DISABLED")
 			return func(sample interface{}) bool {
 				// no process samples are included
-				_, isProcessSample := sample.(types.ProcessSample)
+				_, isProcessSample := sample.(*types.ProcessSample)
 				return !isProcessSample
 			}
 		} else {
@@ -255,7 +255,7 @@ func NewSampleMatchFn(enableProcessMetrics *bool, includeMetricsMatchers config.
 	// configuration option is not defined and feature flag is present, FF determines, otherwise
 	// all process samples will be excluded
 	return func(sample interface{}) bool {
-		if _, isProcessSample := sample.(types.ProcessSample); !isProcessSample {
+		if _, isProcessSample := sample.(*types.ProcessSample); !isProcessSample {
 			return true
 		}
 

--- a/pkg/metrics/sampler/matcher.go
+++ b/pkg/metrics/sampler/matcher.go
@@ -5,6 +5,7 @@ package sampler
 
 import (
 	"fmt"
+	"github.com/newrelic/infrastructure-agent/pkg/config"
 	"github.com/newrelic/infrastructure-agent/pkg/trace"
 	"reflect"
 	"regexp"
@@ -151,7 +152,7 @@ type MatcherChain struct {
 // NewMatcherChain creates a new chain of matchers.
 // Each expression will generate an matcher that gets added to the chain
 // While the chain will be matched for each "sample", it terminates as soon as 1 match is matched (result = true)
-func NewMatcherChain(expressions map[string][]string) MatcherChain {
+func NewMatcherChain(expressions config.IncludeMetricsMap) MatcherChain {
 	chain := MatcherChain{Matchers: map[string][]ExpressionMatcher{}, Enabled: false}
 
 	// no matchers means the chain will be disabled

--- a/pkg/metrics/sampler/matcher.go
+++ b/pkg/metrics/sampler/matcher.go
@@ -223,8 +223,8 @@ func NewSampleMatchFn(enableProcessMetrics *bool, includeMetricsMatchers config.
 			trace.MetricMatch("EnableProcessMetrics is FALSE, process metrics will be DISABLED")
 			return func(sample interface{}) bool {
 				// no process samples are included
-				_, ok := sample.(types.ProcessSample)
-				return !ok
+				_, isProcessSample := sample.(types.ProcessSample)
+				return !isProcessSample
 			}
 		} else {
 			ec := NewMatcherChain(includeMetricsMatchers)
@@ -256,9 +256,11 @@ func NewSampleMatchFn(enableProcessMetrics *bool, includeMetricsMatchers config.
 	// all process samples will be excluded
 	return func(sample interface{}) bool {
 		if enabled, exists := ffRetriever.GetFeatureFlag(handler.FlagFullProcess); exists {
-			return enabled
+			if _, isProcessSample := sample.(types.ProcessSample); !isProcessSample {
+				return !isProcessSample || enabled
+			}
 		}
-		_, ok := sample.(types.ProcessSample)
-		return !ok
+
+		return true
 	}
 }

--- a/pkg/metrics/sampler/matcher.go
+++ b/pkg/metrics/sampler/matcher.go
@@ -255,12 +255,11 @@ func NewSampleMatchFn(enableProcessMetrics *bool, includeMetricsMatchers config.
 	// configuration option is not defined and feature flag is present, FF determines, otherwise
 	// all process samples will be excluded
 	return func(sample interface{}) bool {
-		if enabled, exists := ffRetriever.GetFeatureFlag(handler.FlagFullProcess); exists {
-			if _, isProcessSample := sample.(types.ProcessSample); !isProcessSample {
-				return !isProcessSample || enabled
-			}
+		if _, isProcessSample := sample.(types.ProcessSample); !isProcessSample {
+			return true
 		}
 
-		return true
+		enabled, exists := ffRetriever.GetFeatureFlag(handler.FlagFullProcess)
+		return  exists && enabled
 	}
 }

--- a/pkg/metrics/sampler/matcher_test.go
+++ b/pkg/metrics/sampler/matcher_test.go
@@ -570,7 +570,7 @@ func TestNewSampleMatchFn(t *testing.T) {
 			args: args{
 				enableProcessMetrics:   nil,
 				includeMetricsMatchers: emptyMatchers,
-				ffRetriever:            &disabledFFRetriever{},
+				ffRetriever:            &enabledFFRetriever{},
 				sample:                 fixture.ProcessSample,
 			},
 			include: true,

--- a/pkg/metrics/sampler/matcher_test.go
+++ b/pkg/metrics/sampler/matcher_test.go
@@ -541,7 +541,7 @@ func TestNewSampleMatchFn(t *testing.T) {
 				enableProcessMetrics:   &falseVar,
 				includeMetricsMatchers: emptyMatchers,
 				ffRetriever:            testFF.EmptyFFRetriever,
-				sample:                 fixture.NetworkSample,
+				sample:                 &fixture.NetworkSample,
 			},
 			include: true,
 		},
@@ -551,7 +551,7 @@ func TestNewSampleMatchFn(t *testing.T) {
 				enableProcessMetrics:   &trueVar,
 				includeMetricsMatchers: emptyMatchers,
 				ffRetriever:            testFF.EmptyFFRetriever,
-				sample:                 fixture.ProcessSample,
+				sample:                 &fixture.ProcessSample,
 			},
 			include: true,
 		},
@@ -561,7 +561,7 @@ func TestNewSampleMatchFn(t *testing.T) {
 				enableProcessMetrics:   nil,
 				includeMetricsMatchers: emptyMatchers,
 				ffRetriever:            testFF.EmptyFFRetriever,
-				sample:                 fixture.ProcessSample,
+				sample:                 &fixture.ProcessSample,
 			},
 			include: false,
 		},
@@ -571,7 +571,7 @@ func TestNewSampleMatchFn(t *testing.T) {
 				enableProcessMetrics:   nil,
 				includeMetricsMatchers: emptyMatchers,
 				ffRetriever:            &enabledFFRetriever{},
-				sample:                 fixture.ProcessSample,
+				sample:                 &fixture.ProcessSample,
 			},
 			include: true,
 		},
@@ -581,7 +581,7 @@ func TestNewSampleMatchFn(t *testing.T) {
 				enableProcessMetrics:   nil,
 				includeMetricsMatchers: emptyMatchers,
 				ffRetriever:            &disabledFFRetriever{},
-				sample:                 fixture.ProcessSample,
+				sample:                 &fixture.ProcessSample,
 			},
 			include: false,
 		},
@@ -591,7 +591,7 @@ func TestNewSampleMatchFn(t *testing.T) {
 				enableProcessMetrics: &trueVar,
 				includeMetricsMatchers: config.IncludeMetricsMap{"process.name": []string{"regex \"foo.*\""}},
 				ffRetriever: testFF.EmptyFFRetriever,
-				sample: fixture.ProcessSample,
+				sample: &fixture.ProcessSample,
 			},
 			include: true,
 		},
@@ -601,7 +601,7 @@ func TestNewSampleMatchFn(t *testing.T) {
 				enableProcessMetrics: &trueVar,
 				includeMetricsMatchers: config.IncludeMetricsMap{"process.name": []string{"regex \"bar*\""}},
 				ffRetriever: testFF.EmptyFFRetriever,
-				sample: fixture.ProcessSample,
+				sample: &fixture.ProcessSample,
 			},
 			include: false,
 		},
@@ -609,7 +609,7 @@ func TestNewSampleMatchFn(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			matchFn := sampler.NewSampleMatchFn(tt.args.enableProcessMetrics, tt.args.includeMetricsMatchers, tt.args.ffRetriever)
-			assert.Equal(t, matchFn(tt.args.sample), tt.include)
+			assert.Equal(t, tt.include, matchFn(tt.args.sample))
 		})
 	}
 }

--- a/pkg/metrics/storage/storage_sampler_test.go
+++ b/pkg/metrics/storage/storage_sampler_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/newrelic/infrastructure-agent/internal/agent/mocks"
+	"github.com/newrelic/infrastructure-agent/internal/feature_flags/test"
 	"github.com/newrelic/infrastructure-agent/pkg/sample"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -61,7 +62,8 @@ func TestSampleWithCustomFilesystemList(t *testing.T) {
 	}()
 	config := config.Config{CustomSupportedFileSystems: []string{fs},
 		FileDevicesIgnored: []string{"sda1"}, MetricsStorageSampleRate: config.FREQ_INTERVAL_FLOOR_STORAGE_METRICS}
-	testAgent, err := agent.NewAgent(&config, "1")
+
+	testAgent, err := agent.NewAgent(&config, "1", test.EmptyFFRetriever)
 	assert.NoError(t, err)
 	testAgentConfig := testAgent.Context
 

--- a/pkg/metrics/types/process_sample.go
+++ b/pkg/metrics/types/process_sample.go
@@ -1,0 +1,44 @@
+package types
+
+import (
+	"github.com/newrelic/infrastructure-agent/pkg/sample"
+	"github.com/shirou/gopsutil/process"
+)
+
+// We use pointers to floats instead of plain floats so that if we don't set one
+// of the values, it will not be sent to Dirac. (Not using pointers would mean
+// that Go would always send a default value of 0.)
+type ProcessSample struct {
+	sample.BaseEvent
+	ProcessDisplayName    string   `json:"processDisplayName"`
+	ProcessID             int32    `json:"processId"`
+	CommandName           string   `json:"commandName"`
+	User                  string   `json:"userName,omitempty"`
+	MemoryRSSBytes        int64    `json:"memoryResidentSizeBytes"`
+	MemoryVMSBytes        int64    `json:"memoryVirtualSizeBytes"`
+	CPUPercent            float64  `json:"cpuPercent"`
+	CPUUserPercent        float64  `json:"cpuUserPercent"`
+	CPUSystemPercent      float64  `json:"cpuSystemPercent"`
+	ContainerImage        string   `json:"containerImage,omitempty"`
+	ContainerImageName    string   `json:"containerImageName,omitempty"`
+	ContainerName         string   `json:"containerName,omitempty"`
+	ContainerID           string   `json:"containerId,omitempty"`
+	Contained             string   `json:"contained,omitempty"`
+	CmdLine               string   `json:"commandLine,omitempty"`
+	Status                string   `json:"state,omitempty"`
+	ParentProcessID       int32    `json:"parentProcessId,omitempty"`
+	ThreadCount           int32    `json:"threadCount,omitempty"`
+	FdCount               *int32   `json:"fileDescriptorCount,omitempty"`
+	IOReadCountPerSecond  *float64 `json:"ioReadCountPerSecond,omitempty"`
+	IOWriteCountPerSecond *float64 `json:"ioWriteCountPerSecond,omitempty"`
+	IOReadBytesPerSecond  *float64 `json:"ioReadBytesPerSecond,omitempty"`
+	IOWriteBytesPerSecond *float64 `json:"ioWriteBytesPerSecond,omitempty"`
+	IOTotalReadCount      *uint64  `json:"ioTotalReadCount,omitempty"`
+	IOTotalWriteCount     *uint64  `json:"ioTotalWriteCount,omitempty"`
+	IOTotalReadBytes      *uint64  `json:"ioTotalReadBytes,omitempty"`
+	IOTotalWriteBytes     *uint64  `json:"ioTotalWriteBytes,omitempty"`
+	// Auxiliary values, not to be reported
+	LastIOCounters  *process.IOCountersStat `json:"-"`
+	ContainerLabels map[string]string       `json:"-"`
+}
+

--- a/pkg/metrics/types/process_sample.go
+++ b/pkg/metrics/types/process_sample.go
@@ -5,9 +5,8 @@ import (
 	"github.com/shirou/gopsutil/process"
 )
 
-// We use pointers to floats instead of plain floats so that if we don't set one
-// of the values, it will not be sent to Dirac. (Not using pointers would mean
-// that Go would always send a default value of 0.)
+// ProcessSample data type storing all the data harvested for a process.
+// Pointers are used as nil values represent no data.
 type ProcessSample struct {
 	sample.BaseEvent
 	ProcessDisplayName    string   `json:"processDisplayName"`
@@ -41,4 +40,3 @@ type ProcessSample struct {
 	LastIOCounters  *process.IOCountersStat `json:"-"`
 	ContainerLabels map[string]string       `json:"-"`
 }
-

--- a/pkg/metrics/types/process_sample.go
+++ b/pkg/metrics/types/process_sample.go
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/test/fixture/sample/assert.go
+++ b/test/fixture/sample/assert.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/newrelic/infrastructure-agent/pkg/metrics"
+	"github.com/newrelic/infrastructure-agent/pkg/metrics/types"
 
 	"github.com/newrelic/infrastructure-agent/internal/agent"
 	"github.com/newrelic/infrastructure-agent/pkg/metrics/network"
@@ -46,15 +47,15 @@ func AssertRequestContainsSample(t *testing.T, req http.Request, expected sample
 			gotSample.Timestamp(0)
 			assert.Equal(t, expected, &gotSample)
 
-		case *metrics.ProcessSample:
-			var gotSample metrics.ProcessSample
+		case *types.ProcessSample:
+			var gotSample types.ProcessSample
 			assert.NoError(t, json.Unmarshal(gotEv, &gotSample))
 			assert.NotNil(t, expected)
 			assert.NotNil(t, gotSample)
 			expected.Timestamp(0)
 			gotSample.Timestamp(0)
 			assert.Equal(t, expected, &gotSample)
-			assert.EqualValues(t, expected.(*metrics.ProcessSample).EntityKey, gotSample.EntityKey)
+			assert.EqualValues(t, expected.(*types.ProcessSample).EntityKey, gotSample.EntityKey)
 
 		case *storage.Sample:
 			var gotSample storage.Sample

--- a/test/fixture/sample/processes.go
+++ b/test/fixture/sample/processes.go
@@ -3,12 +3,12 @@
 package fixture
 
 import (
-	"github.com/newrelic/infrastructure-agent/pkg/metrics"
+	"github.com/newrelic/infrastructure-agent/pkg/metrics/types"
 	"github.com/newrelic/infrastructure-agent/pkg/sample"
 )
 
 var (
-	ProcessSample = metrics.ProcessSample{
+	ProcessSample = types.ProcessSample{
 		BaseEvent: sample.BaseEvent{
 			EntityKey: "my-entity-key",
 		},

--- a/test/fuzz/integration_payload/fuzz.go
+++ b/test/fuzz/integration_payload/fuzz.go
@@ -25,7 +25,7 @@ func Fuzz(data []byte) int {
 
 	// integration protocol v4
 	// otherwise parse won't happen
-	ffm := feature_flags.NewManager(map[string]bool{handler.ProtocolV4Enabled: true})
+	ffm := feature_flags.NewManager(map[string]bool{handler.FlagProtocolV4: true})
 	_, err3 := emitter.ParsePayloadV4(data, ffm)
 
 	// discourage mutation when no errors at all

--- a/test/harvest/processmetrics_test.go
+++ b/test/harvest/processmetrics_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/newrelic/infrastructure-agent/internal/agent/mocks"
 	"github.com/newrelic/infrastructure-agent/internal/testhelpers"
 	"github.com/newrelic/infrastructure-agent/pkg/config"
-	"github.com/newrelic/infrastructure-agent/pkg/metrics"
 	"github.com/newrelic/infrastructure-agent/pkg/metrics/process"
 	"github.com/newrelic/infrastructure-agent/pkg/metrics/sampler"
+	"github.com/newrelic/infrastructure-agent/pkg/metrics/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -259,7 +259,7 @@ func contextMock() *mocks.AgentContext {
 }
 
 // assertProcessSample will do the initial check for the sample.
-func assertProcessSample(t assert.TestingT, sample *metrics.ProcessSample) {
+func assertProcessSample(t assert.TestingT, sample *types.ProcessSample) {
 	assert.NotNil(t, sample.ProcessDisplayName)
 	assert.NotNil(t, sample.ProcessID)
 	assert.NotNil(t, sample.CommandName)
@@ -281,7 +281,7 @@ func assertProcessSample(t assert.TestingT, sample *metrics.ProcessSample) {
 	assert.NotNil(t, sample.FdCount)
 }
 
-func assertIOCounters(t assert.TestingT, sample *metrics.ProcessSample) {
+func assertIOCounters(t assert.TestingT, sample *types.ProcessSample) {
 	assert.NotNil(t, sample.IOReadCountPerSecond)
 	assert.NotNil(t, sample.IOWriteCountPerSecond)
 	assert.NotNil(t, sample.IOReadBytesPerSecond)
@@ -292,13 +292,13 @@ func assertIOCounters(t assert.TestingT, sample *metrics.ProcessSample) {
 	assert.NotNil(t, sample.IOTotalWriteBytes)
 }
 
-func sampleProcess(ps sampler.Sampler, pid int32) (*metrics.ProcessSample, error) {
+func sampleProcess(ps sampler.Sampler, pid int32) (*types.ProcessSample, error) {
 	batch, err := ps.Sample()
 	if err != nil {
 		return nil, err
 	}
 	for _, s := range batch {
-		sample := s.(*metrics.ProcessSample) // This will fail if you add container labels to the sample
+		sample := s.(*types.ProcessSample) // This will fail if you add container labels to the sample
 		if sample.ProcessID == pid {
 			return sample, nil
 		}


### PR DESCRIPTION
#### Description of the changes

Process sample is disable by default. It could still be enabled/disabled via feature-flag and config-option.
Precedence is:
1. config option
2. feature flag
3. default behaviour (exclude process samples)

#### PR Review Checklist
### Author

- [x] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
- [x] clean and format the code
- [x] add unit tests for your changes and make sure all unit tests are passing
- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer
- [x] address the feedback 
- [x] add a "ready for review" label. Only PRs with this label will be reviewed.

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
