### PR TITLE
fix: entity registration when there is no entity name

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -164,7 +164,7 @@ func TestSetAgentKeysDisplayInstance(t *testing.T) {
 	}
 
 	a.setAgentKey(idMap)
-	assert.Equal(t, idMap[sysinfo.HOST_SOURCE_INSTANCE_ID], a.Context.AgentIdentifier())
+	assert.Equal(t, idMap[sysinfo.HOST_SOURCE_INSTANCE_ID], a.Context.EntityKey())
 }
 
 // Test that empty strings in the identity map are properly ignored in favor of non-empty ones
@@ -179,7 +179,7 @@ func TestSetAgentKeysInstanceEmptyString(t *testing.T) {
 	}
 
 	a.setAgentKey(keys)
-	assert.Equal(t, keys[sysinfo.HOST_SOURCE_DISPLAY_NAME], a.Context.AgentIdentifier())
+	assert.Equal(t, keys[sysinfo.HOST_SOURCE_DISPLAY_NAME], a.Context.EntityKey())
 }
 
 func TestSetAgentKeysDisplayNameMatchesHostName(t *testing.T) {
@@ -192,7 +192,7 @@ func TestSetAgentKeysDisplayNameMatchesHostName(t *testing.T) {
 	}
 
 	a.setAgentKey(keyMap)
-	assert.Equal(t, "hostName", a.Context.AgentIdentifier())
+	assert.Equal(t, "hostName", a.Context.EntityKey())
 }
 
 func TestSetAgentKeysNoValues(t *testing.T) {
@@ -221,7 +221,7 @@ func TestUpdateIDLookupTable(t *testing.T) {
 	})
 
 	assert.NoError(t, a.updateIDLookupTable(dataset))
