### PR TITLE
Fixed issue where getting cloud metadata would occasionally hang

### DIFF
--- a/internal/agent/delta/store.go
+++ b/internal/agent/delta/store.go
@@ -323,7 +323,7 @@ func (d *Store) ResetAllDeltas(entityKey string) {
 // UpdateState updates in disk the state of the deltas according to the passed PostDeltaBody, whose their ExternalKeys
 // field may be empty.
 func (d *Store) UpdateState(entityKey string, deltas []*inventoryapi.RawDelta, deltaStateResults *inventoryapi.DeltaStateMap) {
-	sentPlugins := make(map[string]bool)
+	sentPlugins := make(map[string]bool, len(deltas))
 	// record what was sent and archive
 	for _, delta := range deltas {
 		var deltaResult *inventoryapi.DeltaState
@@ -358,7 +358,7 @@ func (d *Store) updateLastDeltaSent(entityKey string, delta *inventoryapi.RawDel
 			})
 			if resultHint != nil {
 				if resultHint.Error != nil {
-					dslog.WithFields(logrus.Fields{"error": *resultHint.Error}).
+					dslog.WithField("error", *resultHint.Error).
 						Debug("Plugin delta submission returned a hint with an error.")
 				} else {
 					dslog.WithFields(logrus.Fields{

--- a/pkg/sysinfo/cloud/cloud.go
+++ b/pkg/sysinfo/cloud/cloud.go
@@ -58,7 +58,7 @@ type Harvester interface {
 // Detector is used to detect the cloud type on which the instance is running
 // and can be queried in order to get the information needed.
 type Detector struct {
-	sync.Mutex
+	sync.RWMutex
 	maxRetriesNumber     int           // Specify how many times the Detector will try in case of failure.
 	retryBackOff         time.Duration // Specify how much time to wait between the retries.
 	expiryInSec          int           // The interval of time on which the metadata should be expired and re-fetched.
@@ -122,76 +122,63 @@ func (d *Detector) GetHarvester() (Harvester, error) {
 
 // GetInstanceID will return the id of the cloud instance.
 func (d *Detector) GetInstanceID() (string, error) {
-	cloudHarvester := d.getHarvester()
-
-	if cloudHarvester != nil {
-		return cloudHarvester.GetInstanceID()
+	cloudHarvester, err := d.GetHarvester()
+	if err != nil {
+		return "", err
 	}
-
-	if !d.isInitialized() {
-		return "", ErrDetectorNotInitialized
-	}
-	return "", ErrCouldNotDetect
+	return cloudHarvester.GetInstanceID()
 }
 
 // GetHostType will return the cloud instance type.
 func (d *Detector) GetHostType() (string, error) {
-	cloudHarvester := d.getHarvester()
-	if cloudHarvester != nil {
-		return cloudHarvester.GetHostType()
+	cloudHarvester, err := d.GetHarvester()
+	if err != nil {
+		return "", err
 	}
-
-	if !d.isInitialized() {
-		return "", ErrDetectorNotInitialized
-	}
-	return "", ErrCouldNotDetect
+	return cloudHarvester.GetHostType()
 }
 
 // GetRegion will return the region of cloud instance.
 func (d *Detector) GetRegion() (string, error) {
-	cloudHarvester := d.getHarvester()
-	if cloudHarvester != nil {
-		return cloudHarvester.GetRegion()
+	cloudHarvester, err := d.GetHarvester()
+	if err != nil {
+		return "", err
 	}
-	if !d.isInitialized() {
-		return "", ErrDetectorNotInitialized
-	}
-	return "", ErrCouldNotDetect
+	return cloudHarvester.GetRegion()
 }
 
 // GetCloudType will return the cloud type on which the instance is running.
 func (d *Detector) GetCloudType() Type {
-	cloudHarvester := d.getHarvester()
-	if cloudHarvester != nil {
-		return cloudHarvester.GetCloudType()
+	cloudHarvester, err := d.GetHarvester()
+	if err != nil {
+		if err == ErrDetectorNotInitialized {
+			return TypeInProgress
+		}
+		return TypeNoCloud
 	}
-
-	if !d.isInitialized() {
-		return TypeInProgress
-	}
-	return TypeNoCloud
+	return cloudHarvester.GetCloudType()
 }
 
 // GetCloudSource Returns a string key which will be used as a HostSource (see host_aliases plugin).
 func (d *Detector) GetCloudSource() string {
-	cloudHarvester := d.getHarvester()
-	if cloudHarvester != nil {
-		return cloudHarvester.GetCloudSource()
+	cloudHarvester, err := d.GetHarvester()
+	if err != nil {
+		return ""
 	}
-	return ""
+	return cloudHarvester.GetCloudSource()
 }
 
 // isInitialized will check if the detector is Initialized.
 func (d *Detector) isInitialized() bool {
-	d.Lock()
-	defer d.Unlock()
+	d.RLock()
+	defer d.RUnlock()
 	return d.initialized
 }
 
 // isInProgress will return true if Detector is in initialize process.
 func (d *Detector) isInProgress() bool {
-	d.Lock()
-	defer d.Unlock()
+	d.RLock()
+	defer d.RUnlock()
 	return d.inProgress
 }
 
@@ -219,8 +206,8 @@ func (d *Detector) setHarvester(harvester Harvester) {
 
 // getHarvester returns the Harvester instance.
 func (d *Detector) getHarvester() Harvester {
-	d.Lock()
-	defer d.Unlock()
+	d.RLock()
+	defer d.RUnlock()
 	return d.cloudHarvester
 }
 

--- a/pkg/sysinfo/cloud/cloud.go
+++ b/pkg/sysinfo/cloud/cloud.go
@@ -58,7 +58,7 @@ type Harvester interface {
 // Detector is used to detect the cloud type on which the instance is running
 // and can be queried in order to get the information needed.
 type Detector struct {
-	sync.RWMutex
+	lock                 sync.RWMutex
 	maxRetriesNumber     int           // Specify how many times the Detector will try in case of failure.
 	retryBackOff         time.Duration // Specify how much time to wait between the retries.
 	expiryInSec          int           // The interval of time on which the metadata should be expired and re-fetched.
@@ -170,44 +170,44 @@ func (d *Detector) GetCloudSource() string {
 
 // isInitialized will check if the detector is Initialized.
 func (d *Detector) isInitialized() bool {
-	d.RLock()
-	defer d.RUnlock()
+	d.lock.RLock()
+	defer d.lock.RUnlock()
 	return d.initialized
 }
 
 // isInProgress will return true if Detector is in initialize process.
 func (d *Detector) isInProgress() bool {
-	d.RLock()
-	defer d.RUnlock()
+	d.lock.RLock()
+	defer d.lock.RUnlock()
 	return d.inProgress
 }
 
 // initializeStart is called when the detector initialization process starts.
 func (d *Detector) initializeStart() {
-	d.Lock()
-	defer d.Unlock()
+	d.lock.Lock()
+	defer d.lock.Unlock()
 	d.inProgress = true
 }
 
 // finishInit is called when the initialize process finishes.
 func (d *Detector) finishInit() {
-	d.Lock()
-	defer d.Unlock()
+	d.lock.Lock()
+	defer d.lock.Unlock()
 	d.initialized = true
 	d.inProgress = false
 }
 
 // setHarvester will cache the Harvester instance.
 func (d *Detector) setHarvester(harvester Harvester) {
-	d.Lock()
-	defer d.Unlock()
+	d.lock.Lock()
+	defer d.lock.Unlock()
 	d.cloudHarvester = harvester
 }
 
 // getHarvester returns the Harvester instance.
 func (d *Detector) getHarvester() Harvester {
-	d.RLock()
-	defer d.RUnlock()
+	d.lock.RLock()
+	defer d.lock.RUnlock()
 	return d.cloudHarvester
 }
 

--- a/pkg/sysinfo/cloud/cloud_test.go
+++ b/pkg/sysinfo/cloud/cloud_test.go
@@ -28,31 +28,31 @@ func (s *CloudDetectionSuite) TestParseAWSMeta(c *C) {
 	mux.Handle("/valid", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("i-db519dd1\n"))
+		_, _ = w.Write([]byte("i-db519dd1\n"))
 		return
 	}))
 	mux.Handle("/list", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("foo\nbar"))
+		_, _ = w.Write([]byte("foo\nbar"))
 		return
 	}))
 	mux.Handle("/not200", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte("foo"))
+		_, _ = w.Write([]byte("foo"))
 		return
 	}))
 	mux.Handle("/notplain", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("foo"))
+		_, _ = w.Write([]byte("foo"))
 		return
 	}))
 	mux.Handle("/justgarbage", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("<html>this is some test</html>"))
+		_, _ = w.Write([]byte("<html>this is some test</html>"))
 		return
 	}))
 	server := httptest.NewServer(mux)

--- a/scripts/infra_build.mk
+++ b/scripts/infra_build.mk
@@ -23,7 +23,7 @@ TEST_FLAGS += -race
 export GO111MODULE := on
 export PATH := $(PROJECT_WORKSPACE)/bin:$(PATH)
 
-GO_TEST ?= test $(TEST_OPTIONS) $(TEST_FLAGS) $(SOURCE_FILES) -run $(TEST_PATTERN) -timeout=5m
+GO_TEST ?= test $(TEST_OPTIONS) $(TEST_FLAGS) $(SOURCE_FILES) -run $(TEST_PATTERN) -timeout=10m
 
 .PHONY: go-get-go-1_9
 go-get-go-1_9:


### PR DESCRIPTION
#### Description of the changes

The locking of some of the resources in [`cloud.go`](../tree/master/pkg/sysinfo/cloud/cloud.go ) would cause cloud metadata to not return data sometimes.

Also update the test target in the Makefile to timeout the tests after ten minutes. This should fix issue where tests would fail on slower machines.

#### PR Review Checklist
### Author

- [x] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
- [x] clean and format the code
- [x] add unit tests for your changes and make sure all unit tests are passing
- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer
- [ ] address the feedback 
- [x] add a "ready for review" label. Only PRs with this label will be reviewed.

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
