### PR TITLE
fix: fixed race condition accessing agentKey in agent ctx

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/newrelic/infrastructure-agent/internal/feature_flags"
@@ -130,7 +131,7 @@ type context struct {
 	CancelFn       context2.CancelFunc
 	cfg            *config.Config
 	id             *id.Context
-	agentKey       string
+	agentKey       atomic.Value
 	reconnecting   *sync.Map         // Plugins that must be re-executed after a long disconnection
 	ch             chan PluginOutput // Channel of inbound plugin data payloads
 	activeEntities chan string       // Channel will be reported about the local/remote entities that are active
@@ -191,6 +192,8 @@ func NewContext(
 ) *context {
 	ctx, cancel := context2.WithCancel(context2.Background())
 
+	var agentKey atomic.Value
+	agentKey.Store("")
 	return &context{
 		cfg:                cfg,
 		Ctx:                ctx,
@@ -203,6 +206,7 @@ func NewContext(
 		resolver:           resolver,
 		idLookup:           lookup,
 		shouldIncludeEvent: sampleMatchFn,
+		agentKey:           agentKey,
 	}
 }
 
@@ -293,7 +297,7 @@ func NewAgent(cfg *config.Config, buildVersion string, ffRetriever feature_flags
 	if err != nil {
 		return
 	}
-	ctx.agentKey = agentKey
+	ctx.setAgentKey(agentKey)
 
 	var dataDir string
 	if cfg.AppDataDir != "" {
@@ -420,7 +424,7 @@ func New(
 	a.inventories = map[string]*inventory{}
 
 	// Make sure the network is working before continuing with identity
-	if err := checkCollectorConnectivity(ctx.Ctx, cfg, backoff.NewRetrier(), a.userAgent, a.Context.agentKey, transport); err != nil {
+	if err := checkCollectorConnectivity(ctx.Ctx, cfg, backoff.NewRetrier(), a.userAgent, a.Context.getAgentKey(), transport); err != nil {
 		alog.WithError(err).Error("network is not available")
 		return nil, err
 	}
@@ -528,7 +532,7 @@ func (a *Agent) registerEntityInventory(entityKey string) error {
 
 	var err error
 	if a.Context.cfg.RegisterEnabled {
-		inv.sender, err = newPatchSenderVortex(entityKey, a.Context.agentKey, a.Context, a.store, a.userAgent, a.Context.AgentIdentity, a.provideIDs, a.entityMap, a.httpClient)
+		inv.sender, err = newPatchSenderVortex(entityKey, a.Context.getAgentKey(), a.Context, a.store, a.userAgent, a.Context.AgentIdentity, a.provideIDs, a.entityMap, a.httpClient)
 	} else {
 		lastSubmission := delta.NewLastSubmissionStore(a.store.DataDir, entityKey)
 		lastEntityID := delta.NewEntityIDFilePersist(a.store.DataDir, entityKey)
@@ -687,9 +691,9 @@ func (a *Agent) setAgentKey(idLookupTable IDLookup) error {
 		return err
 	}
 
-	alog.WithField("old", a.Context.agentKey).WithField("new", key).Debug("Updating identity.")
+	alog.WithField("old", a.Context.getAgentKey()).WithField("new", key).Debug("Updating identity.")
 
-	a.Context.agentKey = key
+	a.Context.setAgentKey(key)
 
 	if a.store != nil {
 		a.store.ChangeDefaultEntity(key)
@@ -1029,7 +1033,7 @@ func (c *context) Config() *config.Config {
 }
 
 func (c *context) AgentIdentifier() string {
-	return c.agentKey
+	return c.getAgentKey()
 }
 
 func (c *context) Version() string {
@@ -1094,6 +1098,14 @@ func (c *context) HostnameResolver() hostname.Resolver {
 // HostnameResolver returns the host name change notifier associated to the agent context
 func (c *context) HostnameChangeNotifier() hostname.ChangeNotifier {
 	return c.resolver
+}
+
+func (c *context) setAgentKey(agentKey string) {
+	c.agentKey.Store(agentKey)
+}
+
+func (c *context) getAgentKey() (agentKey string) {
+	return c.agentKey.Load().(string)
 }
 
 func (a *Agent) connect() {

--- a/internal/agent/event_sender_vortex_test.go
+++ b/internal/agent/event_sender_vortex_test.go
@@ -304,8 +304,10 @@ func TestVortexEventSender_QueueEvent_DecoratesRemoteEntityID(t *testing.T) {
 }
 
 func newContextWithVortex() *context {
+	var agentKeyVal atomic.Value
+	agentKeyVal.Store(agentKey)
 	c := &context{
-		agentKey: agentKey,
+		agentKey: agentKeyVal,
 		cfg: &config.Config{
 			ConnectEnabled:          true,
 			PayloadCompressionLevel: gzip.NoCompression,

--- a/pkg/ctl/sender/client_docker_test.go
+++ b/pkg/ctl/sender/client_docker_test.go
@@ -3,15 +3,11 @@
 package sender
 
 import (
-	"testing"
-
 	"github.com/newrelic/infrastructure-agent/pkg/helpers"
+	"testing"
 )
 
 func TestNewContainerisedClient(t *testing.T) {
-	if !helpers.IsDockerRunning() {
-		t.Skip("docker required for this test suite")
-	}
 
 	type args struct {
 		apiVersion  string
@@ -28,6 +24,9 @@ func TestNewContainerisedClient(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if !helpers.IsDockerRunning() {
+				t.Skip("docker required for this test suite")
+			}
 			gotC, err := NewContainerisedClient(tt.args.apiVersion, tt.args.containerID)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewContainerisedClient() error = %v, want %v", err, tt.wantErr)

--- a/pkg/ctl/shutdown_linux_test.go
+++ b/pkg/ctl/shutdown_linux_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/coreos/go-systemd/v22/dbus"
 	"github.com/pkg/errors"
@@ -109,6 +110,7 @@ func Test_shutdownWatcherLinux_checkForShutdownStatus(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
+		time.Sleep(100 * time.Millisecond)
 		s.checkShutdownStatus(shutdown)
 		// checkShutdownStatus will write to the shutdown channel
 		wg.Done()


### PR DESCRIPTION
#### Description of the changes

Some tests around `agent.go` were failing because of a race condition. It looks like we access `agentKey` from different go routines and sometimes change the value as well. Have swapped it from being a `string` to an `atomic.value`.

#### PR Review Checklist
### Author

- [ ] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
- [ ] clean and format the code
- [ ] add unit tests for your changes and make sure all unit tests are passing
- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer
- [ ] address the feedback 
- [ ] add a "ready for review" label. Only PRs with this label will be reviewed.

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
