### PR TITLE
ci: adding code coverage steps to send data to coveralls.io

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,22 @@ jobs:
           go-version: '^1.14.4'
 
       - name: Running unit tests
-        run: make test
+        run: make test-coverage
+
+      - name: Install gcov2lcov
+        working-directory: /tmp
+        run: go get -u github.com/jandelgado/gcov2lcov
+
+      - name: Convert coverage.out to lcov.info
+        run: gcov2lcov -infile=coverage.out -outfile=lcov.info
+
+      - name: Coveralls Parallel
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          path-to-lcov: lcov.info
+          flag-name: run-linux
+          parallel: true
 
   build-container:
     runs-on: ubuntu-latest
@@ -75,3 +90,13 @@ jobs:
         env:
           GOPATH: "${{ github.workspace }}"
         run: make test-centos-5
+
+  finish:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          parallel-finished: true

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ newrelic-infra.yml.*
 c.out
 *.syso
 coverage.xml
+coverage.out
+lcov.info
 *.heap
 /workspace
 .vscode

--- a/build/infra_build.mk
+++ b/build/infra_build.mk
@@ -38,6 +38,15 @@ go-get:
 	$(GO_BIN) mod vendor
 	@echo '[go-get] Done.'
 
+.PHONY: test-coverage
+test-coverage: TEST_FLAGS += -covermode=atomic -coverprofile=coverage.out
+test-coverage: go-get
+	@printf '\n================================================================\n'
+	@printf 'Target: test-coverage'
+	@printf '\n================================================================\n'
+	@echo '[test] Testing packages: $(SOURCE_FILES)'
+	$(GO_BIN) $(GO_TEST)
+
 .PHONY: test
 test: go-get
 	@printf '\n================================================================\n'


### PR DESCRIPTION
#### Description of the changes

Added ability to send code coverage results to [coveralls.io](https://coveralls.io/github/newrelic/infrastructure-agent). At the moment have only added the ability to do this for Linux builds. I've set it up so next step (if we find this useful) is to add Windows code coverage as well to the build.

#### PR Review Checklist
### Author

- [ ] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
- [ ] clean and format the code
- [ ] add unit tests for your changes and make sure all unit tests are passing
- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer
- [ ] address the feedback 
- [ ] add a "ready for review" label. Only PRs with this label will be reviewed.

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
