### PR TITLE
refactor: extract agent key logic to package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 // indirect
 	github.com/sirupsen/logrus v1.6.1-0.20200528085638-6699a89a232f
 	github.com/stretchr/testify v1.5.1
+	github.com/tevino/abool v1.2.0
 	golang.org/dl v0.0.0-20200901180525-35ca1c5c19fb // indirect
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
 	golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/tevino/abool v1.2.0 h1:heAkClL8H6w+mK5md9dzsuohKeXHUpY7Vw0ZCKW+huA=
+github.com/tevino/abool v1.2.0/go.mod h1:qc66Pna1RiIsPa7O4Egxxs9OqkuxDX55zznh9K07Tzg=
 golang.org/dl v0.0.0-20200811212135-d149fc5456ff h1:zKMHVWEjCMOx1QAqcSSHDvXn58fEm/+uMcZ+9pGrnC8=
 golang.org/dl v0.0.0-20200811212135-d149fc5456ff/go.mod h1:IUMfjQLJQd4UTqG1Z90tenwKoCX93Gn3MAQJMOSBsDQ=
 golang.org/dl v0.0.0-20200901180525-35ca1c5c19fb h1:i3Lsq95Zf4tds379b/rzieOgnXxZSfRIyHf+ow+s9SY=

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/newrelic/infrastructure-agent/internal/feature_flags"
+	"github.com/newrelic/infrastructure-agent/pkg/entity/host"
 	"github.com/newrelic/infrastructure-agent/pkg/metrics/sampler"
 	"github.com/newrelic/infrastructure-agent/pkg/trace"
 
