### PR TITLE
feat: register entities under FF

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.14
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/Microsoft/go-winio v0.4.11
-	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6
 	github.com/antihax/optional v1.0.0
 	github.com/aws/aws-sdk-go v1.25.14-0.20200515182354-0961961790e6
@@ -18,7 +17,6 @@ require (
 	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/fortytw2/leaktest v1.3.1-0.20190606143808-d73c753520d9
 	github.com/fsnotify/fsnotify v1.4.9
-	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/gogo/protobuf v1.1.2-0.20181116123445-07eab6a8298c // indirect
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,10 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Microsoft/go-winio v0.4.11 h1:zoIOcVf0xPN1tnMVbTtEdI+P8OofVk3NObnwOQ6nK2Q=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
-github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 h1:fLjPD/aNc3UIOA6tDi6QXUemppXK3P9BI7mr2hd6gx8=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
@@ -36,8 +36,6 @@ github.com/fortytw2/leaktest v1.3.1-0.20190606143808-d73c753520d9 h1:tKHw9zBEj0r
 github.com/fortytw2/leaktest v1.3.1-0.20190606143808-d73c753520d9/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
-github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-ole/go-ole v1.2.1 h1:2lOsA72HgjxAuMlKpFiCbHTvu44PIVkZ5hqm3RSdI/E=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
@@ -58,6 +56,7 @@ github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
+github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
@@ -72,6 +71,7 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/newrelic-forks/go-systemd/v22 v22.1.1 h1:IlK38H3JrNdqT8nHWJ7yIURbqQNaqKF9fjGfulsYgrc=
 github.com/newrelic-forks/go-systemd/v22 v22.1.1/go.mod h1:p4NfqokFlluq2+M0PT0C79+OFaaeBPRsuii4AN/fr38=
@@ -129,7 +129,9 @@ golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 h1:ogLJMz+qpzav7lGMh10LMvAkM/fAoGlaiiHYiFYdm80=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.3-0.20190829152558-3d0f7978add9 h1:SiG/YZHGpKRm5dMlAIMyiH/U4tSjw72M90ryHlc/rto=
 golang.org/x/text v0.3.3-0.20190829152558-3d0f7978add9/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/time v0.0.0-20181108054448-85acf8d2951c h1:fqgJT0MGcGpPgpWU7VRdRjuArfcOvC4AoJmILihzhDg=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/internal/agent/cmdchannel/handler/featureflag_handler.go
+++ b/internal/agent/cmdchannel/handler/featureflag_handler.go
@@ -19,6 +19,7 @@ const (
 	// FFs
 	FlagCategory             = "Infra_Agent"
 	FlagNameRegister         = "register_enabled"
+	FlagDmRegisterEnable     = "dm_register_enabled"
 	FlagParallelizeInventory = "parallelize_inventory_enabled"
 	FlagProtocolV4           = "protocol_v4_enabled"
 	FlagFullProcess          = "full_process_sampling"

--- a/internal/agent/cmdchannel/handler/featureflag_handler.go
+++ b/internal/agent/cmdchannel/handler/featureflag_handler.go
@@ -119,13 +119,8 @@ func (h *FFHandler) Handle(ffArgs commandapi.FFArgs, isInitialFetch bool) {
 		return
 	}
 
-	if ffArgs.Flag == FlagDMRegisterEnable {
-		handleDMRegister(ffArgs, h.cfg, isInitialFetch)
-		return
-	}
-
 	// this is where we handle normal feature flags that are not related to OHIs
-	if ffArgs.Flag == FlagProtocolV4 || ffArgs.Flag == FlagFullProcess {
+	if ffArgs.Flag == FlagProtocolV4 || ffArgs.Flag == FlagFullProcess || ffArgs.Flag == FlagDMRegisterEnable {
 		h.setFFConfig(ffArgs.Flag, ffArgs.Enabled)
 		return
 	}
@@ -225,23 +220,6 @@ func handleRegister(ffArgs commandapi.FFArgs, c *config.Config, isInitialFetch b
 		ffLogger.
 			WithError(err).
 			WithField("field", CfgYmlRegisterEnabled).
-			Warn("unable to update config value")
-	}
-}
-
-func handleDMRegister(ffArgs commandapi.FFArgs, c *config.Config, isInitialFetch bool) {
-	if ffArgs.Enabled == c.DMRegisterEnabled {
-		return
-	}
-
-	if !isInitialFetch {
-		os.Exit(api.ExitCodeRestart)
-	}
-
-	if err := c.SetBoolValueByYamlAttribute(CfgYmlDMRegisterEnable, ffArgs.Enabled); err != nil {
-		ffLogger.
-			WithError(err).
-			WithField("field", CfgYmlDMRegisterEnable).
 			Warn("unable to update config value")
 	}
 }

--- a/internal/agent/cmdchannel/service_test.go
+++ b/internal/agent/cmdchannel/service_test.go
@@ -50,6 +50,42 @@ func TestFFHandlerHandle_DisablesRegisterOnInitialFetch(t *testing.T) {
 	assert.False(t, c.RegisterEnabled)
 }
 
+func TestFFHandler_DMRegisterOnInitialFetch(t *testing.T) {
+	tests := []struct {
+		name   string
+		config config.Config
+		args   commandapi.FFArgs
+		want   bool
+	}{{
+		"Disabled if command api is disabled",
+		config.Config{RegisterEnabled: true},
+		commandapi.FFArgs{
+			Category: handler.FlagCategory,
+			Flag:     handler.FlagDMRegisterEnable,
+			Enabled:  false,
+		},
+		false,
+	},
+		{
+			"Enabled if command api is Enabled",
+			config.Config{},
+			commandapi.FFArgs{
+				Category: handler.FlagCategory,
+				Flag:     handler.FlagDMRegisterEnable,
+				Enabled:  true,
+			},
+			true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler.NewFFHandler(&tc.config, feature_flags.NewManager(nil)).Handle(tc.args, true)
+			assert.Equal(t, tc.want, tc.config.DMRegisterEnabled)
+		})
+	}
+}
+
 func TestFFHandlerHandle_DisablesParallelizeInventoryConfigOnInitialFetch(t *testing.T) {
 	c := config.Config{
 		InventoryQueueLen: 123,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -858,6 +858,12 @@ type Config struct {
 	// Public: No
 	RegisterEnabled bool `yaml:"register_enabled" envconfig:"register_enabled" public:"false"`
 
+	// DMRegisterEnabled If it's enabled entities will be registered using new register endpoint and it assigns
+	// these entities with an assigned entity ID.
+	// Default: False
+	// Public: No
+	DMRegisterEnabled bool `yaml:"dm_register_enabled" envconfig:"dm_register_enabled" public:"false"`
+
 	// FilesConfigOn enables or disables the configuration file monitoring. Disabled by default. We just keep this
 	// configuration value for backwards compatibilities, but any new agent should enable this value.
 	// Default: False

--- a/pkg/integrations/v4/dm/emitter.go
+++ b/pkg/integrations/v4/dm/emitter.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"github.com/newrelic/infrastructure-agent/internal/agent"
 	"github.com/newrelic/infrastructure-agent/internal/agent/cmdchannel/handler"
 	"github.com/newrelic/infrastructure-agent/internal/feature_flags"
@@ -48,6 +49,12 @@ type Emitter interface {
 		extraLabels data.Map,
 		entityRewrite []data.EntityRewrite,
 		integrationJSON []byte) error
+
+	SendWithoutRegister(
+		metadata integration.Definition,
+		extraLabels data.Map,
+		entityRewrite []data.EntityRewrite,
+		integrationJSON []byte) error
 }
 
 func NewEmitter(
@@ -62,6 +69,14 @@ func NewEmitter(
 		ffRetriever:   ffRetriever,
 		idProvider:    idProvider,
 	}
+}
+
+func (e *emitter) SendWithoutRegister(
+	metadata integration.Definition,
+	extraLabels data.Map,
+	entityRewrite []data.EntityRewrite,
+	integrationJSON []byte) error {
+	return nil
 }
 
 func (e *emitter) Send(

--- a/pkg/integrations/v4/emitter/emitter.go
+++ b/pkg/integrations/v4/emitter/emitter.go
@@ -67,7 +67,7 @@ func (e *Legacy) Emit(metadata integration.Definition, extraLabels data.Map, ent
 
 	// dimensional metrics
 	if protocolVersion == protocol.V4 {
-		if enabled, exists := e.FFRetriever.GetFeatureFlag(handler.FlagDmRegisterEnable); exists && enabled {
+		if enabled, exists := e.FFRetriever.GetFeatureFlag(handler.FlagDMRegisterEnable); exists && enabled {
 			return e.dmEmitter.Send(metadata, extraLabels, entityRewrite, integrationJSON)
 		}
 		return e.dmEmitter.SendWithoutRegister(metadata, extraLabels, entityRewrite, integrationJSON)

--- a/pkg/integrations/v4/emitter/emitter_test.go
+++ b/pkg/integrations/v4/emitter/emitter_test.go
@@ -451,7 +451,7 @@ func TestLegacy_Emit(t *testing.T) {
 
 			em := &Legacy{
 				Context:     ma,
-				FFRetriever: feature_flags.NewManager(map[string]bool{handler.FlagProtocolV4: true, handler.FlagDmRegisterEnable: true}),
+				FFRetriever: feature_flags.NewManager(map[string]bool{handler.FlagProtocolV4: true, handler.FlagDMRegisterEnable: true}),
 				dmEmitter:   mockDME,
 			}
 
@@ -494,7 +494,7 @@ func TestProtocolV4_Emit(t *testing.T) {
 
 	em := &Legacy{
 		Context:     ma,
-		FFRetriever: feature_flags.NewManager(map[string]bool{handler.FlagProtocolV4: true, handler.FlagDmRegisterEnable: true}),
+		FFRetriever: feature_flags.NewManager(map[string]bool{handler.FlagProtocolV4: true, handler.FlagDMRegisterEnable: true}),
 		dmEmitter:   mockDME,
 	}
 
@@ -552,7 +552,7 @@ func TestProtocolV4_Emit_WithFFDisabled(t *testing.T) {
 
 	em := &Legacy{
 		Context:     ma,
-		FFRetriever: feature_flags.NewManager(map[string]bool{handler.FlagProtocolV4: false, handler.FlagDmRegisterEnable: true}),
+		FFRetriever: feature_flags.NewManager(map[string]bool{handler.FlagProtocolV4: false, handler.FlagDMRegisterEnable: true}),
 		dmEmitter:   mockDME,
 	}
 
@@ -576,7 +576,7 @@ func TestProtocolV4_Emit_WithoutRegisteringEntities(t *testing.T) {
 
 	em := &Legacy{
 		Context:     mockAgent(),
-		FFRetriever: feature_flags.NewManager(map[string]bool{handler.FlagDmRegisterEnable: false}),
+		FFRetriever: feature_flags.NewManager(map[string]bool{handler.FlagDMRegisterEnable: false}),
 		dmEmitter:   dmEmitter,
 	}
 


### PR DESCRIPTION
The agent now register entities before send metrics/inventory/event to backend.

### Scope 
Integration under `protocol_v4`

Feature flag to enable it: `feature:  dm_register_enabled: true`. 

Customer config has precedence over command api.

### Use cases
<img width="521" alt="Screen Shot 2020-09-16 at 1 50 50 PM" src="https://user-images.githubusercontent.com/4612272/93333463-a391b300-f823-11ea-8d12-ce3bce748a79.png">
