### PR TITLE
Feature flag support for: non blocking inventory processing queue

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/newrelic/infrastructure-agent/internal/feature_flags"
 	"github.com/newrelic/infrastructure-agent/pkg/metrics/sampler"
+	"github.com/newrelic/infrastructure-agent/pkg/trace"
 
 	"github.com/newrelic/infrastructure-agent/pkg/helpers/metric"
 	"github.com/sirupsen/logrus"
@@ -448,6 +449,7 @@ func New(
 	}
 
 	// Create input channel for plugins to feed data back to the agent
+	trace.Inventory("parallelize queue: %v", a.Context.cfg.InventoryQueueLen)
 	a.Context.ch = make(chan PluginOutput, a.Context.cfg.InventoryQueueLen)
 	a.Context.activeEntities = make(chan string, activeEntitiesBufferLength)
 

--- a/internal/agent/cmdchannel/handler/featureflag_handler.go
+++ b/internal/agent/cmdchannel/handler/featureflag_handler.go
@@ -25,7 +25,7 @@ const (
 	// Config
 	CfgYmlRegisterEnabled        = "register_enabled"
 	CfgYmlParallelizeInventory   = "inventory_queue_len"
-	CfgValueParallelizeInventory = int64(10) // default value when no config provided by user and FF enabled
+	CfgValueParallelizeInventory = int64(100) // default value when no config provided by user and FF enabled
 )
 
 var ffLogger = log.WithComponent("FeatureFlagHandler")

--- a/internal/agent/cmdchannel/handler/featureflag_handler.go
+++ b/internal/agent/cmdchannel/handler/featureflag_handler.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/newrelic/infrastructure-agent/internal/os/api"
+	"github.com/newrelic/infrastructure-agent/pkg/trace"
 
 	"github.com/newrelic/infrastructure-agent/internal/feature_flags"
 
@@ -177,6 +178,11 @@ func (h *FFHandler) handleEnableOHI(ff string, enable bool) {
 }
 
 func handleParallelizeInventory(ffArgs commandapi.FFArgs, c *config.Config, isInitialFetch bool) {
+	trace.Inventory("parallelize FF handler initialFetch: %v, enable: %v, queue: %v",
+		isInitialFetch,
+		ffArgs.Enabled,
+		c.InventoryQueueLen,
+	)
 	// feature already in desired state
 	if (ffArgs.Enabled && c.InventoryQueueLen > 0) || (!ffArgs.Enabled && c.InventoryQueueLen == 0) {
 		return

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -592,10 +592,10 @@ type Config struct {
 	// Public: No
 	BatchQueueDepth int `yaml:"batch_queue_depth" envconfig:"batch_queue_depth" public:"false"` // See event_sender.go
 
-	// InventoryQueue sets the inventory processing queue size.
-	// Default: 10
+	// InventoryQueueLen sets the inventory processing queue size. Zero value makes inventory processing synchronous (blocking call).
+	// Default: 0
 	// Public: Yes
-	InventoryQueueLen int
+	InventoryQueueLen int  `yaml:"inventory_queue_len" envconfig:"inventory_queue_len" public:"true"`
 
 	// EnableWinUpdatePlugin enables the windows updates plugin which retrieves the lists of hotfix that are installed
 	// on the host.
@@ -1090,6 +1090,26 @@ func (c *Config) SetBoolValueByYamlAttribute(attribute string, value bool) error
 		if ftags.Get("yaml") == attribute {
 			f := s.Field(i)
 			f.SetBool(value)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("unknown field for yaml attribute '%s'", attribute)
+}
+
+func (c *Config) SetIntValueByYamlAttribute(attribute string, value int64) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	s := reflect.ValueOf(c)
+	s = s.Elem()
+	t := s.Type()
+	for i := 0; i < s.NumField(); i++ {
+		ftype := t.Field(i)
+		ftags := ftype.Tag
+		if ftags.Get("yaml") == attribute {
+			f := s.Field(i)
+			f.SetInt(value)
 			return nil
 		}
 	}

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -43,7 +43,7 @@ var (
 	DefaultStripCommandLine            = true
 	DefaultSmartVerboseModeEntryLimit  = 1000
 	DefaultIntegrationsDir             = "newrelic-integrations"
-	DefaultInventoryQueue              = 10
+	DefaultInventoryQueue              = 0
 
 	// private
 	defaultAppDataDir                    = ""

--- a/pkg/trace/features.go
+++ b/pkg/trace/features.go
@@ -14,9 +14,10 @@ func (f Feature) String() string {
 const (
 	ATTR           Feature = "attributes"    // custom-attributes
 	CONN           Feature = "connect"       // fingerprint connect
-	HOSTNAME       Feature = "hostname"      // hostname
+	HOSTNAME       Feature = "hostname"
 	DM_SUBMISSION  Feature = "dm.submission" // dimensional metrics submission
 	METRIC_MATCHER Feature = "metric.match"  // match metric by rule
+	INVENTORY      Feature = "inventory"
 )
 
 // Helper functions to avoid repeating:
@@ -50,4 +51,9 @@ func Telemetry(format string, args ...interface{}) {
 // MetricMatch traces to "audit" log metric match rule.
 func MetricMatch(format string, args ...interface{}) {
 	On(func() bool { return true }, METRIC_MATCHER, format, args...)
+}
+
+// Inventory traces to "audit" inventory.
+func Inventory(format string, args ...interface{}) {
+	On(func() bool { return true }, INVENTORY, format, args...)
 }


### PR DESCRIPTION
#### Description of the changes

This sets inventory processing queue back to synchronous (blocking call on 0 length channel).
Also adds support for this feature to be enabled or disabled via command-api.

Desired behaviour is:
- default inventory queue len is 0 (current agents size)
- inventory queue can be modified via usual config file/env-var
- this config setup can be disabled via command-api
- when no config setup was provided by user, this feature can be enabled via command-api setting inventory queue value to 100

As this value is set at startup time an agent restart is triggered (not a service restart!) if required.

Also adds an `inventory` *trace* in case a weird case needs to be troubleshooted.

#### PR Review Checklist
### Author

- [ ] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
- [ ] clean and format the code
- [ ] add unit tests for your changes and make sure all unit tests are passing
- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer
- [ ] address the feedback 
- [ ] add a "ready for review" label. Only PRs with this label will be reviewed.

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
