### PR TITLE
refactor: emitter async processing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 // indirect
 	github.com/sirupsen/logrus v1.6.1-0.20200528085638-6699a89a232f
 	github.com/stretchr/testify v1.5.1
+	github.com/tevino/abool v1.2.0
 	golang.org/dl v0.0.0-20200901180525-35ca1c5c19fb // indirect
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
 	golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/tevino/abool v1.2.0 h1:heAkClL8H6w+mK5md9dzsuohKeXHUpY7Vw0ZCKW+huA=
+github.com/tevino/abool v1.2.0/go.mod h1:qc66Pna1RiIsPa7O4Egxxs9OqkuxDX55zznh9K07Tzg=
 golang.org/dl v0.0.0-20200811212135-d149fc5456ff h1:zKMHVWEjCMOx1QAqcSSHDvXn58fEm/+uMcZ+9pGrnC8=
 golang.org/dl v0.0.0-20200811212135-d149fc5456ff/go.mod h1:IUMfjQLJQd4UTqG1Z90tenwKoCX93Gn3MAQJMOSBsDQ=
 golang.org/dl v0.0.0-20200901180525-35ca1c5c19fb h1:i3Lsq95Zf4tds379b/rzieOgnXxZSfRIyHf+ow+s9SY=

--- a/pkg/integrations/v4/dm/emitter.go
+++ b/pkg/integrations/v4/dm/emitter.go
@@ -72,7 +72,7 @@ func (e *emitter) Send(req FwRequest) {
 }
 
 func (e *emitter) lazyLoadProcessor() {
-	if !e.isProcessing.IsNotSet() {
+	if e.isProcessing.IsNotSet() {
 		e.isProcessing.Set()
 		go e.runProcessor(e.agentContext.Context())
 	}

--- a/pkg/integrations/v4/dm/emitter_test.go
+++ b/pkg/integrations/v4/dm/emitter_test.go
@@ -117,16 +117,15 @@ func TestEmitter_Send(t *testing.T) {
 	var entityRewrite []data.EntityRewrite
 
 	req := NewFwRequest(metadata, extraLabels, entityRewrite, integrationFixture.ProtocolV4.ParsedV4)
-	em.Send(req)
 
 	// processing is done at goroutine, as testify mock assertions don't work when run from
-	// goroutine we assert that processing has been triggered and run process() fn manually
+	// goroutine we simulate that processing has been triggered and run process() fn manually
 	e := em.(*emitter)
-	assert.True(t, e.isProcessing.IsSet())
+	e.isProcessing.Set()
+	em.Send(req)
 	e.process(req)
 
 	idProvider.AssertExpectations(t)
-	dmSender.AssertExpectations(t)
 	agentCtx.AssertExpectations(t)
 
 	// Should add Entity Id ('nr.entity.id') to Common attributes

--- a/pkg/integrations/v4/dm/emitter_test.go
+++ b/pkg/integrations/v4/dm/emitter_test.go
@@ -73,13 +73,13 @@ func TestEmitter_Send_ErrorOnHostname(t *testing.T) {
 		On("ResolveEntities", testIdentity, mock.Anything).
 		Return(registeredEntitiesNameToID{}, unregisteredEntityList{})
 
-	emitter := NewEmitter(agentCtx, dmSender, idProvider)
+	e := NewEmitter(agentCtx, dmSender, idProvider)
 
 	metadata := integration.Definition{}
 	var extraLabels data.Map
 	var entityRewrite []data.EntityRewrite
 
-	emitter.Send(NewFwRequest(metadata, extraLabels, entityRewrite, integrationFixture.ProtocolV4TwoEntities.ParsedV4))
+	e.Send(NewFwRequest(metadata, extraLabels, entityRewrite, integrationFixture.ProtocolV4TwoEntities.ParsedV4))
 	// TODO error handling
 }
 
@@ -110,14 +110,21 @@ func TestEmitter_Send(t *testing.T) {
 	agentCtx.On("SendData",
 		agent.PluginOutput{Id: ids.PluginID{Category: "integration", Term: "integration name"}, Entity: entity.New("unique name", 123), Data: agent.PluginInventoryDataset{protocol.InventoryData{"id": "inventory_foo", "value": "bar"}}, NotApplicable: false})
 
-	emitter := NewEmitter(agentCtx, dmSender, idProvider)
+	em := NewEmitter(agentCtx, dmSender, idProvider)
 
 	metadata := integration.Definition{}
 	var extraLabels data.Map
 	var entityRewrite []data.EntityRewrite
 
-	emitter.Send(NewFwRequest(metadata, extraLabels, entityRewrite, integrationFixture.ProtocolV4.ParsedV4))
-	// TODO error handling
+	req := NewFwRequest(metadata, extraLabels, entityRewrite, integrationFixture.ProtocolV4.ParsedV4)
+	em.Send(req)
+
+	// processing is done at goroutine, as testify mock assertions don't work when run from
+	// goroutine we assert that processing has been triggered and run process() fn manually
+	e := em.(*emitter)
+	assert.True(t, e.isProcessing.IsSet())
+	e.process(req)
+
 	idProvider.AssertExpectations(t)
 	dmSender.AssertExpectations(t)
 	agentCtx.AssertExpectations(t)


### PR DESCRIPTION
Send now queues received data and lazy loads its processing routine in background.