### PR TITLE
fix: handle cloud harvester errors

### DIFF
--- a/pkg/helpers/fingerprint/fingerprint.go
+++ b/pkg/helpers/fingerprint/fingerprint.go
@@ -126,6 +126,12 @@ func (ir *harvestor) Harvest() (fp Fingerprint, err error) {
 	// Get ec2 instance id.
 	instanceID, err := ir.cloudHarvester.GetInstanceID()
 	if err != nil {
+		// if we know for sure that the host runs on the cloud, do not generate a fingerprint without a cloud id
+		// because then the host could start reporting under a different entity id.
+		if ir.cloudHarvester.GetCloudType().IsValidCloud() {
+			return
+		}
+
 		hlog.WithError(err).Debug("Unable to get instance id.")
 	}
 

--- a/pkg/helpers/fingerprint/fingerprint_test.go
+++ b/pkg/helpers/fingerprint/fingerprint_test.go
@@ -1,0 +1,110 @@
+package fingerprint
+
+import (
+	"fmt"
+	"github.com/newrelic/infrastructure-agent/pkg/config"
+	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/cloud"
+	"gotest.tools/assert"
+	"testing"
+)
+
+type MockHostNameResolver struct{}
+
+func (r *MockHostNameResolver) Query() (full, short string, err error) {
+	return "full", "short", nil
+}
+
+func (r *MockHostNameResolver) Long() (short string) {
+	return "long"
+}
+
+type MockCloudHarvester struct {
+	cloudId   string
+	cloudType cloud.Type
+	// if true, it means calls to the cloud APIs will return an error
+	error        bool
+	ErrorMessage string
+}
+
+func NewCloudHarvester(cloudId string, cloudType cloud.Type, error bool) *MockCloudHarvester {
+	return &MockCloudHarvester{cloudId: cloudId, cloudType: cloudType, error: error,
+		ErrorMessage: "error connecting to the cloud API"}
+}
+
+func (a *MockCloudHarvester) GetInstanceID() (string, error) {
+	if a.error {
+		return "", fmt.Errorf(a.ErrorMessage)
+	}
+	return a.cloudId, nil
+}
+
+func (a *MockCloudHarvester) GetHostType() (string, error) {
+	return "", nil
+}
+
+func (a *MockCloudHarvester) GetCloudType() cloud.Type {
+	return a.cloudType
+}
+
+func (a *MockCloudHarvester) GetCloudSource() string {
+	return ""
+}
+
+func (a *MockCloudHarvester) GetRegion() (string, error) {
+	return "", nil
+}
+
+func (a *MockCloudHarvester) GetHarvester() (cloud.Harvester, error) {
+	return nil, nil
+}
+
+// the fingerprint should contain the cloud id if there was no error
+func TestCloudNoError(t *testing.T) {
+	hostnameResolver := &MockHostNameResolver{}
+	cloudHarvester := NewCloudHarvester("i-123", cloud.TypeAWS, false)
+	config := config.NewConfig()
+	fpHarvester, _ := NewHarvestor(config, hostnameResolver, cloudHarvester)
+	fp, err := fpHarvester.Harvest()
+
+	assert.NilError(t, err)
+	assert.Equal(t, fp.CloudProviderId, "i-123")
+}
+
+// if there was an error and the cloud harvester was initialized - ie. the host was detected to run on the cloud - then
+// harvesting the fingerprint should return an error
+func TestCloudErrorInitialized(t *testing.T) {
+	hostnameResolver := &MockHostNameResolver{}
+	cloudHarvester := NewCloudHarvester("", cloud.TypeAWS, true)
+	config := config.NewConfig()
+	fpHarvester, _ := NewHarvestor(config, hostnameResolver, cloudHarvester)
+	fp, err := fpHarvester.Harvest()
+
+	assert.Error(t, err, cloudHarvester.ErrorMessage)
+	assert.Equal(t, fp.CloudProviderId, "")
+}
+
+// if there was an error but the host does not run on the cloud, then the fingerprint should be created without
+// any error
+func TestCloudErrorNoCloud(t *testing.T) {
+	hostnameResolver := &MockHostNameResolver{}
+	cloudHarvester := NewCloudHarvester("", cloud.TypeNoCloud, true)
+	config := config.NewConfig()
+	fpHarvester, _ := NewHarvestor(config, hostnameResolver, cloudHarvester)
+	fp, err := fpHarvester.Harvest()
+
+	assert.NilError(t, err)
+	assert.Equal(t, fp.CloudProviderId, "")
+}
+
+// if there was an error but we don't know yet whether the host runs on the cloud, then the fingerprint should be
+// created without any error
+func TestCloudErrorNotInitialized(t *testing.T) {
+	hostnameResolver := &MockHostNameResolver{}
+	cloudHarvester := NewCloudHarvester("", cloud.TypeInProgress, true)
+	config := config.NewConfig()
+	fpHarvester, _ := NewHarvestor(config, hostnameResolver, cloudHarvester)
+	fp, err := fpHarvester.Harvest()
+
+	assert.NilError(t, err)
+	assert.Equal(t, fp.CloudProviderId, "")
+}

--- a/pkg/plugins/host_aliases.go
+++ b/pkg/plugins/host_aliases.go
@@ -91,7 +91,7 @@ func (self *HostAliasesPlugin) getHostAliasesDataset() (dataset agent.PluginInve
 func (self *HostAliasesPlugin) shouldCollectCloudMetadata() bool {
 	return !self.Context.Config().DisableCloudMetadata &&
 		!self.Context.Config().DisableCloudInstanceId &&
-		self.cloudHarvester.GetCloudType().ShouldCollect()
+		self.cloudHarvester.GetCloudType().IsValidCloud()
 }
 
 // Collect cloud metadata and set self.cloudAliases to include whatever we found

--- a/pkg/sysinfo/cloud/cloud.go
+++ b/pkg/sysinfo/cloud/cloud.go
@@ -27,8 +27,7 @@ const (
 
 var dlog = log.WithComponent("CloudDetector")
 
-// ShouldCollect returns true if we should collect data for this cloud type.
-func (t Type) ShouldCollect() bool {
+func (t Type) IsValidCloud() bool {
 	return t != TypeNoCloud && t != TypeInProgress
 }
 


### PR DESCRIPTION
Don't return a fingerprint if the cloud harvester returns an error and
we've previously determined that the host runs on the cloud (#94)