### PR TITLE
test: correct flaky TestManager_SkipLoadingV3IntegrationsWithNoWarnings test

### DIFF
--- a/pkg/integrations/v4/manager_test.go
+++ b/pkg/integrations/v4/manager_test.go
@@ -188,11 +188,19 @@ integrations:
 
 	// WHEN the manager loads and executes the integration
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go mgr.Start(ctx)
+
+	finish := make(chan struct{})
+
+	go func() {
+		mgr.Start(ctx)
+		close(finish)
+	}()
 
 	// THEN emitted metrics are received (gauge, count & summary)
 	_ = expectNMetrics(t, emitter, "nri-protocol-v4", 3)
+	cancel()
+
+	<-finish
 }
 
 func TestManager_SkipLoadingV3IntegrationsWithNoWarnings(t *testing.T) {


### PR DESCRIPTION
Problem: Sometime we had an issue that `TestManager_SkipLoadingV3IntegrationsWithNoWarnings` was failing. I did a research and caught that previous test `TestManager_ProtocolV4` was producing an error in logs and was overlapping in runtime with `TestManager_SkipLoadingV3IntegrationsWithNoWarnings`. This is why we had issues with different tmp folder and file name compared to test we run.

Cause: Shared log instance (my guess)

Solution: Channel added to wait for test to finish `manager.Start()` and only then start another test. 