### PR TITLE
Cache registered ids and fix the register batch loop

### DIFF
--- a/pkg/entity/known_ids.go
+++ b/pkg/entity/known_ids.go
@@ -45,6 +45,9 @@ func NewKnownIDs() KnownIDs {
 
 // Put registers an entity ID for a given entity Key. The entry has a default TTL of 24 hours.
 func (k *KnownIDs) Put(key Key, id ID) {
+	k.lock.Lock()
+	defer k.lock.Unlock()
+
 	k.putTTL(key, id, defaultTTL)
 }
 

--- a/pkg/entity/known_ids.go
+++ b/pkg/entity/known_ids.go
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package entity
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 var now = time.Now
 
@@ -17,6 +20,7 @@ const defaultTTL = 24 * time.Hour
 //
 // This component is not thread-safe.
 type KnownIDs struct {
+	lock sync.Mutex
 	ids  map[Key]*idEntry
 	ttls map[Type]time.Duration // per-entity ttl
 }
@@ -48,6 +52,8 @@ func (k *KnownIDs) Put(key Key, id ID) {
 // type registered with the SetTTL function. If the entity type has not been registered, it assumes the default TTL of
 // 24 hours.
 func (k *KnownIDs) PutType(entityType Type, key Key, id ID) {
+	k.lock.Lock()
+	defer k.lock.Unlock()
 	if ttl, ok := k.ttls[entityType]; ok {
 		k.putTTL(key, id, ttl)
 	} else {
@@ -66,6 +72,9 @@ func (k *KnownIDs) putTTL(key Key, id ID, ttl time.Duration) {
 // Get returns the entity ID for the given entity Key, if exists. If the entry is found, its expiration time is updated
 // to the current time + TTL.
 func (k *KnownIDs) Get(key Key) (ID, bool) {
+	k.lock.Lock()
+	defer k.lock.Unlock()
+
 	entry, ok := k.ids[key]
 	if !ok {
 		return 0, false
@@ -81,14 +90,19 @@ func (k *KnownIDs) Get(key Key) (ID, bool) {
 
 // SetTTL registers a custom TTL for the given entity Type
 func (k *KnownIDs) SetTTL(entityType Type, ttl time.Duration) {
+	k.lock.Lock()
+	defer k.lock.Unlock()
+
 	k.ttls[entityType] = ttl
 }
 
 // Clean removes the expired Key <-> ID entries
-func (kn *KnownIDs) CleanOld() {
-	for k, e := range kn.ids {
+func (k *KnownIDs) CleanOld() {
+	k.lock.Lock()
+	defer k.lock.Unlock()
+	for key, e := range k.ids {
 		if e.isOutdated() {
-			delete(kn.ids, k)
+			delete(k.ids, key)
 		}
 	}
 }

--- a/pkg/entity/register/worker.go
+++ b/pkg/entity/register/worker.go
@@ -102,7 +102,8 @@ func (w *worker) send(batch map[entity.Key]fwrequest.EntityFwRequest, batchSize 
 }
 
 func (w *worker) resetBatch(batch map[entity.Key]fwrequest.EntityFwRequest, batchSize *int) {
-	zero := 0
-	batchSize = &zero
-	batch = map[entity.Key]fwrequest.EntityFwRequest{}
+	*batchSize = 0
+	for key := range batch {
+		delete(batch, key)
+	}
 }

--- a/pkg/integrations/v4/dm/emitter_test.go
+++ b/pkg/integrations/v4/dm/emitter_test.go
@@ -159,6 +159,14 @@ func TestEmitter_Send(t *testing.T) {
 	sent := ms.Calls[0].Arguments[1].([]protocol.Metric)
 	assert.Len(t, sent, 1)
 	assert.Equal(t, eID.String(), sent[0].Attributes[fwrequest.EntityIdAttribute])
+
+	for _, d := range data.DataSets {
+		entityName, err := d.Entity.Key()
+		assert.NoError(t, err)
+		actualEntityID, found := e.idCache.Get(entityName)
+		assert.True(t, found)
+		assert.Equal(t, eID, actualEntityID)
+	}
 }
 
 func Test_NrEntityIdConst(t *testing.T) {


### PR DESCRIPTION
This PR will cache the registered entity ids and also fixes an issue where the batch structure for register entities was not clean