### PR TITLE
fix: remove misleading config

### DIFF
--- a/internal/agent/cmdchannel/handler/featureflag_handler.go
+++ b/internal/agent/cmdchannel/handler/featureflag_handler.go
@@ -25,7 +25,6 @@ const (
 	FlagFullProcess          = "full_process_sampling"
 	// Config
 	CfgYmlRegisterEnabled        = "register_enabled"
-	CfgYmlDMRegisterEnable       = "dm_register_enabled"
 	CfgYmlParallelizeInventory   = "inventory_queue_len"
 	CfgValueParallelizeInventory = int64(100) // default value when no config provided by user and FF enabled
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -858,12 +858,6 @@ type Config struct {
 	// Public: No
 	RegisterEnabled bool `yaml:"register_enabled" envconfig:"register_enabled" public:"false"`
 
-	// DMRegisterEnabled If it's enabled entities will be registered using new register endpoint and it assigns
-	// these entities with an assigned entity ID.
-	// Default: False
-	// Public: No
-	DMRegisterEnabled bool `yaml:"dm_register_enabled" envconfig:"dm_register_enabled" public:"false"`
-
 	// FilesConfigOn enables or disables the configuration file monitoring. Disabled by default. We just keep this
 	// configuration value for backwards compatibilities, but any new agent should enable this value.
 	// Default: False


### PR DESCRIPTION
Deleting dead and misleading code.

`Features` config option should be used instead:

```
features:
  dm_register_enabled: true
```