-	assert.Equal(t, "instanceId", a.Context.AgentIdentifier())
+	assert.Equal(t, "instanceId", a.Context.EntityKey())
 }
 
 func TestIDLookup_EntityNameCloudInstance(t *testing.T) {

--- a/internal/agent/event_sender.go
+++ b/internal/agent/event_sender.go
@@ -168,7 +168,7 @@ func (sender *metricsIngestSender) Stop() (err error) {
 
 // We can accept any kind of object to represent an event. We assume that it will marshal to a valid JSON event object.
 func (sender *metricsIngestSender) QueueEvent(event sample.Event, key entity.Key) (err error) {
-	agentKey := sender.Context.AgentIdentifier()
+	agentKey := sender.Context.EntityKey()
 	// Default to the agent's own ID if we didn't receive one
 	if key == "" {
 		key = entity.Key(agentKey)

--- a/internal/agent/event_sender_vortex.go
+++ b/internal/agent/event_sender_vortex.go
@@ -195,7 +195,7 @@ func (s *vortexEventSender) Stop() (err error) {
 
 // We can accept any kind of object to represent an event. We assume that it will marshal to a valid JSON event object.
 func (s *vortexEventSender) QueueEvent(event sample.Event, key entity.Key) (err error) {
-	agentKey := s.Context.AgentIdentifier()
+	agentKey := s.Context.EntityKey()
 	// Default to the agent's own ID if we didn't receive one
 	if key == "" {
 		key = entity.Key(agentKey)

--- a/internal/agent/mocks/AgentContext.go
+++ b/internal/agent/mocks/AgentContext.go
@@ -53,8 +53,8 @@ func (_m *AgentContext) AddReconnecting(_a0 agent.Plugin) {
 	_m.Called(_a0)
 }
 
-// AgentIdentifier provides a mock function with given fields:
-func (_m *AgentContext) AgentIdentifier() string {
+// EntityKey provides a mock function with given fields:
+func (_m *AgentContext) EntityKey() string {
 	ret := _m.Called()
 
 	var r0 string

--- a/internal/agent/patch_sender.go
+++ b/internal/agent/patch_sender.go
@@ -71,7 +71,7 @@ func newPatchSender(entityInfo entity.Entity, context AgentContext, store delta.
 		context.Config().License,
 		userAgent,
 		context.Config().PayloadCompressionLevel,
-		context.AgentIdentifier(),
+		context.EntityKey(),
 		agentIDProvide,
 		context.Config().ConnectEnabled,
 		httpClient,
@@ -175,10 +175,10 @@ func (p *patchSenderIngest) sendAllDeltas(allDeltas []inventoryapi.RawDeltaBlock
 
 	// Empty entity Key belong to the Agent
 	if entityKey == "" {
-		entityKey = p.context.AgentIdentifier()
+		entityKey = p.context.EntityKey()
 	}
 	// This variable means the entity these deltas represent is an agent
-	areAgentDeltas := entityKey == p.context.AgentIdentifier()
+	areAgentDeltas := entityKey == p.context.EntityKey()
 
 	reset := false
 
@@ -252,7 +252,7 @@ func (p *patchSenderIngest) agentEntityIDChanged() bool {
 	entityKey := p.entityInfo.Key.String()
 
 	// Only check for entityID when is the agent sender.
-	if entityKey != p.context.AgentIdentifier() {
+	if entityKey != p.context.EntityKey() {
 		return false
 	}
 

--- a/internal/agent/patch_sender_vortex.go
+++ b/internal/agent/patch_sender_vortex.go
@@ -64,7 +64,7 @@ func newPatchSenderVortex(entityKey, agentKey string, context AgentContext, stor
 		context.Config().License,
 		userAgent,
 		context.Config().PayloadCompressionLevel,
-		context.AgentIdentifier(),
+		context.EntityKey(),
 		agentIDProvide,
 		context.Config().ConnectEnabled,
 		httpClient,
@@ -173,9 +173,9 @@ func (p *patchSenderVortex) sendAllDeltas(allDeltas []inventoryapi.RawDeltaBlock
 	// Empty entity Key belong to the Agent
 	if p.entityKey == "" {
 		areAgentDeltas = true
-		entityKey = p.context.AgentIdentifier()
+		entityKey = p.context.EntityKey()
 	} else {
-		areAgentDeltas = p.entityKey == p.context.AgentIdentifier()
+		areAgentDeltas = p.entityKey == p.context.EntityKey()
 		entityKey = p.entityKey
 	}
 

--- a/internal/agent/plugin_test.go
+++ b/internal/agent/plugin_test.go
@@ -68,7 +68,7 @@ func (c *fakeContext) ActiveEntitiesChannel() chan string {
 	return make(chan string, 100)
 }
 
-func (c *fakeContext) AgentIdentifier() string {
+func (c *fakeContext) EntityKey() string {
 	return ""
 }
 

--- a/internal/plugins/linux/cloud_security_groups.go
+++ b/internal/plugins/linux/cloud_security_groups.go
@@ -104,7 +104,7 @@ func (p *CloudSecurityGroupsPlugin) Run() {
 					csglog.WithError(err).Debug("Reading security groups.")
 					return
 				}
-				p.EmitInventory(dataset, entity.NewFromNameWithoutID(p.Context.AgentIdentifier()))
+				p.EmitInventory(dataset, entity.NewFromNameWithoutID(p.Context.EntityKey()))
 			}
 		}
 	}

--- a/internal/plugins/linux/daemontools.go
+++ b/internal/plugins/linux/daemontools.go
@@ -153,7 +153,7 @@ func (self *DaemontoolsPlugin) Run() {
 			checkTimer = time.NewTicker(self.frequency)
 			services, pidMap, err := getDaemontoolsServiceStatus()
 			if err == nil {
-				self.EmitInventory(services, entity.NewFromNameWithoutID(self.Context.AgentIdentifier()))
+				self.EmitInventory(services, entity.NewFromNameWithoutID(self.Context.EntityKey()))
 				self.Context.CacheServicePids(sysinfo.PROCESS_NAME_SOURCE_DAEMONTOOLS, pidMap)
 			} else {
 				dtlog.WithError(err).Error("getting daemontools status")

--- a/internal/plugins/linux/dpkg.go
+++ b/internal/plugins/linux/dpkg.go
@@ -171,7 +171,7 @@ func (self *DpkgPlugin) Run() {
 				if err != nil {
 					dpkglog.WithError(err).Error("fetching dpkg data")
 				} else {
-					self.EmitInventory(data, entity.NewFromNameWithoutID(self.Context.AgentIdentifier()))
+					self.EmitInventory(data, entity.NewFromNameWithoutID(self.Context.EntityKey()))
 				}
 				counter = 0
 			}

--- a/internal/plugins/linux/facter.go
+++ b/internal/plugins/linux/facter.go
@@ -98,7 +98,7 @@ func (self *FacterPlugin) Run() {
 			time.Sleep(self.frequency)
 			continue
 		}
-		self.EmitInventory(data, entity.NewFromNameWithoutID(self.Context.AgentIdentifier()))
+		self.EmitInventory(data, entity.NewFromNameWithoutID(self.Context.EntityKey()))
 		time.Sleep(self.frequency)
 	}
 }

--- a/internal/plugins/linux/hostinfo.go
+++ b/internal/plugins/linux/hostinfo.go
@@ -219,7 +219,7 @@ func (self *HostinfoPlugin) Data() agent.PluginInventoryDataset {
 func (self *HostinfoPlugin) Run() {
 	self.Context.AddReconnecting(self)
 	data := self.Data()
-	self.EmitInventory(data, entity.NewFromNameWithoutID(self.Context.AgentIdentifier()))
+	self.EmitInventory(data, entity.NewFromNameWithoutID(self.Context.EntityKey()))
 }
 
 // getCpuNum reads the `cpu cores` entry from `cpuInfoFile`, on some

--- a/internal/plugins/linux/kernel_modules.go
+++ b/internal/plugins/linux/kernel_modules.go
@@ -167,7 +167,7 @@ func (self *KernelModulesPlugin) Run() {
 				kmlog.WithError(err).Error("getting kernel module status")
 			} else {
 				if self.needsFlush {
-					self.EmitInventory(self.getKernelModulesDataset(), entity.NewFromNameWithoutID(self.Context.AgentIdentifier()))
+					self.EmitInventory(self.getKernelModulesDataset(), entity.NewFromNameWithoutID(self.Context.EntityKey()))
 					self.needsFlush = false
 				}
 			}

--- a/internal/plugins/linux/rpm.go
+++ b/internal/plugins/linux/rpm.go
@@ -175,7 +175,7 @@ func (p *rpmPlugin) Run() {
 				if err != nil {
 					rpmlog.WithError(err).Error("fetching rpm data")
 				} else {
-					p.EmitInventory(data, entity.NewFromNameWithoutID(p.Context.AgentIdentifier()))
+					p.EmitInventory(data, entity.NewFromNameWithoutID(p.Context.EntityKey()))
 				}
 				counter = 0
 			}

--- a/internal/plugins/linux/selinux.go
+++ b/internal/plugins/linux/selinux.go
@@ -193,7 +193,7 @@ func (self *SELinuxPlugin) Run() {
 				sllog.WithError(err).Error("selinux can't get dataset")
 			}
 
-			entity := entity.NewFromNameWithoutID(self.Context.AgentIdentifier())
+			entity := entity.NewFromNameWithoutID(self.Context.EntityKey())
 			self.Context.SendData(agent.NewPluginOutput(self.Id(), entity, basicData))
 			self.Context.SendData(agent.NewPluginOutput(ids.PluginID{self.ID.Category, fmt.Sprintf("%s-policies", self.ID.Term)}, entity, policyData))
 			if self.enableSemodule {

--- a/internal/plugins/linux/sshd_config.go
+++ b/internal/plugins/linux/sshd_config.go
@@ -118,7 +118,7 @@ func (self *SshdConfigPlugin) Run() {
 		if err != nil {
 			sshdlog.WithError(err).Error("parsing sshd config file")
 		} else {
-			self.EmitInventory(convertSshValuesToPluginData(config), entity.NewFromNameWithoutID(self.Context.AgentIdentifier()))
+			self.EmitInventory(convertSshValuesToPluginData(config), entity.NewFromNameWithoutID(self.Context.EntityKey()))
 		}
 		<-refreshTimer.C
 	}

--- a/internal/plugins/linux/supervisor.go
+++ b/internal/plugins/linux/supervisor.go
@@ -142,7 +142,7 @@ func (self *SupervisorPlugin) Run() {
 			slog.WithError(err).Error("getting supervisord data")
 			continue
 		}
-		self.EmitInventory(data, entity.NewFromNameWithoutID(self.Context.AgentIdentifier()))
+		self.EmitInventory(data, entity.NewFromNameWithoutID(self.Context.EntityKey()))
 		self.Context.CacheServicePids(sysinfo.PROCESS_NAME_SOURCE_SUPERVISOR, pidMap)
 	}
 }

--- a/internal/plugins/linux/sysctl_polling.go
+++ b/internal/plugins/linux/sysctl_polling.go
@@ -143,7 +143,7 @@ func (sp *SysctlPlugin) Run() {
 			if err != nil {
 				sclog.WithError(err).Error("fetching sysctl data")
 			} else {
-				sp.EmitInventory(dataset, entity.NewFromNameWithoutID(sp.Context.AgentIdentifier()))
+				sp.EmitInventory(dataset, entity.NewFromNameWithoutID(sp.Context.EntityKey()))
 			}
 		}
 	}

--- a/internal/plugins/linux/sysctl_subscriber.go
+++ b/internal/plugins/linux/sysctl_subscriber.go
@@ -61,11 +61,11 @@ func (p *SysctlSubscriberPlugin) Run() {
 				if err != nil {
 					sclog.WithError(err).Error("fetching sysctl initial data")
 				} else {
-					p.EmitInventory(initialDataset, entity.NewFromNameWithoutID(p.Context.AgentIdentifier()))
+					p.EmitInventory(initialDataset, entity.NewFromNameWithoutID(p.Context.EntityKey()))
 					initialSubmitOk = true
 				}
 			} else if needsFlush {
-				p.EmitInventory(deltas, entity.NewFromNameWithoutID(p.Context.AgentIdentifier()))
+				p.EmitInventory(deltas, entity.NewFromNameWithoutID(p.Context.EntityKey()))
 				needsFlush = false
 				deltas = agent.PluginInventoryDataset{}
 			}

--- a/internal/plugins/linux/systemd.go
+++ b/internal/plugins/linux/systemd.go
@@ -167,7 +167,7 @@ func (self *SystemdPlugin) Run() {
 					refreshTimer.Stop()
 					refreshTimer = time.NewTicker(self.frequency)
 					self.getSystemdServiceStatus()
-					self.EmitInventory(self.getSystemdDataset(), entity.NewFromNameWithoutID(self.Context.AgentIdentifier()))
+					self.EmitInventory(self.getSystemdDataset(), entity.NewFromNameWithoutID(self.Context.EntityKey()))
 					self.Context.CacheServicePids(sysinfo.PROCESS_NAME_SOURCE_SYSTEMD, self.getSystemdPidMap())
 				}
 			}

--- a/internal/plugins/linux/sysvinit.go
+++ b/internal/plugins/linux/sysvinit.go
@@ -91,7 +91,7 @@ func (self *SysvInitPlugin) Run() {
 			}
 		}
 
-		self.EmitInventory(dataset, entity.NewFromNameWithoutID(self.Context.AgentIdentifier()))
+		self.EmitInventory(dataset, entity.NewFromNameWithoutID(self.Context.EntityKey()))
 		self.Context.CacheServicePids(sysinfo.PROCESS_NAME_SOURCE_SYSVINIT, pidMap)
 	}
 }

--- a/internal/plugins/linux/upstart.go
+++ b/internal/plugins/linux/upstart.go
@@ -145,7 +145,7 @@ func (up *UpstartPlugin) Run() {
 					refreshTimer.Stop()
 					refreshTimer = time.NewTicker(up.frequency)
 					up.getUpstartServiceStatus()
-					up.EmitInventory(up.getUpstartDataset(), entity.NewFromNameWithoutID(up.Context.AgentIdentifier()))
+					up.EmitInventory(up.getUpstartDataset(), entity.NewFromNameWithoutID(up.Context.EntityKey()))
 					up.Context.CacheServicePids(sysinfo.PROCESS_NAME_SOURCE_UPSTART, up.getUpstartPidMap())
 				}
 			}

--- a/internal/plugins/linux/users.go
+++ b/internal/plugins/linux/users.go
@@ -119,7 +119,7 @@ func (self *UsersPlugin) Run() {
 			{
 				refreshTimer.Reset(self.frequency)
 				if needsFlush {
-					self.EmitInventory(self.getUserDetails(), entity.NewFromNameWithoutID(self.Context.AgentIdentifier()))
+					self.EmitInventory(self.getUserDetails(), entity.NewFromNameWithoutID(self.Context.EntityKey()))
 					needsFlush = false
 				}
 			}

--- a/internal/plugins/testing/agent_mock.go
+++ b/internal/plugins/testing/agent_mock.go
@@ -91,7 +91,7 @@ func (self *MockAgent) Config() *config.Config {
 	return self.cfg
 }
 
-func (self *MockAgent) AgentIdentifier() string {
+func (self *MockAgent) EntityKey() string {
 	return ""
 }
 

--- a/internal/plugins/windows/hostinfo.go
+++ b/internal/plugins/windows/hostinfo.go
@@ -84,7 +84,7 @@ func (self *HostinfoPlugin) Data() agent.PluginInventoryDataset {
 func (self *HostinfoPlugin) Run() {
 	self.Context.AddReconnecting(self)
 	data := self.Data()
-	self.EmitInventory(data, entity.NewFromNameWithoutID(self.Context.AgentIdentifier()))
+	self.EmitInventory(data, entity.NewFromNameWithoutID(self.Context.EntityKey()))
 }
 
 func getHostInfo() *host.InfoStat {

--- a/internal/plugins/windows/services.go
+++ b/internal/plugins/windows/services.go
@@ -179,7 +179,7 @@ func (self *ServicesPlugin) Run() {
 		if err != nil {
 			slog.WithError(err).Error("services plugin can't get dataset")
 		}
-		self.EmitInventory(dataset, entity.NewFromNameWithoutID(self.Context.AgentIdentifier()))
+		self.EmitInventory(dataset, entity.NewFromNameWithoutID(self.Context.EntityKey()))
 		<-refreshTimer.C
 	}
 }

--- a/internal/plugins/windows/updates.go
+++ b/internal/plugins/windows/updates.go
@@ -77,7 +77,7 @@ func (self *UpdatesPlugin) Run() {
 		if err != nil {
 			ulog.WithError(err).Error("updates plugin can't get dataset")
 		}
-		self.EmitInventory(dataset, entity.NewFromNameWithoutID(self.Context.AgentIdentifier()))
+		self.EmitInventory(dataset, entity.NewFromNameWithoutID(self.Context.EntityKey()))
 		<-refreshTimer.C
 	}
 }

--- a/pkg/entity/host/host.go
+++ b/pkg/entity/host/host.go
@@ -14,7 +14,7 @@ import (
 // Errors
 var (
 	ErrUndefinedLookupType = errors.New("no known identifier types found in ID lookup table")
-	ErrNoAgentIdentifiers  = errors.New("no agent identifiers available")
+	ErrNoEntityKeys        = errors.New("no agent identifiers available")
 )
 
 // IDLookup contains the identifiers used for resolving the agent entity name and agent key.
@@ -22,7 +22,7 @@ type IDLookup map[string]string
 
 func (i IDLookup) AgentKey() (agentKey string, err error) {
 	if len(i) == 0 {
-		err = ErrNoAgentIdentifiers
+		err = ErrNoEntityKeys
 		return
 	}
 

--- a/pkg/integrations/legacy/runner.go
+++ b/pkg/integrations/legacy/runner.go
@@ -700,7 +700,7 @@ func EmitDataSet(
 ) error {
 	elog := rlog.WithField("action", "EmitDataSet")
 
-	agentIdentifier := ctx.AgentIdentifier()
+	agentIdentifier := ctx.EntityKey()
 
 	idLookup := ctx.IDLookup()
 	entityKey, err := host.ResolveUniqueEntityKey(dataSet.Entity, agentIdentifier, idLookup, entityRewrite, protocolVersion)

--- a/pkg/integrations/legacy/runner_test.go
+++ b/pkg/integrations/legacy/runner_test.go
@@ -425,7 +425,7 @@ func (cc customContext) ActiveEntitiesChannel() chan string {
 	return make(chan string, 100)
 }
 
-func (cc customContext) AgentIdentifier() string {
+func (cc customContext) EntityKey() string {
 	return ""
 }
 
@@ -943,7 +943,7 @@ func (rs *RunnerSuite) TestBadProtocolVersions(c *C) {
 		ForceProtocolV2toV3: false,
 	}
 	ctx.On("Config").Return(cfg)
-	ctx.On("AgentIdentifier").Return("my-agent-id")
+	ctx.On("EntityKey").Return("my-agent-id")
 	ctx.On("HostnameResolver").Return(newFixedHostnameResolver("foo.bar", "short"))
 	ctx.On("IDLookup").Return(newFixedIDLookup())
 
@@ -1555,7 +1555,7 @@ func TestEmitPayloadV2NoDisplayNameNoEntityName(t *testing.T) {
 		ForceProtocolV2toV3: false,
 	}
 	ctx.On("Config").Return(cfg)
-	ctx.On("AgentIdentifier").Return("my-agent-id")
+	ctx.On("EntityKey").Return("my-agent-id")
 	ctx.On("HostnameResolver").Return(newFixedHostnameResolver("foo.bar", "short"))
 	ctx.On("IDLookup").Return(newFixedIDLookup())
 
@@ -1615,7 +1615,7 @@ func TestEmitDataSet_OnAddHostnameDecoratesWithHostname(t *testing.T) {
 	}
 
 	ctx := new(mocks.AgentContext)
-	ctx.On("AgentIdentifier").Return(agentIdentifier)
+	ctx.On("EntityKey").Return(agentIdentifier)
 	ctx.On("HostnameResolver").Return(newFixedHostnameResolver(hn, "short"))
 	ctx.On("IDLookup").Return(newFixedIDLookup())
 
@@ -1666,7 +1666,7 @@ func TestEmitDataSet_EntityNameLocalhostIsNotReplacedWithHostnameV2(t *testing.T
 	}
 
 	ctx := new(mocks.AgentContext)
-	ctx.On("AgentIdentifier").Return(agID)
+	ctx.On("EntityKey").Return(agID)
 	ctx.On("HostnameResolver").Return(newFixedHostnameResolver("foo.bar", "short"))
 	ctx.On("IDLookup").Return(newFixedIDLookup())
 
@@ -1713,7 +1713,7 @@ func TestEmitDataSet_EntityNameLocalhostIsReplacedWithHostnameV3(t *testing.T) {
 	}
 
 	ctx := new(mocks.AgentContext)
-	ctx.On("AgentIdentifier").Return(agID)
+	ctx.On("EntityKey").Return(agID)
 	ctx.On("HostnameResolver").Return(newFixedHostnameResolver("foo.bar", "short"))
 	ctx.On("IDLookup").Return(newFixedIDLookup())
 
@@ -1761,7 +1761,7 @@ func TestEmitDataSet_MetricHostnameIsReplacedIfLocalhostV3(t *testing.T) {
 	}
 
 	ctx := new(mocks.AgentContext)
-	ctx.On("AgentIdentifier").Return(agID)
+	ctx.On("EntityKey").Return(agID)
 	ctx.On("HostnameResolver").Return(newFixedHostnameResolver("foo.bar", "short"))
 	ctx.On("IDLookup").Return(newFixedIDLookup())
 
@@ -1810,7 +1810,7 @@ func TestEmitDataSet_ReportingFieldsAreReplacedIfLocalhostV3(t *testing.T) {
 	}
 
 	ctx := new(mocks.AgentContext)
-	ctx.On("AgentIdentifier").Return(agID)
+	ctx.On("EntityKey").Return(agID)
 	ctx.On("HostnameResolver").Return(newFixedHostnameResolver("foo.bar", "short"))
 	ctx.On("IDLookup").Return(newFixedIDLookup())
 
@@ -1858,7 +1858,7 @@ func TestEmitDataSet_LogsEntityViolationsOncePerEntity(t *testing.T) {
 	}
 
 	ctx := new(mocks.AgentContext)
-	ctx.On("AgentIdentifier").Return(agID)
+	ctx.On("EntityKey").Return(agID)
 	ctx.On("HostnameResolver").Return(newFixedHostnameResolver("foo.bar", "short"))
 	ctx.On("IDLookup").Return(newFixedIDLookup())
 
@@ -1895,7 +1895,7 @@ func TestEmitDataSet_DoNotOverrideExistingMetrics(t *testing.T) {
 	}
 
 	ctx := new(mocks.AgentContext)
-	ctx.On("AgentIdentifier").Return("agent-id")
+	ctx.On("EntityKey").Return("agent-id")
 	ctx.On("HostnameResolver").Return(newFixedHostnameResolver("long", "short"))
 	ctx.On("IDLookup").Return(newFixedIDLookup())
 	em := &fakeEmitter{}
@@ -2106,7 +2106,7 @@ func TestProtocolV2_LocalhostIsNotReplaced(t *testing.T) {
 
 func TestResolveEntityKeyWithAgent(t *testing.T) {
 	ctx := new(mocks.AgentContext)
-	ctx.On("AgentIdentifier").Return("agent_id")
+	ctx.On("EntityKey").Return("agent_id")
 	ctx.On("IDLookup").Return(newFixedIDLookup())
 
 	e := entity.Fields{}
@@ -2117,7 +2117,7 @@ func TestResolveEntityKeyWithAgent(t *testing.T) {
 
 func TestResolveEntityWithReplacement(t *testing.T) {
 	ctx := new(mocks.AgentContext)
-	ctx.On("AgentIdentifier").Return("agent_id")
+	ctx.On("EntityKey").Return("agent_id")
 	ctx.On("IDLookup").Return(newFixedIDLookup())
 
 	e := entity.Fields{
@@ -2131,7 +2131,7 @@ func TestResolveEntityWithReplacement(t *testing.T) {
 
 func TestResolveEntityWithProtocolV2(t *testing.T) {
 	ctx := new(mocks.AgentContext)
-	ctx.On("AgentIdentifier").Return("agent_id")
+	ctx.On("EntityKey").Return("agent_id")
 	ctx.On("IDLookup").Return(newFixedIDLookup())
 
 	e := entity.Fields{
@@ -2181,7 +2181,7 @@ func BenchmarkEmitDataSet_MetricHostnameIsReplacedIfLocalhost(b *testing.B) {
 			}
 
 			ctx := new(mocks.AgentContext)
-			ctx.On("AgentIdentifier").Return(agID)
+			ctx.On("EntityKey").Return(agID)
 			ctx.On("IDLookup").Return(newFixedIDLookup())
 			ctx.On("HostnameResolver").Return(&stubResolver{host: t})
 

--- a/pkg/integrations/v4/dm/emitter.go
+++ b/pkg/integrations/v4/dm/emitter.go
@@ -120,6 +120,11 @@ func (e *emitter) runFwReqConsumer(ctx context.Context) {
 
 		case req := <-e.reqsQueue:
 			for _, ds := range req.Data.DataSets {
+				// local entity
+				if ds.Entity.Name == "" {
+					ds.Entity.Name = e.agentContext.EntityKey()
+				}
+
 				// TODO use host.ResolveUniqueEntityKey instead!
 				eKey = entity.Key(ds.Entity.Name)
 				eID, found := e.idCache.Get(eKey)

--- a/pkg/integrations/v4/dm/emitter_bench_test.go
+++ b/pkg/integrations/v4/dm/emitter_bench_test.go
@@ -198,7 +198,7 @@ package dm
 //	panic("implement me")
 //}
 //
-//func (n noopAgentContext) AgentIdentifier() string {
+//func (n noopAgentContext) EntityKey() string {
 //	panic("implement me")
 //}
 //

--- a/pkg/integrations/v4/emitter/emitter_test.go
+++ b/pkg/integrations/v4/emitter/emitter_test.go
@@ -577,7 +577,7 @@ func mockAgent() *mocks.AgentContext {
 	}
 
 	ma := &mocks.AgentContext{}
-	ma.On("AgentIdentifier").Return("bob")
+	ma.On("EntityKey").Return("bob")
 	ma.On("IDLookup").Return(aID)
 	ma.On("SendData", mock.AnythingOfType("agent.PluginOutput")).Once()
 	ma.SendDataWg.Add(1)

--- a/pkg/metrics/process/sampler_linux_test.go
+++ b/pkg/metrics/process/sampler_linux_test.go
@@ -139,7 +139,7 @@ func (*dummyAgentContext) ActiveEntitiesChannel() chan string {
 
 func (*dummyAgentContext) AddReconnecting(agent.Plugin) {}
 
-func (*dummyAgentContext) AgentIdentifier() string {
+func (*dummyAgentContext) EntityKey() string {
 	return ""
 }
 

--- a/pkg/plugins/agent_config.go
+++ b/pkg/plugins/agent_config.go
@@ -63,5 +63,5 @@ func (ac *AgentConfigPlugin) Run() {
 
 	helpers.LogStructureDetails(aclog, flat, "config", "raw", logrus.Fields{})
 
-	ac.EmitInventory(agent.PluginInventoryDataset{ConfigAttrs(flat)}, entity.NewFromNameWithoutID(ac.Context.AgentIdentifier()))
+	ac.EmitInventory(agent.PluginInventoryDataset{ConfigAttrs(flat)}, entity.NewFromNameWithoutID(ac.Context.EntityKey()))
 }

--- a/pkg/plugins/agent_config_test.go
+++ b/pkg/plugins/agent_config_test.go
@@ -55,7 +55,7 @@ func TestConfig(t *testing.T) {
 
 	ctx := new(mocks.AgentContext)
 	ctx.On("AddReconnecting", mock.Anything).Return()
-	ctx.On("AgentIdentifier").Return(agentId)
+	ctx.On("EntityKey").Return(agentId)
 	ctx.On("Config").Return(config.NewConfig())
 	ch := make(chan mock.Arguments)
 	ctx.On("SendData", mock.Anything).Run(func(args mock.Arguments) {

--- a/pkg/plugins/custom_attrs.go
+++ b/pkg/plugins/custom_attrs.go
@@ -35,7 +35,7 @@ func (self *CustomAttrsPlugin) Run() {
 	self.Context.AddReconnecting(self)
 
 	data := agent.PluginInventoryDataset{CustomAttrs(self.customAttributes)}
-	entityKey := self.Context.AgentIdentifier()
+	entityKey := self.Context.EntityKey()
 
 	trace.Attr("run, entity: %s, data: %+v", entityKey, self.customAttributes)
 

--- a/pkg/plugins/files_config.go
+++ b/pkg/plugins/files_config.go
@@ -278,7 +278,7 @@ func (self *ConfigFilePlugin) Run() {
 				if err != nil {
 					self.logger.WithError(err).Error("Fetching external data set")
 				}
-				self.EmitInventory(dataset, entity.NewFromNameWithoutID(self.Context.AgentIdentifier()))
+				self.EmitInventory(dataset, entity.NewFromNameWithoutID(self.Context.EntityKey()))
 				flushNeeded = false
 
 				// re-add any files that may have been renamed in the last flush interval

--- a/pkg/plugins/host_aliases.go
+++ b/pkg/plugins/host_aliases.go
@@ -124,7 +124,7 @@ func (self *HostAliasesPlugin) Run() {
 					continue
 				}
 				self.logger.WithField("dataset", dataset).Debug("Completed harvest, emitting.")
-				self.EmitInventory(dataset, entity.NewFromNameWithoutID(self.Context.AgentIdentifier()))
+				self.EmitInventory(dataset, entity.NewFromNameWithoutID(self.Context.EntityKey()))
 				self.logger.Debug("Completed emitting.")
 			}
 		}

--- a/pkg/plugins/http_server_test.go
+++ b/pkg/plugins/http_server_test.go
@@ -41,7 +41,7 @@ func TestHTTPServerPlugin(t *testing.T) {
 	})
 
 	ctx.On("HostnameResolver").Return(testhelpers.NewFakeHostnameResolver("something.com", "sc", nil))
-	ctx.On("AgentIdentifier").Return("test-agent")
+	ctx.On("EntityKey").Return("test-agent")
 	ctx.On("IDLookup").Return(host.IDLookup{"test-agent": "test-agent-id"})
 
 	// Given an HTTP Server Plugin

--- a/pkg/plugins/k8s_integrations.go
+++ b/pkg/plugins/k8s_integrations.go
@@ -46,7 +46,7 @@ func NewK8sIntegrationsPlugin(ctx agent.AgentContext, pluginRetrieveFn pluginRet
 
 func (kip *K8sIntegrationsPlugin) Run() {
 	kip.Context.AddReconnecting(kip)
-	entityKey := kip.Context.AgentIdentifier()
+	entityKey := kip.Context.EntityKey()
 
 	refreshTimer := time.NewTicker(kip.frequency)
 	for range refreshTimer.C {

--- a/pkg/plugins/k8s_integrations_test.go
+++ b/pkg/plugins/k8s_integrations_test.go
@@ -47,7 +47,7 @@ func TestK8sIntegrationsPlugin(t *testing.T) {
 		K8sIntegrationSamplesIntervalSec: 1,
 	})
 
-	ctx.On("AgentIdentifier").Return("my-agent")
+	ctx.On("EntityKey").Return("my-agent")
 	ctx.On(
 		"SendEvent",
 		mock.AnythingOfType("agent.mapEvent"), entity.Key("my-agent"),

--- a/pkg/plugins/network_interface.go
+++ b/pkg/plugins/network_interface.go
@@ -104,7 +104,7 @@ func (self *NetworkInterfacePlugin) Run() {
 			if err != nil {
 				slog.WithError(err).WithPlugin(self.Id().String()).Error("fetching network interface data")
 			}
-			self.EmitInventory(dataset, entity.NewFromNameWithoutID(self.Context.AgentIdentifier()))
+			self.EmitInventory(dataset, entity.NewFromNameWithoutID(self.Context.EntityKey()))
 		}
 	}
 }

--- a/pkg/plugins/network_interface_test.go
+++ b/pkg/plugins/network_interface_test.go
@@ -154,7 +154,7 @@ func TestNetworkPlugin(t *testing.T) {
 
 	ctx := &mocks.AgentContext{}
 	ctx.On("Config").Return(&config.Config{})
-	ctx.On("AgentIdentifier").Return(agentId)
+	ctx.On("EntityKey").Return(agentId)
 	ch := make(chan mock.Arguments)
 	ctx.On("SendData", mock.Anything).Run(func(args mock.Arguments) {
 		ch <- args

--- a/pkg/plugins/proxy/proxy_config.go
+++ b/pkg/plugins/proxy/proxy_config.go
@@ -136,5 +136,5 @@ func pathEntry(path string) *fileEntry {
 func (pcp *configPlugin) Run() {
 	pcp.Context.AddReconnecting(pcp)
 
-	pcp.EmitInventory(pcp.config, entity.NewFromNameWithoutID(pcp.Context.AgentIdentifier()))
+	pcp.EmitInventory(pcp.config, entity.NewFromNameWithoutID(pcp.Context.EntityKey()))
 }

--- a/test/core/core.go
+++ b/test/core/core.go
@@ -42,7 +42,7 @@ func (cp *dummyPlugin) Run() {
 			dataset := agent.PluginInventoryDataset{
 				&valueEntry{Id: "dummy", Value: cp.value},
 			}
-			cp.EmitInventory(dataset, entity.NewFromNameWithoutID(cp.Context.AgentIdentifier()))
+			cp.EmitInventory(dataset, entity.NewFromNameWithoutID(cp.Context.EntityKey()))
 		}
 	}
 }

--- a/test/harvest/facter_test.go
+++ b/test/harvest/facter_test.go
@@ -34,7 +34,7 @@ func TestFacter(t *testing.T) {
 		FacterIntervalSec: 1,
 		FacterHomeDir:     usr.HomeDir,
 	})
-	ctx.On("AgentIdentifier").Return(agentIdentifier)
+	ctx.On("EntityKey").Return(agentIdentifier)
 	ch := make(chan agent.PluginOutput)
 	ctx.On("SendData", mock.Anything).Return().Run(func(args mock.Arguments) {
 		ch <- args[0].(agent.PluginOutput)

--- a/test/harvest/hostinfo_test.go
+++ b/test/harvest/hostinfo_test.go
@@ -63,7 +63,7 @@ func TestHostInfo(t *testing.T) {
 		RunMode:              config.ModePrivileged, // Used only to read the productUUID
 	})
 	ctx.On("Version").Return(agentVersion)
-	ctx.On("AgentIdentifier").Return(agentIdentifier)
+	ctx.On("EntityKey").Return(agentIdentifier)
 	// Cannot assert the plugin payload here because `UpSince` is gotten from
 	// running the `uptime` command.
 	ctx.On("SendData", mock.Anything).Return(nil)


### PR DESCRIPTION
This fixes: https://github.com/newrelic/infrastructure-agent/issues/166

- Fix https://github.com/newrelic/infrastructure-agent/pull/175/files#diff-40e4625b8b3ab308cd3e3f69351498bd1d68f4babb2c15a776599a602cd595c6R123-R126
- It also renames AgentContext.AgentIdentifier with EntityKey to become more explicit.
