### PR TITLE
fix: tests now don't run into a race condition when testing on AWS

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -423,11 +423,11 @@ func TestCheckConnectionTimeout(t *testing.T) {
 func TestCheckNetworkNoTimeout(t *testing.T) {
 	retval := make(chan error, 1)
 
-	go func() {
-		// Given a server that always returns timeouts
-		ts := NewTimeoutServer(-1)
-		defer ts.Cancel()
+	// Given a server that always returns timeouts
+	ts := NewTimeoutServer(-1)
+	defer ts.Cancel()
 
+	go func() {
 		cnf := &config.Config{
 			CollectorURL:             ts.server.URL,
 			StartupConnectionRetries: -1,
@@ -748,52 +748,52 @@ func Test_ProcessSampling(t *testing.T) {
 	testCases := []testCase{
 		{
 			name: "ConfigurationOptionIsDisabled",
-			c:    &config.Config{EnableProcessMetrics: getBooleanPtr(false)},
+			c:    &config.Config{EnableProcessMetrics: getBooleanPtr(false), DisableCloudMetadata: true},
 			want: false,
 		},
 		{
 			name: "ConfigurationOptionIsEnabled",
-			c:    &config.Config{EnableProcessMetrics: getBooleanPtr(true)},
+			c:    &config.Config{EnableProcessMetrics: getBooleanPtr(true), DisableCloudMetadata: true},
 			want: true,
 		},
 		{
 			// if the matchers are empty (corner case), the FF retriever is checked so it needs to not be nil
 			name: "ConfigurationOptionIsNotPresentAndMatchersAreEmptyAndFeatureFlagIsNotConfigured",
-			c:    &config.Config{IncludeMetricsMatchers: map[string][]string{}},
+			c:    &config.Config{IncludeMetricsMatchers: map[string][]string{}, DisableCloudMetadata: true},
 			ff:   test.NewFFRetrieverReturning(false, false),
 			want: false,
 		},
 		{
 			name: "ConfigurationOptionIsNotPresentAndMatchersConfiguredDoNotMatch",
-			c:    &config.Config{IncludeMetricsMatchers: map[string][]string{"process.name": {"does-not-match"}}},
+			c:    &config.Config{IncludeMetricsMatchers: map[string][]string{"process.name": {"does-not-match"}}, DisableCloudMetadata: true},
 			want: false,
 		},
 		{
 			name: "ConfigurationOptionIsNotPresentAndMatchersConfiguredDoMatch",
-			c:    &config.Config{IncludeMetricsMatchers: map[string][]string{"process.name": {"some-process"}}},
+			c:    &config.Config{IncludeMetricsMatchers: map[string][]string{"process.name": {"some-process"}}, DisableCloudMetadata: true},
 			want: true,
 		},
 		{
 			name: "ConfigurationOptionIsNotPresentAndMatchersAreNotConfiguredAndFeatureFlagIsEnabled",
-			c:    &config.Config{},
+			c:    &config.Config{DisableCloudMetadata: true},
 			ff:   test.NewFFRetrieverReturning(true, true),
 			want: true,
 		},
 		{
 			name: "ConfigurationOptionIsNotPresentAndMatchersAreNotConfiguredAndFeatureFlagIsDisabled",
-			c:    &config.Config{},
+			c:    &config.Config{DisableCloudMetadata: true},
 			ff:   test.NewFFRetrieverReturning(false, true),
 			want: false,
 		},
 		{
 			name: "ConfigurationOptionIsNotPresentAndMatchersAreNotConfiguredAndFeatureFlagIsNotFound",
-			c:    &config.Config{},
+			c:    &config.Config{DisableCloudMetadata: true},
 			ff:   test.NewFFRetrieverReturning(false, false),
 			want: false,
 		},
 		{
 			name: "DefaultBehaviourExcludesProcessSamples",
-			c:    &config.Config{},
+			c:    &config.Config{DisableCloudMetadata: true},
 			ff:   test.NewFFRetrieverReturning(false, false),
 			want: false,
 		},


### PR DESCRIPTION
#### Description of the changes

Sometimes when running unit test from agent_test.go would end up in a race condition as the cloud metadata plugins would try and run.

#### PR Review Checklist
### Author

- [x] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
- [x] clean and format the code
- [x] add unit tests for your changes and make sure all unit tests are passing
- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer
- [ ] address the feedback 
- [x] add a "ready for review" label. Only PRs with this label will be reviewed.

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
