### PR TITLE
ci: Updated path to build scripts in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Standard variables defining directories and other useful stuff.
 PROJECT_WORKSPACE	?= $(CURDIR)
+INCLUDE_BUILD_DIR	?= $(PROJECT_WORKSPACE)/build
 PROJECT_NAME		:= newrelic-infra
 TARGET_DIR			= $(PROJECT_WORKSPACE)/target
 TARGET_DIR_CENTOS5	= $(TARGET_DIR)/el_5
@@ -12,9 +13,9 @@ GO_BIN				?= go
 GO_BIN_1_9			?= go1.9.4
 
 # Scripts for building the Agent
-include $(CURDIR)/build/infra_build.mk
+include $(INCLUDE_BUILD_DIR)/infra_build.mk
 
 # Scripts for getting On Host Integrations
 # https://docs.newrelic.com/docs/integrations/host-integrations/getting-started/introduction-host-integrations
-include $(CURDIR)/build/embed_ohis.mk
+include $(INCLUDE_BUILD_DIR)/embed_ohis.mk
 

--- a/build/embed_ohis.mk
+++ b/build/embed_ohis.mk
@@ -1,4 +1,4 @@
-NRI_INTEGRATIONS_FILE	?= $(CURDIR)/build/nri-integrations
+NRI_INTEGRATIONS_FILE	?= $(INCLUDE_BUILD_DIR)/nri-integrations
 get-nri-version			= $(shell awk -F, '/^$(1),/ {print $$2}' ${NRI_INTEGRATIONS_FILE})
 
 NRI_PKG_DIR				?= $(PKG_DIR)


### PR DESCRIPTION
This is needed because of an issue where old build scripts would have the wrong path when importing `nri-integrations` file. Due to this bug it meant that when we updated the OHI version in `nri-integrations` it wasn't getting picked up correctly.