### PR TITLE
refactor: rename v4 config Name to InstanceName

### DIFF
--- a/internal/integrations/v4/integration/definition_test.go
+++ b/internal/integrations/v4/integration/definition_test.go
@@ -28,8 +28,8 @@ func TestRun(t *testing.T) {
 
 	// GIVEN a definition entry with no discovery sources
 	def, err := NewDefinition(config.ConfigEntry{
-		Name: "foo",
-		Exec: testhelp.Command(fixtures.BasicCmd),
+		InstanceName: "foo",
+		Exec:         testhelp.Command(fixtures.BasicCmd),
 	}, ErrLookup, nil, nil)
 	require.NoError(t, err)
 
@@ -49,8 +49,8 @@ func TestRun_NoDiscovery(t *testing.T) {
 
 	// GIVEN a definition entry with discovery sources
 	def, err := NewDefinition(config.ConfigEntry{
-		Name: "foo",
-		Exec: testhelp.Command(fixtures.BasicCmd),
+		InstanceName: "foo",
+		Exec:         testhelp.Command(fixtures.BasicCmd),
 		Env: map[string]string{
 			"CONFIG": "${discovery.foo}",
 		},
@@ -73,8 +73,8 @@ func TestRun_Discovery(t *testing.T) {
 	}
 	// GIVEN a definition entry with discoverable configuration
 	def, err := NewDefinition(config.ConfigEntry{
-		Name: "foo",
-		Exec: testhelp.Command(fixtures.BasicCmd, "${argument}"),
+		InstanceName: "foo",
+		Exec:         testhelp.Command(fixtures.BasicCmd, "${argument}"),
 		Env: map[string]string{
 			"PREFIX": "${prefix}",
 		},
@@ -116,8 +116,8 @@ func TestRun_CmdSlice(t *testing.T) {
 
 	// GIVEN a definition entry whose parameters are specified as a command array
 	def, err := NewDefinition(config.ConfigEntry{
-		Name: "foo",
-		Exec: testhelp.CommandSlice(fixtures.BasicCmd, "argument"),
+		InstanceName: "foo",
+		Exec:         testhelp.CommandSlice(fixtures.BasicCmd, "argument"),
 	}, ErrLookup, nil, nil)
 	require.NoError(t, err)
 
@@ -139,8 +139,8 @@ func TestRun_CancelPropagation(t *testing.T) {
 	// GIVEN a definition entry with discoverable configuration
 	// that is executed with different discovery matches
 	def, err := NewDefinition(config.ConfigEntry{
-		Name: "foo",
-		Exec: testhelp.Command(fixtures.BlockedCmd, "-f", "${argument}"),
+		InstanceName: "foo",
+		Exec:         testhelp.Command(fixtures.BlockedCmd, "-f", "${argument}"),
 	}, ErrLookup, nil, nil)
 	require.NoError(t, err)
 	vals := databind.NewValues(nil,
@@ -187,8 +187,8 @@ func TestRun_CancelPropagationWithoutReads(t *testing.T) {
 
 	// GIVEN a definition run
 	def, err := NewDefinition(config.ConfigEntry{
-		Name: "foo",
-		Exec: testhelp.Command(fixtures.BlockedCmd),
+		InstanceName: "foo",
+		Exec:         testhelp.Command(fixtures.BlockedCmd),
 	}, ErrLookup, nil, nil)
 	require.NoError(t, err)
 
@@ -226,8 +226,8 @@ func TestRun_Cancel_Partial(t *testing.T) {
 	// GIVEN a definition entry with discoverable configuration
 	// that is executed with different discovery matches
 	def, err := NewDefinition(config.ConfigEntry{
-		Name: "foo",
-		Exec: testhelp.Command("${script}"),
+		InstanceName: "foo",
+		Exec:         testhelp.Command("${script}"),
 	}, ErrLookup, nil, nil)
 	require.NoError(t, err)
 	vals := databind.NewValues(nil,
@@ -271,9 +271,9 @@ func TestRun_Directory(t *testing.T) {
 		currentpath = ".\\"
 	}
 	def, err := NewDefinition(config.ConfigEntry{
-		Name:    "foo",
-		Exec:    testhelp.Command(testhelp.Script(currentpath + scriptFile)),
-		WorkDir: tmpDir,
+		InstanceName: "foo",
+		Exec:         testhelp.Command(testhelp.Script(currentpath + scriptFile)),
+		WorkDir:      tmpDir,
 	}, ErrLookup, nil, nil)
 	require.NoError(t, err)
 
@@ -294,9 +294,9 @@ func TestRun_RemoveExternalConfig(t *testing.T) {
 	// GIVEN an integration with an external configuration file
 
 	configEntry := config.ConfigEntry{
-		Name:   "foo",
-		Exec:   testhelp.Command(fixtures.FileContentsWithArgCmd, "${config.path}"),
-		Config: "${discovery.ip}",
+		InstanceName: "foo",
+		Exec:         testhelp.Command(fixtures.FileContentsWithArgCmd, "${config.path}"),
+		Config:       "${discovery.ip}",
 	}
 	config, err := LoadConfigTemplate(configEntry.TemplatePath, configEntry.Config)
 	require.NoError(t, err)

--- a/internal/integrations/v4/integration/integration.go
+++ b/internal/integrations/v4/integration/integration.go
@@ -61,7 +61,7 @@ func NewDefinition(ce config2.ConfigEntry, lookup InstancesLookup, passthroughEn
 			Passthrough: passthroughEnv,
 		},
 		Labels:         ce.Labels,
-		Name:           ce.Name,
+		Name:           ce.InstanceName,
 		Interval:       getInterval(ce.Interval),
 		WhenConditions: conditions(ce.When),
 		ConfigTemplate: configTemplate,
@@ -163,18 +163,18 @@ func (d *Definition) fromExecPath(te config2.ConfigEntry) error {
 
 // loads the Definition runnable from an executable name, looking for it into a
 // set of predefined folders
-func (d *Definition) fromName(te config2.ConfigEntry, lookup InstancesLookup) error {
+func (d *Definition) fromName(cfg config2.ConfigEntry, lookup InstancesLookup) error {
 	// if not an "exec" nor legacy integration, we'll look for an
 	// executable corresponding to the "name" field in any of the integrations
 	// folders, and wrap it into an "exec"
-	path, err := lookup.ByName(te.Name)
+	path, err := lookup.ByName(cfg.InstanceName)
 	if err != nil {
 		return errors.New("can't instantiate integration: " + err.Error())
 	}
 	// we need to pass the path as part of an array, to avoid splitting the
 	// folders as different arguments
-	te.Exec = []string{path}
-	d.runnable, err = newExecutor(&d.ExecutorConfig, te.Exec)
+	cfg.Exec = []string{path}
+	d.runnable, err = newExecutor(&d.ExecutorConfig, cfg.Exec)
 	return err
 }
 

--- a/internal/integrations/v4/integration/integration_test.go
+++ b/internal/integrations/v4/integration/integration_test.go
@@ -33,20 +33,20 @@ func TestConfigTemplate(t *testing.T) {
 	}
 	cases := []testCase{{"Passing ${config.path} as command-line argument",
 		config2.ConfigEntry{
-			Name:         "test-integration",
+			InstanceName: "test-integration",
 			Exec:         testhelp.Command(fixtures.FileContentsWithArgCmd, "${config.path}"),
 			TemplatePath: file.Name(),
 		}}}
 	if runtime.GOOS != "windows" { // executing Powershell passing env vars has problems
 		cases = append(cases, testCase{"Using default CONFIG_PATH env var",
 			config2.ConfigEntry{
-				Name:         "test-integration",
+				InstanceName: "test-integration",
 				Exec:         testhelp.Command(fixtures.FileContentsCmd),
 				TemplatePath: file.Name(),
 			}})
 		cases = append(cases, testCase{"Passing ${config.path} as environment variable",
 			config2.ConfigEntry{
-				Name:         "test-integration",
+				InstanceName: "test-integration",
 				Exec:         testhelp.Command(fixtures.FileContentsFromEnvCmd),
 				Env:          map[string]string{"CUSTOM_CONFIG_PATH": "${config.path}"},
 				TemplatePath: file.Name(),
@@ -99,23 +99,23 @@ func TestEmbeddedConfig_String(t *testing.T) {
 	}
 	cases := []testCase{{"Passing ${config.path} as command-line argument. External file embedded in yaml",
 		config2.ConfigEntry{
-			Name:   "test-integration",
-			Exec:   testhelp.Command(fixtures.FileContentsWithArgCmd, "${config.path}"),
-			Config: "${discovery.ip}",
+			InstanceName: "test-integration",
+			Exec:         testhelp.Command(fixtures.FileContentsWithArgCmd, "${config.path}"),
+			Config:       "${discovery.ip}",
 		}}}
 	if runtime.GOOS != "windows" { // executing Powershell passing env vars has problems
 		cases = append(cases, testCase{"Using default CONFIG_PATH env var. External file embedded in yaml",
 			config2.ConfigEntry{
-				Name:   "test-integration",
-				Exec:   testhelp.Command(fixtures.FileContentsCmd),
-				Config: "${discovery.ip}",
+				InstanceName: "test-integration",
+				Exec:         testhelp.Command(fixtures.FileContentsCmd),
+				Config:       "${discovery.ip}",
 			}})
 		cases = append(cases, testCase{"Passing ${config.path} as environment variable. External file embedded in yaml",
 			config2.ConfigEntry{
-				Name:   "test-integration",
-				Exec:   testhelp.Command(fixtures.FileContentsFromEnvCmd),
-				Env:    map[string]string{"CUSTOM_CONFIG_PATH": "${config.path}"},
-				Config: "${discovery.ip}",
+				InstanceName: "test-integration",
+				Exec:         testhelp.Command(fixtures.FileContentsFromEnvCmd),
+				Env:          map[string]string{"CUSTOM_CONFIG_PATH": "${config.path}"},
+				Config:       "${discovery.ip}",
 			},
 		})
 	}
@@ -157,7 +157,7 @@ func TestEmbeddedConfig_String(t *testing.T) {
 func TestTimeout_Default(t *testing.T) {
 	// GIVEN a configuration without timeout
 	// WHEN an integration is loaded from it
-	i, err := NewDefinition(config2.ConfigEntry{Name: "foo", Exec: config2.ShlexOpt{"bar"}}, ErrLookup, nil, nil)
+	i, err := NewDefinition(config2.ConfigEntry{InstanceName: "foo", Exec: config2.ShlexOpt{"bar"}}, ErrLookup, nil, nil)
 	require.NoError(t, err)
 
 	// THEN the integration has a default timeout

--- a/internal/integrations/v4/runner/group_test.go
+++ b/internal/integrations/v4/runner/group_test.go
@@ -33,9 +33,9 @@ func TestGroup_Run(t *testing.T) {
 	te := &testemit.RecordEmitter{}
 	loader := NewLoadFn(config2.YAML{
 		Integrations: []config2.ConfigEntry{
-			{Name: "sayhello", Exec: testhelp.Command(fixtures.IntegrationScript, "hello"),
+			{InstanceName: "sayhello", Exec: testhelp.Command(fixtures.IntegrationScript, "hello"),
 				Labels: map[string]string{"foo": "bar", "ou": "yea"}},
-			{Name: "saygoodbye", Exec: testhelp.Command(fixtures.IntegrationScript, "bye")},
+			{InstanceName: "saygoodbye", Exec: testhelp.Command(fixtures.IntegrationScript, "bye")},
 		},
 	}, nil)
 	gr, _, err := NewGroup(loader, integration.InstancesLookup{}, nil, te, cmdrequest.NoopHandleFn, "")
@@ -72,7 +72,7 @@ func TestGroup_Run_Inventory(t *testing.T) {
 	te := &testemit.RecordEmitter{}
 	loader := NewLoadFn(config2.YAML{
 		Integrations: []config2.ConfigEntry{
-			{Name: "nri-test", Exec: testhelp.GoRun(fixtures.InventoryGoFile, "key1=val1", "key2=val2"),
+			{InstanceName: "nri-test", Exec: testhelp.GoRun(fixtures.InventoryGoFile, "key1=val1", "key2=val2"),
 				Labels: map[string]string{"foo": "bar", "ou": "yea"}},
 		},
 	}, nil)
@@ -121,7 +121,7 @@ func TestGroup_Run_Inventory_OverridePrefix(t *testing.T) {
 	te := &testemit.RecordEmitter{}
 	loader := NewLoadFn(config2.YAML{
 		Integrations: []config2.ConfigEntry{
-			{Name: "nri-test", Exec: testhelp.GoRun(fixtures.InventoryGoFile, "key1=val1"),
+			{InstanceName: "nri-test", Exec: testhelp.GoRun(fixtures.InventoryGoFile, "key1=val1"),
 				InventorySource: "custom/inventory"},
 		},
 	}, nil)
@@ -148,7 +148,7 @@ func TestGroup_Run_Timeout(t *testing.T) {
 	to := 200 * time.Millisecond
 	loader := NewLoadFn(config2.YAML{
 		Integrations: []config2.ConfigEntry{
-			{Name: "Hello", Exec: testhelp.Command(fixtures.BlockedCmd), Timeout: &to},
+			{InstanceName: "Hello", Exec: testhelp.Command(fixtures.BlockedCmd), Timeout: &to},
 		},
 	}, nil)
 	gr, _, err := NewGroup(loader, integration.InstancesLookup{}, nil, te, cmdrequest.NoopHandleFn, "")
@@ -187,8 +187,8 @@ discovery:
 
 	// GIVEN a grouprunner that runs an integration with discovery configurations
 	integr, err := integration.NewDefinition(config2.ConfigEntry{
-		Name: "timestamp",
-		Exec: testhelp.Command(fixtures.IntegrationScript, "${discovery.timestamp}"),
+		InstanceName: "timestamp",
+		Exec:         testhelp.Command(fixtures.IntegrationScript, "${discovery.timestamp}"),
 	}, integration.InstancesLookup{}, []string{}, nil)
 	require.NoError(t, err)
 
@@ -237,9 +237,9 @@ func TestGroup_Run_ConfigPathUpdated(t *testing.T) {
 	te := &testemit.RecordEmitter{}
 	loader := NewLoadFn(config2.YAML{
 		Integrations: []config2.ConfigEntry{{
-			Name:   "cfgpath",
-			Exec:   testhelp.Command(fixtures.IntegrationScript, "${config.path}"),
-			Config: "hello",
+			InstanceName: "cfgpath",
+			Exec:         testhelp.Command(fixtures.IntegrationScript, "${config.path}"),
+			Config:       "hello",
 		}},
 	}, nil)
 	group, _, err := NewGroup(loader, integration.InstancesLookup{}, nil, te, cmdrequest.NoopHandleFn, "")
@@ -316,7 +316,7 @@ func TestGroup_Run_IntegrationScriptPrintsErrorsAndReturnCodeIsZero(t *testing.T
 	te := &testemit.RecordEmitter{}
 	loader := NewLoadFn(config2.YAML{
 		Integrations: []config2.ConfigEntry{
-			{Name: "log_errors", Exec: testhelp.Command(fixtures.IntegrationPrintsErr, "bye")},
+			{InstanceName: "log_errors", Exec: testhelp.Command(fixtures.IntegrationPrintsErr, "bye")},
 		},
 	}, nil)
 	gr, _, err := NewGroup(loader, integration.InstancesLookup{}, nil, te, cmdrequest.NoopHandleFn, "")

--- a/internal/integrations/v4/runner/runner_test.go
+++ b/internal/integrations/v4/runner/runner_test.go
@@ -17,8 +17,8 @@ import (
 
 func Test_runner_Run(t *testing.T) {
 	def, err := integration.NewDefinition(config.ConfigEntry{
-		Name: "foo",
-		Exec: testhelp.Command(fixtures.IntegrationScript, "bar"),
+		InstanceName: "foo",
+		Exec:         testhelp.Command(fixtures.IntegrationScript, "bar"),
 	}, integration.ErrLookup, nil, nil)
 	require.NoError(t, err)
 

--- a/pkg/integrations/cmdrequest/handler.go
+++ b/pkg/integrations/cmdrequest/handler.go
@@ -55,8 +55,8 @@ func NewHandleFn(definitionQueue chan<- integration.Definition, logger log.Entry
 // TODO this still needs to be worked on
 func NewConfigFromCmdReq(cr protocol.CmdRequestV1Cmd) config.ConfigEntry {
 	return config.ConfigEntry{
-		Name: cr.Name,
-		Exec: append([]string{cr.Command}, cr.Args...),
+		InstanceName: cr.Name,
+		Exec:         append([]string{cr.Command}, cr.Args...),
 		//Arguments: cr.Args, // CAUTION: Arguments are converted into key-value env-vars
 		Env: cr.Env,
 	}

--- a/pkg/integrations/v4/config/config.go
+++ b/pkg/integrations/v4/config/config.go
@@ -11,20 +11,20 @@ import (
 
 // ConfigEntry holds an integrations YAML configuration entry. It may define multiple types of tasks
 type ConfigEntry struct {
-	Name     string            `yaml:"name"`     // integration name
-	Exec     ShlexOpt          `yaml:"exec"`     // it may be a CLI string or a YAML array
-	Env      map[string]string `yaml:"env"`      // User-defined environment variables
-	Interval string            `yaml:"interval"` // User-defined interval string (duration notation)
-	Timeout  *time.Duration    `yaml:"timeout"`
-	User     string            `yaml:"integration_user"`
-	WorkDir  string            `yaml:"working_dir"`
-	Labels   map[string]string `yaml:"labels"`
-	When     EnableConditions  `yaml:"when"`
+	InstanceName string            `yaml:"name"`     // integration instance name
+	Exec         ShlexOpt          `yaml:"exec"`     // it may be a CLI string or a YAML array
+	Env          map[string]string `yaml:"env"`      // User-defined environment variables
+	Interval     string            `yaml:"interval"` // User-defined interval string (duration notation)
+	Timeout      *time.Duration    `yaml:"timeout"`
+	User         string            `yaml:"integration_user"`
+	WorkDir      string            `yaml:"working_dir"`
+	Labels       map[string]string `yaml:"labels"`
+	When         EnableConditions  `yaml:"when"`
 
 	// Legacy definition commands
 	Command         string            `yaml:"command"`
 	Arguments       map[string]string `yaml:"arguments"`
-	IntegrationName string            `yaml:"integration_name"` // refers to the definition 'name' top field
+	IntegrationName string            `yaml:"integration_name"`
 	InventorySource string            `yaml:"inventory_source"`
 
 	// Config embeds a configuration file as a string. It can't coexist with TemplatePath
@@ -89,7 +89,7 @@ func (s *ShlexOpt) Value() []string {
 
 // checks that the format is correct and fixes possible nil leaks with default values
 func (cf *ConfigEntry) Sanitize() error {
-	if cf.Name == "" {
+	if cf.InstanceName == "" {
 		return errors.New("integration entry requires a non-empty 'name' field")
 	}
 	// Checking if there is any configuration file or path to be passed externally to the integration


### PR DESCRIPTION
Renaming `Name` var to express functionality, so it can be distinguished from `IntegrationName`.

Doc reference: https://docs.newrelic.com/docs/create-integrations/infrastructure-integrations-sdk/specifications/host-integrations-newer-configuration-format