### PR TITLE
fix: log forwarder trace

### DIFF
--- a/pkg/integrations/v4/supervisor.go
+++ b/pkg/integrations/v4/supervisor.go
@@ -178,7 +178,7 @@ func (s *Supervisor) logLine(out []byte, channel string) {
 	// avoid feedback loops
 	if !strings.Contains(strOut, componentName) {
 		if s.traceOutput {
-			trace.LogFwdOutput(saneLine)
+			trace.LogFwdOutput(strOut)
 			return
 		}
 


### PR DESCRIPTION
Fixes trace for log forwarder where line would be empty otherwise.

LogFw tracing feature hasn't been released yet, so *consider this for next release*.