### PR TITLE
feat: telemetryapi client now has a worker pool to perform HTTP requests

### DIFF
--- a/pkg/backend/identityapi/register_client.go
+++ b/pkg/backend/identityapi/register_client.go
@@ -90,7 +90,6 @@ func NewRegisterClient(
 	}
 	icfg := identity.NewConfiguration()
 	icfg.BasePath = svcUrl + identityPath
-	icfg.Debug = true
 	// TODO: add the global HTTP client here
 	// icfg.HTTPClient = httpClient
 	identityClient := identity.NewAPIClient(icfg)

--- a/pkg/backend/telemetryapi/aggregated_metrics_test.go
+++ b/pkg/backend/telemetryapi/aggregated_metrics_test.go
@@ -4,6 +4,7 @@
 package telemetryapi
 
 import (
+	"context"
 	"math"
 	"os"
 	"reflect"
@@ -55,7 +56,7 @@ func TestManyAttributes(t *testing.T) {
 	}
 	h.MetricAggregator().Gauge("myGauge", attributes).valueNow(1.0, now)
 	h.MetricAggregator().Gauge("myGauge", attributes).valueNow(2.0, now)
-	if ms := h.swapOutMetrics(time.Now()); len(ms) != 1 {
+	if ms := h.swapOutMetrics(context.Background(), time.Now()); len(ms) != 1 {
 		t.Fatal(len(ms))
 	}
 }
@@ -136,7 +137,7 @@ func TestCountNegative(t *testing.T) {
 	h, _ := NewHarvester(configTesting)
 	count := h.MetricAggregator().Count("myCount", map[string]interface{}{"zip": "zap"})
 	count.Increase(-123)
-	if ms := h.swapOutMetrics(time.Now()); len(ms) != 0 {
+	if ms := h.swapOutMetrics(context.Background(), time.Now()); len(ms) != 0 {
 		t.Fatal(ms)
 	}
 }

--- a/pkg/backend/telemetryapi/config.go
+++ b/pkg/backend/telemetryapi/config.go
@@ -4,12 +4,17 @@
 package telemetryapi
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"log"
 	"net/http"
 	"time"
 )
+
+// DefaultMaxConns is the default value of the Config's
+// MaxConns.
+const DefaultMaxConns = 2
 
 // Config customizes the behavior of a Harvester.
 type Config struct {
@@ -49,6 +54,11 @@ type Config struct {
 	Product string
 	// ProductVersion is added to the User-Agent header. eg. "0.1.0".
 	ProductVersion string
+	// MaxConns limits the total number of concurrent connections when submitting data
+	// If zero, DefaultMaxConns is used.
+	MaxConns int
+	// Context is the Context to use for making requests
+	Context context.Context
 }
 
 // ConfigAPIKey sets the Config's APIKey which is required and refers to your
@@ -56,6 +66,14 @@ type Config struct {
 func ConfigAPIKey(key string) func(*Config) {
 	return func(cfg *Config) {
 		cfg.APIKey = key
+	}
+}
+
+// ConfigContext add the given context.Context to the Config's
+// Context field
+func ConfigContext(ctx context.Context) func(*Config) {
+	return func(cfg *Config) {
+		cfg.Context = ctx
 	}
 }
 

--- a/pkg/backend/telemetryapi/config.go
+++ b/pkg/backend/telemetryapi/config.go
@@ -143,6 +143,7 @@ func ConfigSpansURLOverride(url string) func(*Config) {
 func configTesting(cfg *Config) {
 	cfg.APIKey = "api-key"
 	cfg.HarvestPeriod = 0
+	cfg.Context = context.Background()
 }
 
 func (cfg *Config) logError(fields map[string]interface{}) {

--- a/pkg/backend/telemetryapi/config_test.go
+++ b/pkg/backend/telemetryapi/config_test.go
@@ -5,6 +5,7 @@ package telemetryapi
 
 import (
 	"bytes"
+	"context"
 	"strings"
 	"testing"
 )
@@ -53,6 +54,17 @@ func TestConfigBasicErrorLogger(t *testing.T) {
 	h.config.logError(map[string]interface{}{"zip": func() {}})
 	if log := buf.String(); !strings.Contains(log, "json: unsupported type: func()") {
 		t.Error("message not logged correctly", log)
+	}
+}
+
+func TestConfigContext(t *testing.T) {
+	ctx := context.Background()
+	h, err := NewHarvester(ConfigAPIKey("apikey"), ConfigContext(ctx))
+	if nil == h || err != nil {
+		t.Fatal(h, err)
+	}
+	if ctx != h.config.Context {
+		t.Error("config func does not set context correctly")
 	}
 }
 

--- a/pkg/backend/telemetryapi/harvester.go
+++ b/pkg/backend/telemetryapi/harvester.go
@@ -111,7 +111,7 @@ func (h *Harvester) Start() {
 		go harvestRoutine(h)
 	}
 
-	for i := 0; i < h.config.MaxConns; i++ {
+	for i := 1; i <= h.config.MaxConns; i++ {
 		go func(workerNo int) {
 			wlog := logger.WithField("WorkerNo.", workerNo)
 			wlog.Debug("Starting worker.")
@@ -124,7 +124,7 @@ func (h *Harvester) Start() {
 					harvestRequest(req, &h.config)
 				}
 			}
-		}(i + 1)
+		}(i)
 	}
 }
 
@@ -276,7 +276,6 @@ func (r response) needsRetry(_ *Config, attempts int) (bool, time.Duration) {
 func postData(req *http.Request, client *http.Client) response {
 	resp, err := client.Do(req)
 	if nil != err {
-		logger.WithError(err).Info("BOOM")
 		return response{err: fmt.Errorf("error posting data: %v", err)}
 	}
 	defer resp.Body.Close()

--- a/pkg/backend/telemetryapi/metrics_batch_test.go
+++ b/pkg/backend/telemetryapi/metrics_batch_test.go
@@ -5,6 +5,7 @@ package telemetryapi
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"github.com/stretchr/testify/assert"
@@ -53,7 +54,8 @@ func TestMetrics(t *testing.T) {
 		]
 	}]`)
 
-	reqs, err := newRequests(metrics, "my-api-key", defaultMetricURL, "userAgent")
+	expectedContext := context.Background()
+	reqs, err := newRequests(expectedContext, metrics, "my-api-key", defaultMetricURL, "userAgent")
 	if err != nil {
 		t.Error("error creating request", err)
 	}
@@ -79,6 +81,9 @@ func TestMetrics(t *testing.T) {
 	}
 	if string(uncompressed) != expect {
 		t.Error("metrics JSON mismatch", string(uncompressed), expect)
+	}
+	if expectedContext != req.ctx {
+		t.Error("request context mismatch", expectedContext, req.ctx)
 	}
 }
 
@@ -127,7 +132,7 @@ func TestMetricBatch(t *testing.T) {
 		metricBatches = append(metricBatches, metrics)
 	}
 
-	requests, err := newBatchRequest(metricBatches, "my-api-key", defaultMetricURL, "userAgent")
+	requests, err := newBatchRequest(context.Background(), metricBatches, "my-api-key", defaultMetricURL, "userAgent")
 	require.NoError(t, err)
 	require.Len(t, requests, 1)
 	assert.Equal(t, "Identity-0,Identity-1", requests[0].Request.Header.Get("X-NRI-Entity-Ids"))
@@ -238,7 +243,7 @@ func testBatchJSON(t testing.TB, batch *metricBatch, expect string) {
 	if th, ok := t.(interface{ Helper() }); ok {
 		th.Helper()
 	}
-	reqs, err := newRequests(batch, "my-api-key", defaultMetricURL, "userAgent")
+	reqs, err := newRequests(context.Background(), batch, "my-api-key", defaultMetricURL, "userAgent")
 	if nil != err {
 		t.Fatal(err)
 	}

--- a/pkg/backend/telemetryapi/metrics_batch_test.go
+++ b/pkg/backend/telemetryapi/metrics_batch_test.go
@@ -82,9 +82,6 @@ func TestMetrics(t *testing.T) {
 	if string(uncompressed) != expect {
 		t.Error("metrics JSON mismatch", string(uncompressed), expect)
 	}
-	if expectedContext != req.ctx {
-		t.Error("request context mismatch", expectedContext, req.ctx)
-	}
 }
 
 func generateMetrics(start time.Time) []Metric {

--- a/pkg/backend/telemetryapi/metrics_test.go
+++ b/pkg/backend/telemetryapi/metrics_test.go
@@ -4,6 +4,7 @@
 package telemetryapi
 
 import (
+	"context"
 	"math"
 	"reflect"
 	"testing"
@@ -41,7 +42,7 @@ func TestMetricPayload(t *testing.T) {
 	})
 	h.lastHarvest = now
 	end := h.lastHarvest.Add(5 * time.Second)
-	reqs := h.swapOutMetrics(end)
+	reqs := h.swapOutMetrics(context.Background(), end)
 	if len(reqs) != 1 {
 		t.Fatal(reqs)
 	}

--- a/pkg/backend/telemetryapi/request.go
+++ b/pkg/backend/telemetryapi/request.go
@@ -5,6 +5,7 @@ package telemetryapi
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -24,6 +25,8 @@ type request struct {
 
 	compressedBody       []byte
 	compressedBodyLength int
+
+	ctx context.Context
 }
 
 type requestsBuilder interface {
@@ -35,7 +38,7 @@ var (
 	errUnableToSplit = fmt.Errorf("unable to split large payload further")
 )
 
-func newBatchRequest(metricsBatch []metricBatch, apiKey string, url string, userAgent string) (reqs []request, err error) {
+func newBatchRequest(ctx context.Context, metricsBatch []metricBatch, apiKey string, url string, userAgent string) (reqs []request, err error) {
 	// todo: split payload based on:
 	// a) number of entities being sent
 	// b) payload size
@@ -55,7 +58,7 @@ func newBatchRequest(metricsBatch []metricBatch, apiKey string, url string, user
 		}
 	}
 	buf.WriteByte(']')
-	req, err := createRequest(buf.Bytes(), apiKey, url, userAgent)
+	req, err := createRequest(ctx, buf.Bytes(), apiKey, url, userAgent)
 	if err != nil {
 		return nil, err
 	}
@@ -70,11 +73,11 @@ func requestNeedsSplit(r request) bool {
 	return r.compressedBodyLength >= maxCompressedSizeBytes
 }
 
-func newRequests(batch requestsBuilder, apiKey string, url string, userAgent string) ([]request, error) {
-	return newRequestsInternal(batch, apiKey, url, userAgent, requestNeedsSplit)
+func newRequests(ctx context.Context, batch requestsBuilder, apiKey string, url string, userAgent string) ([]request, error) {
+	return newRequestsInternal(ctx, batch, apiKey, url, userAgent, requestNeedsSplit)
 }
 
-func createRequest(rawJSON json.RawMessage, apiKey string, url string, userAgent string) (req request, err error) {
+func createRequest(ctx context.Context, rawJSON json.RawMessage, apiKey string, url string, userAgent string) (req request, err error) {
 	compressed, err := internal.Compress(rawJSON)
 	if nil != err {
 		return req, fmt.Errorf("error compressing data: %v", err)
@@ -94,12 +97,13 @@ func createRequest(rawJSON json.RawMessage, apiKey string, url string, userAgent
 		UncompressedBody:     rawJSON,
 		compressedBody:       compressed.Bytes(),
 		compressedBodyLength: compressedLen,
+		ctx:                  ctx,
 	}
 	return req, err
 }
 
-func newRequestsInternal(batch requestsBuilder, apiKey string, url string, userAgent string, needsSplit func(request) bool) ([]request, error) {
-	req, err := createRequest(batch.makeBody(), apiKey, url, userAgent)
+func newRequestsInternal(ctx context.Context, batch requestsBuilder, apiKey string, url string, userAgent string, needsSplit func(request) bool) ([]request, error) {
+	req, err := createRequest(ctx, batch.makeBody(), apiKey, url, userAgent)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +119,7 @@ func newRequestsInternal(batch requestsBuilder, apiKey string, url string, userA
 	}
 
 	for _, b := range batches {
-		rs, err := newRequestsInternal(b, apiKey, url, userAgent, needsSplit)
+		rs, err := newRequestsInternal(ctx, b, apiKey, url, userAgent, needsSplit)
 		if nil != err {
 			return nil, err
 		}

--- a/pkg/backend/telemetryapi/request.go
+++ b/pkg/backend/telemetryapi/request.go
@@ -25,8 +25,6 @@ type request struct {
 
 	compressedBody       []byte
 	compressedBodyLength int
-
-	ctx context.Context
 }
 
 type requestsBuilder interface {
@@ -93,11 +91,10 @@ func createRequest(ctx context.Context, rawJSON json.RawMessage, apiKey string, 
 	reqHTTP.Header.Add("Content-Encoding", "gzip")
 	reqHTTP.Header.Add("User-Agent", userAgent)
 	req = request{
-		Request:              reqHTTP,
+		Request:              reqHTTP.WithContext(ctx),
 		UncompressedBody:     rawJSON,
 		compressedBody:       compressed.Bytes(),
 		compressedBodyLength: compressedLen,
-		ctx:                  ctx,
 	}
 	return req, err
 }

--- a/pkg/backend/telemetryapi/request_test.go
+++ b/pkg/backend/telemetryapi/request_test.go
@@ -204,7 +204,7 @@ func Test_newBatchRequest(t *testing.T) {
 				assert.Equal(t, expectedURL, gotReqs[i].Request.URL.String())
 				assert.Equal(t, expectedUserAgent, gotReqs[i].Request.Header.Get("User-Agent"))
 				assert.Equal(t, tt.wantReqs[i].xNRIEntityIdsHeader, gotReqs[i].Request.Header.Get("X-NRI-Entity-Ids"))
-				assert.Equal(t, expectedContext, gotReqs[i].ctx)
+				assert.Equal(t, expectedContext, gotReqs[i].Request.Context())
 			}
 		})
 	}

--- a/pkg/backend/telemetryapi/spans_batch_test.go
+++ b/pkg/backend/telemetryapi/spans_batch_test.go
@@ -4,6 +4,7 @@
 package telemetryapi
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"testing"
@@ -16,7 +17,8 @@ func testSpanBatchJSON(t testing.TB, batch *spanBatch, expect string) {
 	if th, ok := t.(interface{ Helper() }); ok {
 		th.Helper()
 	}
-	reqs, err := newRequests(batch, "apiKey", defaultSpanURL, "userAgent")
+	expectedContext := context.Background()
+	reqs, err := newRequests(expectedContext, batch, "apiKey", defaultSpanURL, "userAgent")
 	if nil != err {
 		t.Fatal(err)
 	}
@@ -31,7 +33,7 @@ func testSpanBatchJSON(t testing.TB, batch *spanBatch, expect string) {
 	}
 
 	body, err := ioutil.ReadAll(req.Request.Body)
-	req.Request.Body.Close()
+	_ = req.Request.Body.Close()
 	if err != nil {
 		t.Fatal("unable to read body", err)
 	}
@@ -45,6 +47,9 @@ func testSpanBatchJSON(t testing.TB, batch *spanBatch, expect string) {
 	}
 	if string(uncompressed) != string(req.UncompressedBody) {
 		t.Error("request JSON mismatch", string(uncompressed), string(req.UncompressedBody))
+	}
+	if expectedContext != req.ctx {
+		t.Error("request context mismatch", expectedContext, req.ctx)
 	}
 }
 

--- a/pkg/backend/telemetryapi/spans_batch_test.go
+++ b/pkg/backend/telemetryapi/spans_batch_test.go
@@ -48,9 +48,6 @@ func testSpanBatchJSON(t testing.TB, batch *spanBatch, expect string) {
 	if string(uncompressed) != string(req.UncompressedBody) {
 		t.Error("request JSON mismatch", string(uncompressed), string(req.UncompressedBody))
 	}
-	if expectedContext != req.ctx {
-		t.Error("request context mismatch", expectedContext, req.ctx)
-	}
 }
 
 func TestSpansPayloadSplit(t *testing.T) {

--- a/pkg/backend/telemetryapi/spans_test.go
+++ b/pkg/backend/telemetryapi/spans_test.go
@@ -5,6 +5,7 @@ package telemetryapi
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -42,7 +43,7 @@ func BenchmarkSpansJSON(b *testing.B) {
 }
 
 func testHarvesterSpans(t testing.TB, h *Harvester, expect string) {
-	reqs := h.swapOutSpans()
+	reqs := h.swapOutSpans(context.Background())
 	if nil == reqs {
 		if expect != "null" {
 			t.Error("nil spans", expect)


### PR DESCRIPTION
This PR adds a worker pool to process HTTP requests. This should speed up the sending of DM to the backend. For more details see #125.