### PR TITLE
LOGGING-2546: Support for multiple entity.guid in the Log Forwarder

### DIFF
--- a/pkg/integrations/v4/logs/cfg.go
+++ b/pkg/integrations/v4/logs/cfg.go
@@ -52,7 +52,7 @@ const (
 )
 
 const (
-	rAttEntityGUID = "entity.guid"
+	rAttEntityGUID = "entity.guid.INFRA"
 	rAttFbInput    = "fb.input"
 	rAttPluginType = "plugin.type"
 	rAttHostname   = "hostname"

--- a/pkg/integrations/v4/logs/cfg_test.go
+++ b/pkg/integrations/v4/logs/cfg_test.go
@@ -28,7 +28,7 @@ func TestNewFBConf(t *testing.T) {
 		Name:  "record_modifier",
 		Match: "*",
 		Records: map[string]string{
-			"entity.guid": "0",
+			"entity.guid.INFRA": "0",
 			"plugin.type": "nri-agent",
 			"hostname":    "",
 		},
@@ -230,7 +230,7 @@ func TestNewFBConf(t *testing.T) {
 				File: "/foo/file.foo",
 				Attributes: map[string]string{
 					"valid":       "value",
-					"entity.guid": "should-be-ignored",
+					"entity.guid.INFRA": "should-be-ignored",
 				},
 			},
 		}, FBCfg{
@@ -728,7 +728,7 @@ func TestFBCfgFormat(t *testing.T) {
 [FILTER]
     Name  record_modifier
     Match *
-    Record entity.guid testGUID
+    Record entity.guid.INFRA testGUID
     Record fb.source nri-agent
 
 [OUTPUT]
@@ -803,7 +803,7 @@ func TestFBCfgFormat(t *testing.T) {
 				Name:  "record_modifier",
 				Match: "*",
 				Records: map[string]string{
-					"entity.guid": "testGUID",
+					"entity.guid.INFRA": "testGUID",
 					"fb.source":   "nri-agent",
 				},
 			},
@@ -843,7 +843,7 @@ func TestFBCfgFormatWithHostname(t *testing.T) {
 [FILTER]
     Name  record_modifier
     Match *
-    Record entity.guid testGUID
+    Record entity.guid.INFRA testGUID
     Record hostname ubuntu
     Record plugin.type nri-agent
 
@@ -893,7 +893,7 @@ func TestFBCfgFormatWithHostname(t *testing.T) {
 				Name:  "record_modifier",
 				Match: "*",
 				Records: map[string]string{
-					"entity.guid": "testGUID",
+					"entity.guid.INFRA": "testGUID",
 					"plugin.type": "nri-agent",
 					"hostname":    "ubuntu",
 				},

--- a/pkg/integrations/v4/logs/cfg_test.go
+++ b/pkg/integrations/v4/logs/cfg_test.go
@@ -29,8 +29,8 @@ func TestNewFBConf(t *testing.T) {
 		Match: "*",
 		Records: map[string]string{
 			"entity.guid.INFRA": "0",
-			"plugin.type": "nri-agent",
-			"hostname":    "",
+			"plugin.type":       "nri-agent",
+			"hostname":          "",
 		},
 	}
 	inputRecordModifier := func(i string, m string) FBCfgParser {
@@ -229,7 +229,7 @@ func TestNewFBConf(t *testing.T) {
 				Name: "reserved-test",
 				File: "/foo/file.foo",
 				Attributes: map[string]string{
-					"valid":       "value",
+					"valid":             "value",
 					"entity.guid.INFRA": "should-be-ignored",
 				},
 			},
@@ -804,7 +804,7 @@ func TestFBCfgFormat(t *testing.T) {
 				Match: "*",
 				Records: map[string]string{
 					"entity.guid.INFRA": "testGUID",
-					"fb.source":   "nri-agent",
+					"fb.source":         "nri-agent",
 				},
 			},
 		},
@@ -894,8 +894,8 @@ func TestFBCfgFormatWithHostname(t *testing.T) {
 				Match: "*",
 				Records: map[string]string{
 					"entity.guid.INFRA": "testGUID",
-					"plugin.type": "nri-agent",
-					"hostname":    "ubuntu",
+					"plugin.type":       "nri-agent",
+					"hostname":          "ubuntu",
 				},
 			},
 		},

--- a/pkg/integrations/v4/logs/loader_test.go
+++ b/pkg/integrations/v4/logs/loader_test.go
@@ -33,8 +33,8 @@ var (
 		Match: "*",
 		Records: map[string]string{
 			"entity.guid.INFRA": "FOOBAR",
-			"plugin.type": logRecordModifierSource,
-			"hostname":    hostName,
+			"plugin.type":       logRecordModifierSource,
+			"hostname":          hostName,
 		}, // see idnProvide below
 	}
 	idnProvide = func() entity.Identity {

--- a/pkg/integrations/v4/logs/loader_test.go
+++ b/pkg/integrations/v4/logs/loader_test.go
@@ -32,7 +32,7 @@ var (
 		Name:  "record_modifier",
 		Match: "*",
 		Records: map[string]string{
-			"entity.guid": "FOOBAR",
+			"entity.guid.INFRA": "FOOBAR",
 			"plugin.type": logRecordModifierSource,
 			"hostname":    hostName,
 		}, // see idnProvide below


### PR DESCRIPTION
#### Description of the changes

This PR adds support in the Infrastructure Agent to support multiple `entity.guids` in the log records forwarded by the Log Forwarder. The current implementation overwrites the `entity.guid` field of the original log record. If that record came from the APM, for instance, this means that the APM's `entity.guid` is lost forever and replaced by the INFRA one.

This implementation introduces the INFRA `entity.guid` as `entity.guid.INFRA` instead, to avoid this collision. The Logging ingest pipeline will then take care of parsing any `entity.guid` or `entity.guid.*` attributes and glueing them together into a single `entity.guids` attribute.

#### PR Review Checklist
### Author

- [x] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
- [x] clean and format the code
- [x] add unit tests for your changes and make sure all unit tests are passing
- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer
- [x] address the feedback 
- [x] add a "ready for review" label. Only PRs with this label will be reviewed.

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
