### PR TITLE
feat: use existing timestamps when available

### DIFF
--- a/internal/agent/plugin.go
+++ b/internal/agent/plugin.go
@@ -136,7 +136,9 @@ func (self *PluginCommon) gatherDecorations() {
 }
 
 func (self *PluginCommon) decorateEvent(eventData map[string]interface{}) {
-	eventData["timestamp"] = time.Now().Unix()
+	if eventData["timestamp"] == nil {
+		eventData["timestamp"] = time.Now().Unix()
+	}
 
 	self.gatherDecorations()
 	for k, v := range self.decorations {


### PR DESCRIPTION
When an integration such as Flex generates an event that contains a timestamp do not overwrite the timestamp.
If the timestamp is nil generate the timestamp with `time.Now().Unix()` as it does currently.

Tested changes with a custom build of the agent, functionality works as intended.

 cc/ @carlosroman @jfjoly @fryckbos 