@@ -27,8 +28,6 @@ import (
 
 	"github.com/newrelic/infrastructure-agent/pkg/ctl"
 	"github.com/newrelic/infrastructure-agent/pkg/ipc"
-
-	"github.com/pkg/errors"
 
 	"github.com/newrelic/infrastructure-agent/pkg/backend/identityapi"
 	"github.com/newrelic/infrastructure-agent/pkg/backend/state"
@@ -57,9 +56,6 @@ const (
 	defaultRemoveEntitiesPeriod = 48 * time.Hour
 	activeEntitiesBufferLength  = 32
 )
-
-// ErrUndefinedLookupType error when an identifier type is not found
-var ErrUndefinedLookupType = errors.New("no known identifier types found in ID lookup table")
 
 type registerableSender interface {
 	Start() error
@@ -128,7 +124,7 @@ type AgentContext interface {
 	ActiveEntitiesChannel() chan string
 	// HostnameResolver returns the host name resolver associated to the agent context
 	HostnameResolver() hostname.Resolver
-	IDLookup() IDLookup
+	IDLookup() host.IDLookup
 
 	// Identity returns the entity ID of the infra agent
 	Identity() entity.Identity
@@ -153,7 +149,7 @@ type context struct {
 	servicePids        map[string]map[int]string // Map of plugin -> (map of pid -> service)
 	resolver           hostname.ResolverChangeNotifier
 	EntityMap          entity.KnownIDs
-	idLookup           IDLookup
+	idLookup           host.IDLookup
 	shouldIncludeEvent sampler.IncludeSampleMatchFn
 }
 
@@ -190,19 +186,16 @@ func (c *context) SetAgentIdentity(id entity.Identity) {
 }
 
 //IDLookup returns the IDLookup map.
-func (c *context) IDLookup() IDLookup {
+func (c *context) IDLookup() host.IDLookup {
 	return c.idLookup
 }
-
-// IDLookup contains the identifiers used for resolving the agent entity name and agent key.
-type IDLookup map[string]string
 
 //NewContext creates a new context.
 func NewContext(
 	cfg *config.Config,
 	buildVersion string,
 	resolver hostname.ResolverChangeNotifier,
-	lookup IDLookup,
+	lookup host.IDLookup,
 	sampleMatchFn sampler.IncludeSampleMatchFn,
 ) *context {
 	ctx, cancel := context2.WithCancel(context2.Background())
@@ -312,7 +305,7 @@ func NewAgent(
 	sampleMatchFn := sampler.NewSampleMatchFn(cfg.EnableProcessMetrics, cfg.IncludeMetricsMatchers, ffRetriever)
 	ctx := NewContext(cfg, buildVersion, hostnameResolver, idLookupTable, sampleMatchFn)
 
-	agentKey, err := idLookupTable.getAgentKey()
+	agentKey, err := idLookupTable.AgentKey()
 	if err != nil {
 		return
 	}
@@ -397,7 +390,7 @@ func New(
 	cfg *config.Config,
 	ctx *context,
 	userAgent string,
-	idLookupTable IDLookup,
+	idLookupTable host.IDLookup,
 	s *delta.Store,
 	connectSrv *identityConnectService,
 	provideIDs ProvideIDs,
@@ -474,48 +467,9 @@ func New(
 	return a, nil
 }
 
-func (i IDLookup) getAgentKey() (agentKey string, err error) {
-	if len(i) == 0 {
-		err = fmt.Errorf("No identifiers given")
-		return
-	}
-
-	for _, keyType := range sysinfo.HOST_ID_TYPES {
-		// Skip blank identifiers which may have found their way into the map.
-		// (Specifically, Azure can sometimes give us a blank VMID - See MTBLS-1429)
-		if key, ok := i[keyType]; ok && key != "" {
-			return key, nil
-		}
-	}
-
-	err = ErrUndefinedLookupType
-	return
-}
-
-// AgentShortEntityName is the agent entity name, but without having long-hostname into account.
-// It is taken from the first field in the priority.
-func (i IDLookup) AgentShortEntityName() (string, error) {
-	priorities := []string{
-		sysinfo.HOST_SOURCE_INSTANCE_ID,
-		sysinfo.HOST_SOURCE_AZURE_VM_ID,
-		sysinfo.HOST_SOURCE_GCP_VM_ID,
-		sysinfo.HOST_SOURCE_ALIBABA_VM_ID,
-		sysinfo.HOST_SOURCE_DISPLAY_NAME,
-		sysinfo.HOST_SOURCE_HOSTNAME_SHORT,
-	}
-
-	for _, k := range priorities {
-		if name, ok := i[k]; ok && name != "" {
-			return name, nil
-		}
-	}
-
-	return "", ErrUndefinedLookupType
-}
-
 // NewIdLookup creates a new agent ID lookup table.
-func NewIdLookup(resolver hostname.Resolver, cloudHarvester cloud.Harvester, displayName string) IDLookup {
-	idLookupTable := make(IDLookup)
+func NewIdLookup(resolver hostname.Resolver, cloudHarvester cloud.Harvester, displayName string) host.IDLookup {
+	idLookupTable := make(host.IDLookup)
 	// Attempt to get the hostname
 	host, short, err := resolver.Query()
 	llog := alog.WithField("displayName", displayName)
@@ -707,8 +661,8 @@ func (a *Agent) updateIDLookupTable(hostAliases PluginInventoryDataset) (err err
 // identifiers and choose the first one we can find.
 // If one is found, it will be set on the context object as well as returned.
 // Otherwise, the context is not modified.
-func (a *Agent) setAgentKey(idLookupTable IDLookup) error {
-	key, err := idLookupTable.getAgentKey()
+func (a *Agent) setAgentKey(idLookupTable host.IDLookup) error {
+	key, err := idLookupTable.AgentKey()
 	if err != nil {
 		return err
 	}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -7,7 +7,10 @@ import (
 	context2 "context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/newrelic/infrastructure-agent/pkg/entity"
+	"github.com/newrelic/infrastructure-agent/pkg/entity/host"
+
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -41,7 +44,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var NilIDLookup IDLookup
+var NilIDLookup host.IDLookup
 
 var matcher = func(interface{}) bool { return true }
 
@@ -153,7 +156,7 @@ func TestSetAgentKeysDisplayInstance(t *testing.T) {
 	a := newTesting(nil)
 	defer os.RemoveAll(a.store.DataDir)
 
-	idMap := IDLookup{
+	idMap := host.IDLookup{
 		sysinfo.HOST_SOURCE_DISPLAY_NAME: "displayName",
 		sysinfo.HOST_SOURCE_HOSTNAME:     "hostName",
 		sysinfo.HOST_SOURCE_INSTANCE_ID:  "instanceId",
@@ -168,7 +171,7 @@ func TestSetAgentKeysInstanceEmptyString(t *testing.T) {
 	a := newTesting(nil)
 	defer os.RemoveAll(a.store.DataDir)
 
-	keys := IDLookup{
+	keys := host.IDLookup{
 		sysinfo.HOST_SOURCE_DISPLAY_NAME: "displayName",
 		sysinfo.HOST_SOURCE_HOSTNAME:     "hostName",
 		sysinfo.HOST_SOURCE_INSTANCE_ID:  "",
@@ -182,7 +185,7 @@ func TestSetAgentKeysDisplayNameMatchesHostName(t *testing.T) {
 	a := newTesting(nil)
 	defer os.RemoveAll(a.store.DataDir)
 
-	keyMap := IDLookup{
+	keyMap := host.IDLookup{
 		sysinfo.HOST_SOURCE_DISPLAY_NAME: "hostName",
 		sysinfo.HOST_SOURCE_HOSTNAME:     "hostName",
 	}
@@ -195,7 +198,7 @@ func TestSetAgentKeysNoValues(t *testing.T) {
 	a := newTesting(nil)
 	defer os.RemoveAll(a.store.DataDir)
 
-	assert.Error(t, a.setAgentKey(IDLookup{}))
+	assert.Error(t, a.setAgentKey(host.IDLookup{}))
 }
 
 func TestUpdateIDLookupTable(t *testing.T) {
@@ -221,7 +224,7 @@ func TestUpdateIDLookupTable(t *testing.T) {
 }
 
 func TestIDLookup_EntityNameCloudInstance(t *testing.T) {
-	l := IDLookup{
+	l := host.IDLookup{
 		sysinfo.HOST_SOURCE_INSTANCE_ID:    "instance-id",
 		sysinfo.HOST_SOURCE_AZURE_VM_ID:    "azure-id",
 		sysinfo.HOST_SOURCE_GCP_VM_ID:      "gcp-id",
@@ -237,7 +240,7 @@ func TestIDLookup_EntityNameCloudInstance(t *testing.T) {
 }
 
 func TestIDLookup_EntityNameAzure(t *testing.T) {
-	l := IDLookup{
+	l := host.IDLookup{
 		sysinfo.HOST_SOURCE_INSTANCE_ID:    "",
 		sysinfo.HOST_SOURCE_AZURE_VM_ID:    "azure-id",
 		sysinfo.HOST_SOURCE_GCP_VM_ID:      "gcp-id",
@@ -252,7 +255,7 @@ func TestIDLookup_EntityNameAzure(t *testing.T) {
 }
 
 func TestIDLookup_EntityNameGCP(t *testing.T) {
-	l := IDLookup{
+	l := host.IDLookup{
 		sysinfo.HOST_SOURCE_INSTANCE_ID:    "",
 		sysinfo.HOST_SOURCE_AZURE_VM_ID:    "",
 		sysinfo.HOST_SOURCE_GCP_VM_ID:      "gcp-id",
@@ -267,7 +270,7 @@ func TestIDLookup_EntityNameGCP(t *testing.T) {
 }
 
 func TestIDLookup_EntityNameAlibaba(t *testing.T) {
-	l := IDLookup{
+	l := host.IDLookup{
 		sysinfo.HOST_SOURCE_INSTANCE_ID:    "",
 		sysinfo.HOST_SOURCE_AZURE_VM_ID:    "",
 		sysinfo.HOST_SOURCE_GCP_VM_ID:      "",
@@ -282,7 +285,7 @@ func TestIDLookup_EntityNameAlibaba(t *testing.T) {
 }
 
 func TestIDLookup_EntityNameDisplayName(t *testing.T) {
-	l := IDLookup{
+	l := host.IDLookup{
 		sysinfo.HOST_SOURCE_DISPLAY_NAME:   "display-name",
 		sysinfo.HOST_SOURCE_HOSTNAME_SHORT: "short",
 	}
@@ -293,7 +296,7 @@ func TestIDLookup_EntityNameDisplayName(t *testing.T) {
 }
 
 func TestIDLookup_EntityNameShortName(t *testing.T) {
-	l := IDLookup{
+	l := host.IDLookup{
 		sysinfo.HOST_SOURCE_HOSTNAME:       "long",
 		sysinfo.HOST_SOURCE_HOSTNAME_SHORT: "short",
 	}

--- a/internal/agent/event_sender_test.go
+++ b/internal/agent/event_sender_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/newrelic/infrastructure-agent/internal/testhelpers"
+	"github.com/newrelic/infrastructure-agent/pkg/entity/host"
 	infra "github.com/newrelic/infrastructure-agent/test/infra/http"
 	"github.com/stretchr/testify/assert"
 
@@ -507,7 +508,7 @@ func TestEventSender_ResponseError(t *testing.T) {
 				ConnectEnabled:          true,
 				PayloadCompressionLevel: gzip.NoCompression,
 			}
-			c := NewContext(cfg, "1.2.3", testhelpers.NullHostnameResolver, IDLookup{}, nil)
+			c := NewContext(cfg, "1.2.3", testhelpers.NullHostnameResolver, host.IDLookup{}, nil)
 			c.setAgentKey(agentKey)
 			c.SetAgentIdentity(agentIdn)
 

--- a/internal/agent/mocks/AgentContext.go
+++ b/internal/agent/mocks/AgentContext.go
@@ -8,6 +8,7 @@ import (
 
 	agent "github.com/newrelic/infrastructure-agent/internal/agent"
 	config "github.com/newrelic/infrastructure-agent/pkg/config"
+	"github.com/newrelic/infrastructure-agent/pkg/entity/host"
 
 	entity "github.com/newrelic/infrastructure-agent/pkg/entity"
 
@@ -137,15 +138,15 @@ func (_m *AgentContext) HostnameResolver() hostname.Resolver {
 }
 
 // IDLookup provides a mock function with given fields:
-func (_m *AgentContext) IDLookup() agent.IDLookup {
+func (_m *AgentContext) IDLookup() host.IDLookup {
 	ret := _m.Called()
 
-	var r0 agent.IDLookup
-	if rf, ok := ret.Get(0).(func() agent.IDLookup); ok {
+	var r0 host.IDLookup
+	if rf, ok := ret.Get(0).(func() host.IDLookup); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(agent.IDLookup)
+			r0 = ret.Get(0).(host.IDLookup)
 		}
 	}
 

--- a/internal/plugins/testing/agent_mock.go
+++ b/internal/plugins/testing/agent_mock.go
@@ -4,8 +4,10 @@ package testing
 
 import (
 	"context"
-	"github.com/newrelic/infrastructure-agent/pkg/sysinfo"
 	"time"
+
+	"github.com/newrelic/infrastructure-agent/pkg/entity/host"
+	"github.com/newrelic/infrastructure-agent/pkg/sysinfo"
 
 	"github.com/newrelic/infrastructure-agent/internal/agent"
 	"github.com/newrelic/infrastructure-agent/pkg/config"
@@ -113,8 +115,8 @@ func (m *MockAgent) AddReconnecting(agent.Plugin) {}
 
 func (m *MockAgent) Reconnect() {}
 
-func (m *MockAgent) IDLookup() agent.IDLookup {
-	idLookupTable := make(agent.IDLookup)
+func (m *MockAgent) IDLookup() host.IDLookup {
+	idLookupTable := make(host.IDLookup)
 	idLookupTable[sysinfo.HOST_SOURCE_HOSTNAME_SHORT] = "short_hostname"
 	return idLookupTable
 }

--- a/pkg/entity/host/host.go
+++ b/pkg/entity/host/host.go
@@ -1,0 +1,106 @@
+package host
+
+import (
+	"strings"
+
+	"github.com/newrelic/infrastructure-agent/pkg/backend/http"
+	"github.com/newrelic/infrastructure-agent/pkg/databind/pkg/data"
+	"github.com/newrelic/infrastructure-agent/pkg/entity"
+	"github.com/newrelic/infrastructure-agent/pkg/integrations/v4/protocol"
+	"github.com/newrelic/infrastructure-agent/pkg/sysinfo"
+	"github.com/pkg/errors"
+)
+
+// Errors
+var (
+	ErrUndefinedLookupType = errors.New("no known identifier types found in ID lookup table")
+	ErrNoAgentIdentifiers  = errors.New("no agent identifiers available")
+)
+
+// IDLookup contains the identifiers used for resolving the agent entity name and agent key.
+type IDLookup map[string]string
+
+func (i IDLookup) AgentKey() (agentKey string, err error) {
+	if len(i) == 0 {
+		err = ErrNoAgentIdentifiers
+		return
+	}
+
+	for _, keyType := range sysinfo.HOST_ID_TYPES {
+		// Skip blank identifiers which may have found their way into the map.
+		// (Specifically, Azure can sometimes give us a blank VMID - See MTBLS-1429)
+		if key, ok := i[keyType]; ok && key != "" {
+			return key, nil
+		}
+	}
+
+	err = ErrUndefinedLookupType
+	return
+}
+
+// AgentShortEntityName is the agent entity name, but without having long-hostname into account.
+// It is taken from the first field in the priority.
+func (i IDLookup) AgentShortEntityName() (string, error) {
+	priorities := []string{
+		sysinfo.HOST_SOURCE_INSTANCE_ID,
+		sysinfo.HOST_SOURCE_AZURE_VM_ID,
+		sysinfo.HOST_SOURCE_GCP_VM_ID,
+		sysinfo.HOST_SOURCE_ALIBABA_VM_ID,
+		sysinfo.HOST_SOURCE_DISPLAY_NAME,
+		sysinfo.HOST_SOURCE_HOSTNAME_SHORT,
+	}
+
+	for _, k := range priorities {
+		if name, ok := i[k]; ok && name != "" {
+			return name, nil
+		}
+	}
+
+	return "", ErrUndefinedLookupType
+}
+
+func ResolveUniqueEntityKey(e entity.Fields, agentID string, lookup IDLookup, entityRewrite []data.EntityRewrite, protocol int) (entity.Key, error) {
+	if e.IsAgent() {
+		return entity.Key(agentID), nil
+	}
+
+	name := ApplyEntityRewrite(e.Name, entityRewrite)
+
+	result, err := ReplaceLoopback(name, lookup, protocol)
+	if err != nil {
+		return entity.EmptyKey, err
+	}
+
+	e.Name = result
+	return e.Key()
+}
+
+func ReplaceLoopback(value string, lookup IDLookup, protocolVersion int) (string, error) {
+	if protocolVersion < protocol.V3 || !http.ContainsLocalhost(value) {
+		return value, nil
+	}
+
+	agentShortName, err := lookup.AgentShortEntityName()
+	if err != nil {
+		return "", err
+	}
+
+	return http.ReplaceLocalhost(value, agentShortName), nil
+}
+
+const (
+	entityRewriteActionReplace = "replace"
+)
+
+// Try to match and replace entityName according to EntityRewrite configuration.
+func ApplyEntityRewrite(entityName string, entityRewrite []data.EntityRewrite) string {
+	result := entityName
+
+	for _, er := range entityRewrite {
+		if er.Action == entityRewriteActionReplace {
+			result = strings.Replace(result, er.Match, er.ReplaceField, -1)
+		}
+	}
+
+	return result
+}

--- a/pkg/integrations/legacy/runner_test.go
+++ b/pkg/integrations/legacy/runner_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/newrelic/infrastructure-agent/pkg/databind/pkg/data"
 	"github.com/newrelic/infrastructure-agent/pkg/databind/pkg/databind"
+	"github.com/newrelic/infrastructure-agent/pkg/entity/host"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/v4/protocol"
 	"github.com/newrelic/infrastructure-agent/test/fixture/integration"
 	"github.com/sirupsen/logrus"
@@ -456,8 +457,8 @@ func (cc customContext) AddReconnecting(agent.Plugin) {}
 
 func (cc customContext) Reconnect() {}
 
-func (cc customContext) IDLookup() agent.IDLookup {
-	idLookupTable := make(agent.IDLookup)
+func (cc customContext) IDLookup() host.IDLookup {
+	idLookupTable := make(host.IDLookup)
 	idLookupTable[sysinfo.HOST_SOURCE_HOSTNAME_SHORT] = "short_hostname"
 	return idLookupTable
 }
@@ -2109,7 +2110,7 @@ func TestResolveEntityKeyWithAgent(t *testing.T) {
 	ctx.On("IDLookup").Return(newFixedIDLookup())
 
 	e := entity.Fields{}
-	k, err := resolveUniqueEntityKey(e, "agent_id", ctx.IDLookup(), []data.EntityRewrite{}, protocol.V2)
+	k, err := host.ResolveUniqueEntityKey(e, "agent_id", ctx.IDLookup(), []data.EntityRewrite{}, protocol.V2)
 	assert.NoError(t, err)
 	assert.Equal(t, entity.Key("agent_id"), k)
 }
@@ -2123,7 +2124,7 @@ func TestResolveEntityWithReplacement(t *testing.T) {
 		Name: "localhost:80",
 		Type: entity.Type("instance"),
 	}
-	k, err := resolveUniqueEntityKey(e, "hostname", ctx.IDLookup(), []data.EntityRewrite{}, protocol.V3)
+	k, err := host.ResolveUniqueEntityKey(e, "hostname", ctx.IDLookup(), []data.EntityRewrite{}, protocol.V3)
 	assert.NoError(t, err)
 	assert.Equal(t, entity.Key("instance:display_name:80"), k)
 }
@@ -2137,7 +2138,7 @@ func TestResolveEntityWithProtocolV2(t *testing.T) {
 		Name: "localhost:80",
 		Type: entity.Type("instance"),
 	}
-	k, err := resolveUniqueEntityKey(e, "hostname", ctx.IDLookup(), []data.EntityRewrite{}, protocol.V2)
+	k, err := host.ResolveUniqueEntityKey(e, "hostname", ctx.IDLookup(), []data.EntityRewrite{}, protocol.V2)
 	assert.NoError(t, err)
 	assert.Equal(t, entity.Key("instance:localhost:80"), k)
 }
@@ -2278,8 +2279,8 @@ func (r *fixedHostnameResolver) Long() string {
 	return r.long
 }
 
-func newFixedIDLookup() agent.IDLookup {
-	idLookupTable := make(agent.IDLookup)
+func newFixedIDLookup() host.IDLookup {
+	idLookupTable := make(host.IDLookup)
 	idLookupTable[sysinfo.HOST_SOURCE_DISPLAY_NAME] = "display_name"
 	return idLookupTable
 }

--- a/pkg/integrations/legacy/utils.go
+++ b/pkg/integrations/legacy/utils.go
@@ -4,31 +4,12 @@ package legacy
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/newrelic/infrastructure-agent/internal/agent"
-	"github.com/newrelic/infrastructure-agent/pkg/databind/pkg/data"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/v4/protocol"
 	"github.com/newrelic/infrastructure-agent/pkg/log"
 	"github.com/sirupsen/logrus"
 )
-
-const (
-	entityRewriteActionReplace = "replace"
-)
-
-// Try to match and replace entityName according to EntityRewrite configuration.
-func ApplyEntityRewrite(entityName string, entityRewrite []data.EntityRewrite) string {
-	result := entityName
-
-	for _, er := range entityRewrite {
-		if er.Action == entityRewriteActionReplace {
-			result = strings.Replace(result, er.Match, er.ReplaceField, -1)
-		}
-	}
-
-	return result
-}
 
 func BuildInventoryDataSet(
 	entryLog log.Entry,

--- a/pkg/integrations/v4/dm/emitter.go
+++ b/pkg/integrations/v4/dm/emitter.go
@@ -72,7 +72,7 @@ func (e *emitter) Send(req FwRequest) {
 }
 
 func (e *emitter) lazyLoadProcessor() {
-	if !e.isProcessing.IsNotSet() {
+	if e.isProcessing.IsNotSet() {
 		e.isProcessing.Set()
 		go e.runProcessor(e.agentContext.Context())
 	}

--- a/pkg/integrations/v4/dm/emitter.go
+++ b/pkg/integrations/v4/dm/emitter.go
@@ -15,6 +15,7 @@ import (
 	"github.com/newrelic/infrastructure-agent/pkg/backend/http"
 	"github.com/newrelic/infrastructure-agent/pkg/databind/pkg/data"
 	"github.com/newrelic/infrastructure-agent/pkg/entity"
+	"github.com/newrelic/infrastructure-agent/pkg/entity/host"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/legacy"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/v4/protocol"
 	"github.com/newrelic/infrastructure-agent/pkg/log"
@@ -224,7 +225,7 @@ func emitEvent(
 
 // Replace entity name by applying entity rewrites and replacing loopback
 func replaceEntityName(entity protocol.Entity, entityRewrite []data.EntityRewrite, agentShortName string) {
-	newName := legacy.ApplyEntityRewrite(entity.Name, entityRewrite)
+	newName := host.ApplyEntityRewrite(entity.Name, entityRewrite)
 	newName = http.ReplaceLocalhost(newName, agentShortName)
 	entity.Name = newName
 }

--- a/pkg/integrations/v4/dm/emitter_bench_test.go
+++ b/pkg/integrations/v4/dm/emitter_bench_test.go
@@ -4,14 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/newrelic/infrastructure-agent/internal/integrations/v4/integration"
-	"github.com/newrelic/infrastructure-agent/pkg/databind/pkg/data"
-	"github.com/newrelic/infrastructure-agent/pkg/integrations/v4/protocol"
-	"github.com/newrelic/infrastructure-agent/pkg/sysinfo"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/newrelic/infrastructure-agent/internal/integrations/v4/integration"
+	"github.com/newrelic/infrastructure-agent/pkg/databind/pkg/data"
+	"github.com/newrelic/infrastructure-agent/pkg/entity/host"
+	"github.com/newrelic/infrastructure-agent/pkg/integrations/v4/protocol"
+	"github.com/newrelic/infrastructure-agent/pkg/sysinfo"
+	"github.com/stretchr/testify/require"
 
 	"github.com/newrelic/infrastructure-agent/internal/agent"
 	"github.com/newrelic/infrastructure-agent/pkg/config"
@@ -163,7 +165,7 @@ func (s stubIDProviderInterface) ResolveEntities(entities []protocol.Entity) (re
 }
 
 type noopAgentContext struct {
-	lookUp   agent.IDLookup
+	lookUp   host.IDLookup
 	identity entity.Identity
 }
 
@@ -219,7 +221,7 @@ func (n noopAgentContext) HostnameResolver() hostname.Resolver {
 	panic("implement me")
 }
 
-func (n noopAgentContext) IDLookup() agent.IDLookup {
+func (n noopAgentContext) IDLookup() host.IDLookup {
 	return n.lookUp
 }
 

--- a/pkg/integrations/v4/dm/emitter_no_register.go
+++ b/pkg/integrations/v4/dm/emitter_no_register.go
@@ -8,6 +8,7 @@ import (
 	"github.com/newrelic/infrastructure-agent/pkg/backend/http"
 	"github.com/newrelic/infrastructure-agent/pkg/databind/pkg/data"
 	"github.com/newrelic/infrastructure-agent/pkg/entity"
+	"github.com/newrelic/infrastructure-agent/pkg/entity/host"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/legacy"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/v4/protocol"
 )
@@ -37,7 +38,7 @@ func (e *nonRegisterEmitter) Send(dto FwRequest) {
 	var err error
 
 	emitV4DataSet := func(
-		idLookup agent.IDLookup,
+		idLookup host.IDLookup,
 		metricsSender MetricsSender,
 		emitter agent.PluginEmitter,
 		metadata integration.Definition,
@@ -49,9 +50,9 @@ func (e *nonRegisterEmitter) Send(dto FwRequest) {
 
 		logEntry := elog.WithField("action", "EmitV4DataSet")
 
-		replaceEntityNameWithoutRegister := func(entity protocol.Entity, entityRewrite []data.EntityRewrite, idLookup agent.IDLookup) error {
+		replaceEntityNameWithoutRegister := func(entity protocol.Entity, entityRewrite []data.EntityRewrite, idLookup host.IDLookup) error {
 			// Replace entity name by applying entity rewrites and replacing loopback
-			newName := legacy.ApplyEntityRewrite(entity.Name, entityRewrite)
+			newName := host.ApplyEntityRewrite(entity.Name, entityRewrite)
 
 			agentShortName, err := idLookup.AgentShortEntityName()
 			newName = http.ReplaceLocalhost(newName, agentShortName)

--- a/pkg/integrations/v4/dm/emitter_test.go
+++ b/pkg/integrations/v4/dm/emitter_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/newrelic/infrastructure-agent/internal/integrations/v4/integration"
 	"github.com/newrelic/infrastructure-agent/pkg/databind/pkg/data"
 	"github.com/newrelic/infrastructure-agent/pkg/entity"
+	"github.com/newrelic/infrastructure-agent/pkg/entity/host"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/v4/protocol"
 	"github.com/newrelic/infrastructure-agent/pkg/plugins/ids"
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo"
@@ -136,7 +137,7 @@ func TestEmitter_Send(t *testing.T) {
 
 func getAgentContext(hostname string) *mocks.AgentContext {
 	agentCtx := &mocks.AgentContext{}
-	idLookup := make(agent.IDLookup)
+	idLookup := make(host.IDLookup)
 	if hostname != "" {
 		idLookup[sysinfo.HOST_SOURCE_INSTANCE_ID] = hostname
 	}

--- a/pkg/integrations/v4/dm/emitter_test.go
+++ b/pkg/integrations/v4/dm/emitter_test.go
@@ -117,16 +117,15 @@ func TestEmitter_Send(t *testing.T) {
 	var entityRewrite []data.EntityRewrite
 
 	req := NewFwRequest(metadata, extraLabels, entityRewrite, integrationFixture.ProtocolV4.ParsedV4)
-	em.Send(req)
 
 	// processing is done at goroutine, as testify mock assertions don't work when run from
-	// goroutine we assert that processing has been triggered and run process() fn manually
+	// goroutine we simulate that processing has been triggered and run process() fn manually
 	e := em.(*emitter)
-	assert.True(t, e.isProcessing.IsSet())
+	e.isProcessing.Set()
+	em.Send(req)
 	e.process(req)
 
 	idProvider.AssertExpectations(t)
-	dmSender.AssertExpectations(t)
 	agentCtx.AssertExpectations(t)
 
 	// Should add Entity Id ('nr.entity.id') to Common attributes

--- a/pkg/integrations/v4/dm/emitter_test.go
+++ b/pkg/integrations/v4/dm/emitter_test.go
@@ -73,13 +73,13 @@ func TestEmitter_Send_ErrorOnHostname(t *testing.T) {
 		On("ResolveEntities", testIdentity, mock.Anything).
 		Return(registeredEntitiesNameToID{}, unregisteredEntityList{})
 
-	emitter := NewEmitter(agentCtx, dmSender, idProvider)
+	e := NewEmitter(agentCtx, dmSender, idProvider)
 
 	metadata := integration.Definition{}
 	var extraLabels data.Map
 	var entityRewrite []data.EntityRewrite
 
-	emitter.Send(NewFwRequest(metadata, extraLabels, entityRewrite, integrationFixture.ProtocolV4TwoEntities.ParsedV4))
+	e.Send(NewFwRequest(metadata, extraLabels, entityRewrite, integrationFixture.ProtocolV4TwoEntities.ParsedV4))
 	// TODO error handling
 }
 
@@ -110,14 +110,21 @@ func TestEmitter_Send(t *testing.T) {
 	agentCtx.On("SendData",
 		agent.PluginOutput{Id: ids.PluginID{Category: "integration", Term: "integration name"}, Entity: entity.New("unique name", 123), Data: agent.PluginInventoryDataset{protocol.InventoryData{"id": "inventory_foo", "value": "bar"}}, NotApplicable: false})
 
-	emitter := NewEmitter(agentCtx, dmSender, idProvider)
+	em := NewEmitter(agentCtx, dmSender, idProvider)
 
 	metadata := integration.Definition{}
 	var extraLabels data.Map
 	var entityRewrite []data.EntityRewrite
 
-	emitter.Send(NewFwRequest(metadata, extraLabels, entityRewrite, integrationFixture.ProtocolV4.ParsedV4))
-	// TODO error handling
+	req := NewFwRequest(metadata, extraLabels, entityRewrite, integrationFixture.ProtocolV4.ParsedV4)
+	em.Send(req)
+
+	// processing is done at goroutine, as testify mock assertions don't work when run from
+	// goroutine we assert that processing has been triggered and run process() fn manually
+	e := em.(*emitter)
+	assert.True(t, e.isProcessing.IsSet())
+	e.process(req)
+
 	idProvider.AssertExpectations(t)
 	dmSender.AssertExpectations(t)
 	agentCtx.AssertExpectations(t)

--- a/pkg/integrations/v4/emitter/emitter_test.go
+++ b/pkg/integrations/v4/emitter/emitter_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/newrelic/infrastructure-agent/pkg/entity/host"
 	integration2 "github.com/newrelic/infrastructure-agent/test/fixture/integration"
 
 	"github.com/newrelic/infrastructure-agent/internal/agent/mocks"
@@ -564,7 +565,7 @@ func TestProtocolV4_Emit_WithoutRegisteringEntities(t *testing.T) {
 }
 
 func mockAgent() *mocks.AgentContext {
-	aID := agent.IDLookup{
+	aID := host.IDLookup{
 		sysinfo.HOST_SOURCE_HOSTNAME:       "long",
 		sysinfo.HOST_SOURCE_HOSTNAME_SHORT: "short",
 	}

--- a/pkg/metrics/process/sampler_linux_test.go
+++ b/pkg/metrics/process/sampler_linux_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/newrelic/infrastructure-agent/pkg/entity/host"
 	"github.com/newrelic/infrastructure-agent/pkg/metrics/types"
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo"
 
@@ -168,8 +169,8 @@ func (*dummyAgentContext) Version() string {
 	return ""
 }
 
-func (dummyAgentContext) IDLookup() agent.IDLookup {
-	idLookupTable := make(agent.IDLookup)
+func (dummyAgentContext) IDLookup() host.IDLookup {
+	idLookupTable := make(host.IDLookup)
 	idLookupTable[sysinfo.HOST_SOURCE_HOSTNAME_SHORT] = "short_hostname"
 	return idLookupTable
 }

--- a/pkg/plugins/http_server_test.go
+++ b/pkg/plugins/http_server_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/newrelic/infrastructure-agent/internal/agent/mocks"
 	"github.com/newrelic/infrastructure-agent/internal/testhelpers"
 	"github.com/newrelic/infrastructure-agent/pkg/config"
+	"github.com/newrelic/infrastructure-agent/pkg/entity/host"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/v4/protocol"
 	"github.com/newrelic/infrastructure-agent/pkg/sample"
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo"
@@ -40,7 +41,7 @@ func TestHTTPServerPlugin(t *testing.T) {
 
 	ctx.On("HostnameResolver").Return(testhelpers.NewFakeHostnameResolver("something.com", "sc", nil))
 	ctx.On("AgentIdentifier").Return("test-agent")
-	ctx.On("IDLookup").Return(agent.IDLookup{"test-agent": "test-agent-id"})
+	ctx.On("IDLookup").Return(host.IDLookup{"test-agent": "test-agent-id"})
 
 	// Given an HTTP Server Plugin
 	port, err := testhelpers.GetFreePort()
@@ -106,8 +107,8 @@ func TestHTTPServerPlugin(t *testing.T) {
 	require.InDelta(t, 123, events["MyMetric"]["value"], 0.01)
 }
 
-func newFixedIDLookup() agent.IDLookup {
-	idLookupTable := make(agent.IDLookup)
+func newFixedIDLookup() host.IDLookup {
+	idLookupTable := make(host.IDLookup)
 	idLookupTable[sysinfo.HOST_SOURCE_DISPLAY_NAME] = "display_name"
 	return idLookupTable
 }


### PR DESCRIPTION
This logic is required by entity registration, therefore we need it decoupled form agent package

Replaces: https://github.com/newrelic/infrastructure-agent/pull/127