### PR TITLE
chore: upgraded fsnotify to v1.4.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/fortytw2/leaktest v1.3.1-0.20190606143808-d73c753520d9
-	github.com/fsnotify/fsnotify v0.9.3
+	github.com/fsnotify/fsnotify v1.4.9
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/gogo/protobuf v1.1.2-0.20181116123445-07eab6a8298c // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/fortytw2/leaktest v1.3.1-0.20190606143808-d73c753520d9 h1:tKHw9zBEj0r
 github.com/fortytw2/leaktest v1.3.1-0.20190606143808-d73c753520d9/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fsnotify/fsnotify v0.9.3 h1:ohbr5HT+EHaq7KpTqPxkowzWw0vTFj25E8HVrVVHNIA=
 github.com/fsnotify/fsnotify v0.9.3/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
+github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-fsnotify/fsnotify v0.0.0-20180321022601-755488143dae h1:PeVNzgTRtWGm6fVic5i21t+n5ptPGCZuMcSPVMyTWjs=
@@ -135,6 +137,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190204203706-41f3e6584952/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 h1:ogLJMz+qpzav7lGMh10LMvAkM/fAoGlaiiHYiFYdm80=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/agent/bulk_inventories_test.go
+++ b/internal/agent/bulk_inventories_test.go
@@ -19,9 +19,9 @@ import (
 const maxInventoryDataSize = 3 * 1000 * 1000
 
 var plugin = &delta.PluginInfo{
-	Source:       "metadata/plugin",
-	Plugin:       "metadata",
-	FileName:     "plugin.json",
+	Source:   "metadata/plugin",
+	Plugin:   "metadata",
+	FileName: "plugin.json",
 }
 
 // createDelta creates and stores a delta JSON for a given entity, with a size approximate to the given size

--- a/internal/agent/delta/store.go
+++ b/internal/agent/delta/store.go
@@ -406,7 +406,7 @@ func (s *Store) updateLastDeltaSent(entityKey string, dRaw *inventoryapi.RawDelt
 			// Send again? This is a no-op, set last sent id to one previous.
 			dslog.WithFields(logrus.Fields{"sendNextID": id, "plugin": p}).
 				Debug("Requesting to update last delta sent to identical value.")
-			p.setLastSentID(entityKey, id - 1)
+			p.setLastSentID(entityKey, id-1)
 		}
 	} else if id > p.lastSentID(entityKey) {
 		p.setLastSentID(entityKey, id)
@@ -417,7 +417,7 @@ func (s *Store) updateLastDeltaSent(entityKey string, dRaw *inventoryapi.RawDelt
 
 func (s *Store) reconciliateWithBackend(pi *PluginInfo, entityKey string, resultHint *inventoryapi.DeltaState) {
 	_ = s.clearPluginDeltaStore(pi, entityKey)
-	pi.setLastSentID(entityKey, resultHint.SendNextID - 1)
+	pi.setLastSentID(entityKey, resultHint.SendNextID-1)
 	pi.setDeltaID(entityKey, resultHint.LastStoredID)
 }
 

--- a/internal/agent/delta/store_test.go
+++ b/internal/agent/delta/store_test.go
@@ -725,7 +725,7 @@ func (s *DeltaUtilsCoreSuite) TestCompactStoreTrimSentDelta(c *C) {
 	const eKey = "entity:ID"
 
 	ds := s.SetupSavedState(c)
-	ds.plugins["metadata/plugin"].setLastSentID(eKey,2)
+	ds.plugins["metadata/plugin"].setLastSentID(eKey, 2)
 	err := ds.archivePlugin(ds.plugins["metadata/plugin"], eKey)
 	c.Check(err, IsNil)
 	size, err := ds.StorageSize(ds.CacheDir)
@@ -801,8 +801,8 @@ func (s *DeltaUtilsCoreSuite) TestDeltaFileCorrupt(c *C) {
 
 	secondPlugin := newPluginInfo("metadata", "plugin.json")
 	// break on purpose, so read should fail
-	secondPlugin.Source =       "metadata/plugin2"
-	secondPlugin.Plugin =       "metadata2"
+	secondPlugin.Source = "metadata/plugin2"
+	secondPlugin.Plugin = "metadata2"
 
 	srcFile2 := ds.SourceFilePath(secondPlugin, eKey)
 	err = os.MkdirAll(filepath.Dir(srcFile2), 0755)

--- a/internal/plugins/linux/users.go
+++ b/internal/plugins/linux/users.go
@@ -97,7 +97,7 @@ func (self *UsersPlugin) Run() {
 		return
 	}
 
-	err = watcher.WatchFlags("/var/run/utmp", fsnotify.FSN_MODIFY)
+	err = watcher.Add("/var/run/utmp")
 	if err != nil {
 		usrlog.WithError(err).Error("can't setup trigger file watcher for users")
 		self.Unregister()
@@ -108,8 +108,12 @@ func (self *UsersPlugin) Run() {
 
 	for {
 		select {
-		case <-watcher.Event:
-			needsFlush = true
+		case event, ok := <-watcher.Events:
+			if ok {
+				if event.Op&fsnotify.Write == fsnotify.Write {
+					needsFlush = true
+				}
+			}
 		case <-refreshTimer.C:
 			{
 				refreshTimer.Reset(self.frequency)

--- a/pkg/plugins/files_config.go
+++ b/pkg/plugins/files_config.go
@@ -203,7 +203,7 @@ func (self *ConfigFilePlugin) parseAndAddPaths() {
 		if shouldBeIgnored(file) {
 			ignored += 1
 		} else {
-			if err := self.watcher.Watch(file); err != nil {
+			if err := self.watcher.Add(file); err != nil {
 				self.logger.WithError(err).WithField("file", file).Error("Unable to add watch to file")
 			}
 		}
@@ -234,7 +234,7 @@ func (self *ConfigFilePlugin) Run() {
 			// stop the ticker regardless, it gets recreated below if needed
 			checkTicker.Stop()
 			// if we successfully add a watch for external.d kill the ticker
-			if err := self.watcher.Watch(self.externalDDir); err == nil {
+			if err := self.watcher.Add(self.externalDDir); err == nil {
 				externalDExists = true
 				self.parseAndAddPaths()
 				// since we just updated ALL THE FILES, we probably want to flush
@@ -244,21 +244,25 @@ func (self *ConfigFilePlugin) Run() {
 				checkTicker = time.NewTicker(1 * time.Minute)
 			}
 
-		case event := <-self.watcher.Event:
+		case event := <-self.watcher.Events:
 			if filepath.Dir(event.Name) == self.externalDDir {
 				self.parseAndAddPaths()
 				flushNeeded = true
 			}
 
-			if event.IsRename() {
+			if event.Op&fsnotify.Rename == fsnotify.Rename {
 				movedFiles[event.Name] = true
 			}
 
-			if event.IsModify() {
+			if event.Op&fsnotify.Remove == fsnotify.Remove {
 				flushNeeded = true
 			}
 
-		case err := <-self.watcher.Error:
+			if event.Op&fsnotify.Write == fsnotify.Write {
+				flushNeeded = true
+			}
+
+		case err := <-self.watcher.Errors:
 			self.logger.WithError(err).Error("watcher received an error")
 
 		case <-flushTimer.C:
@@ -278,7 +282,7 @@ func (self *ConfigFilePlugin) Run() {
 
 				// re-add any files that may have been renamed in the last flush interval
 				for file := range movedFiles {
-					if err := self.watcher.Watch(file); err != nil {
+					if err := self.watcher.Add(file); err != nil {
 						self.logger.WithError(err).WithField(
 							"file", file,
 						).Error("Couldn't re-add file to watch")

--- a/test/harvest/sysctl_test.go
+++ b/test/harvest/sysctl_test.go
@@ -111,7 +111,7 @@ func BenchmarkSysctlSubscriberRootless(b *testing.B) {
 
 	// fake some FS changes
 	for i := 0; i < b.N; i++ {
-		evCh <- &fsnotify.FileEvent{
+		evCh <- fsnotify.Event{
 			Name: fmt.Sprintf("fake/path/iteration-%d", i),
 		}
 	}


### PR DESCRIPTION
The reasons for this PR is to update fsnotify as latest version as some libraries we want to use have issues with old versions of this library (like spf13/cobra).