### PR TITLE
feat: DM submission split request by max amount of entities

### DIFF
--- a/cmd/newrelic-infra/newrelic-infra.go
+++ b/cmd/newrelic-infra/newrelic-infra.go
@@ -306,7 +306,7 @@ func initializeAgentAndRun(c *config.Config, logFwCfg config.LogForward) error {
 		os.Exit(1)
 	}
 
-	metricsSenderConfig := dm.NewConfig(c.MetricURL, c.License, time.Duration(c.DMSubmissionPeriod)*time.Second)
+	metricsSenderConfig := dm.NewConfig(c.MetricURL, c.License, time.Duration(c.DMSubmissionPeriod)*time.Second, c.MaxMetricBatchEntitiesCount)
 	dmSender, err := dm.NewDMSender(metricsSenderConfig, transport, agt.Context.IdContext().AgentIdentity)
 	if err != nil {
 		return err

--- a/pkg/backend/telemetryapi/config.go
+++ b/pkg/backend/telemetryapi/config.go
@@ -12,9 +12,12 @@ import (
 	"time"
 )
 
-// DefaultMaxConns is the default value of the Config's
-// MaxConns.
-const DefaultMaxConns = 2
+const (
+	// DefaultMaxConns is the default value of the Config's
+	// MaxConns.
+	DefaultMaxConns              = 2
+	DefaultMaxEntitiesPerRequest = 100
+)
 
 // Config customizes the behavior of a Harvester.
 type Config struct {
@@ -59,6 +62,9 @@ type Config struct {
 	MaxConns int
 	// Context is the Context to use for making requests
 	Context context.Context
+	// MaxEntitiesPerBatch limits the total number of entities per request when submitting metric
+	// If zero, DefaultMaxEntitiesPerRequest is used (100 entities).
+	MaxEntitiesPerBatch int
 }
 
 // ConfigAPIKey sets the Config's APIKey which is required and refers to your
@@ -82,6 +88,14 @@ func ConfigContext(ctx context.Context) func(*Config) {
 func ConfigCommonAttributes(attributes map[string]interface{}) func(*Config) {
 	return func(cfg *Config) {
 		cfg.CommonAttributes = attributes
+	}
+}
+
+// ConfigEntitiesPerBatch sets the Config's MaxEntitiesPerBatch field which controls the
+// amount of entities that is submitted to New Relic per request.
+func ConfigEntitiesPerBatch(quantity int) func(*Config) {
+	return func(cfg *Config) {
+		cfg.MaxEntitiesPerBatch = quantity
 	}
 }
 

--- a/pkg/backend/telemetryapi/metrics_batch_test.go
+++ b/pkg/backend/telemetryapi/metrics_batch_test.go
@@ -129,7 +129,13 @@ func TestMetricBatch(t *testing.T) {
 		metricBatches = append(metricBatches, metrics)
 	}
 
-	requests, err := newBatchRequest(context.Background(), metricBatches, "my-api-key", defaultMetricURL, "userAgent")
+	requests, err := newBatchRequest(context.Background(), config{
+		metricBatches,
+		"my-api-key",
+		defaultMetricURL,
+		"userAgent",
+		2,
+	})
 	require.NoError(t, err)
 	require.Len(t, requests, 1)
 	assert.Equal(t, "Identity-0,Identity-1", requests[0].Request.Header.Get("X-NRI-Entity-Ids"))

--- a/pkg/backend/telemetryapi/request.go
+++ b/pkg/backend/telemetryapi/request.go
@@ -47,7 +47,7 @@ func newBatchRequest(ctx context.Context, metricsBatch []metricBatch, apiKey str
 		return buildRequests(ctx, metricsBatch, apiKey, url, userAgent)
 	}
 
-	metrics := metricsBatch[:min(len(metricsBatch), maxEntitiesByRequest)]
+	metrics := metricsBatch[:maxEntitiesByRequest]
 	req, err := buildRequests(ctx, metrics, apiKey, url, userAgent)
 	reqs = append(reqs, req...)
 
@@ -84,13 +84,6 @@ func buildRequests(ctx context.Context, metricsBatch []metricBatch, apiKey strin
 	logger.WithField("json", jsonPayload).Debug("Request created")
 	req.Request.Header.Add("X-NRI-Entity-Ids", entityIds)
 	return []request{req}, err
-}
-
-func min(a, b int) int {
-	if a <= b {
-		return a
-	}
-	return b
 }
 
 func requestNeedsSplit(r request) bool {

--- a/pkg/backend/telemetryapi/request_test.go
+++ b/pkg/backend/telemetryapi/request_test.go
@@ -555,12 +555,17 @@ func Test_newBatchRequest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			maxEntitiesByRequest = 2
 			expectedAPIKey := "apiKey_" + tt.name
 			expectedURL := "http://url/" + tt.name
 			expectedUserAgent := "userAgent/" + tt.name
 			expectedContext := context.Background()
-			gotReqs, err := newBatchRequest(expectedContext, tt.args.metrics, expectedAPIKey, expectedURL, expectedUserAgent)
+			gotReqs, err := newBatchRequest(expectedContext, config{
+				data:        tt.args.metrics,
+				apiKey:      expectedAPIKey,
+				url:         expectedURL,
+				userAgent:   expectedUserAgent,
+				maxEntities: 2,
+			})
 			if !tt.wantErr {
 				require.NoError(t, err)
 			}

--- a/pkg/backend/telemetryapi/request_test.go
+++ b/pkg/backend/telemetryapi/request_test.go
@@ -187,9 +187,330 @@ func Test_newBatchRequest(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "split-req-by-nr-of-entities",
+			args: args{
+				metrics: []metricBatch{
+					{
+						Identity:       "my-identity-one",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Count{
+								Name:      "my_count",
+								Value:     10,
+								Timestamp: now,
+								Interval:  101,
+							},
+						},
+					},
+					{
+						Identity:       "my-identity-two",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Summary{
+								Name:      "my_summary",
+								Count:     1,
+								Sum:       10,
+								Timestamp: now,
+								Interval:  101,
+							},
+						},
+					},
+					{
+						Identity:       "my-identity-three",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Gauge{
+								Name:      "my_gauge",
+								Value:     10,
+								Timestamp: now,
+							},
+						},
+					},
+				},
+			},
+			wantReqs: []testRequest{
+				{xNRIEntityIdsHeader: "my-identity-one,my-identity-two"},
+				{xNRIEntityIdsHeader: "my-identity-three"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "split-high-nr-of-entities",
+			args: args{
+				metrics: []metricBatch{
+					{
+						Identity:       "my-identity-one",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Count{
+								Name:      "my_count",
+								Value:     10,
+								Timestamp: now,
+								Interval:  101,
+							},
+						},
+					},
+					{
+						Identity:       "my-identity-two",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Summary{
+								Name:      "my_summary",
+								Count:     1,
+								Sum:       10,
+								Timestamp: now,
+								Interval:  101,
+							},
+						},
+					},
+					{
+						Identity:       "my-identity-three",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Gauge{
+								Name:      "my_gauge",
+								Value:     10,
+								Timestamp: now,
+							},
+						},
+					}, {
+						Identity:       "my-identity-four",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Count{
+								Name:      "my_count",
+								Value:     10,
+								Timestamp: now,
+								Interval:  101,
+							},
+						},
+					},
+					{
+						Identity:       "my-identity-five",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Summary{
+								Name:      "my_summary",
+								Count:     1,
+								Sum:       10,
+								Timestamp: now,
+								Interval:  101,
+							},
+						},
+					},
+					{
+						Identity:       "my-identity-six",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Gauge{
+								Name:      "my_gauge",
+								Value:     10,
+								Timestamp: now,
+							},
+						},
+					}, {
+						Identity:       "my-identity-seven",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Count{
+								Name:      "my_count",
+								Value:     10,
+								Timestamp: now,
+								Interval:  101,
+							},
+						},
+					},
+					{
+						Identity:       "my-identity-eighth",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Summary{
+								Name:      "my_summary",
+								Count:     1,
+								Sum:       10,
+								Timestamp: now,
+								Interval:  101,
+							},
+						},
+					},
+					{
+						Identity:       "my-identity-nine",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Gauge{
+								Name:      "my_gauge",
+								Value:     10,
+								Timestamp: now,
+							},
+						},
+					}, {
+						Identity:       "my-identity-ten",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Count{
+								Name:      "my_count",
+								Value:     10,
+								Timestamp: now,
+								Interval:  101,
+							},
+						},
+					},
+					{
+						Identity:       "my-identity-eleven",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Summary{
+								Name:      "my_summary",
+								Count:     1,
+								Sum:       10,
+								Timestamp: now,
+								Interval:  101,
+							},
+						},
+					},
+					{
+						Identity:       "my-identity-twelve",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Gauge{
+								Name:      "my_gauge",
+								Value:     10,
+								Timestamp: now,
+							},
+						},
+					}, {
+						Identity:       "my-identity-thirteen",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Count{
+								Name:      "my_count",
+								Value:     10,
+								Timestamp: now,
+								Interval:  101,
+							},
+						},
+					},
+					{
+						Identity:       "my-identity-fourteen",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Summary{
+								Name:      "my_summary",
+								Count:     1,
+								Sum:       10,
+								Timestamp: now,
+								Interval:  101,
+							},
+						},
+					},
+					{
+						Identity:       "my-identity-fifteen",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Gauge{
+								Name:      "my_gauge",
+								Value:     10,
+								Timestamp: now,
+							},
+						},
+					}, {
+						Identity:       "my-identity-sixteen",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Count{
+								Name:      "my_count",
+								Value:     10,
+								Timestamp: now,
+								Interval:  101,
+							},
+						},
+					},
+					{
+						Identity:       "my-identity-seventeen",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Summary{
+								Name:      "my_summary",
+								Count:     1,
+								Sum:       10,
+								Timestamp: now,
+								Interval:  101,
+							},
+						},
+					},
+					{
+						Identity:       "my-identity-eighteen",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Gauge{
+								Name:      "my_gauge",
+								Value:     10,
+								Timestamp: now,
+							},
+						},
+					},
+				},
+			},
+			wantReqs: []testRequest{
+				{xNRIEntityIdsHeader: "my-identity-one,my-identity-two"},
+				{xNRIEntityIdsHeader: "my-identity-three,my-identity-four"},
+				{xNRIEntityIdsHeader: "my-identity-five,my-identity-six"},
+				{xNRIEntityIdsHeader: "my-identity-seven,my-identity-eighth"},
+				{xNRIEntityIdsHeader: "my-identity-nine,my-identity-ten"},
+				{xNRIEntityIdsHeader: "my-identity-eleven,my-identity-twelve"},
+				{xNRIEntityIdsHeader: "my-identity-thirteen,my-identity-fourteen"},
+				{xNRIEntityIdsHeader: "my-identity-fifteen,my-identity-sixteen"},
+				{xNRIEntityIdsHeader: "my-identity-seventeen,my-identity-eighteen"},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			maxEntitiesByRequest = 2
 			expectedAPIKey := "apiKey_" + tt.name
 			expectedURL := "http://url/" + tt.name
 			expectedUserAgent := "userAgent/" + tt.name

--- a/pkg/backend/telemetryapi/request_test.go
+++ b/pkg/backend/telemetryapi/request_test.go
@@ -286,7 +286,8 @@ func Test_newBatchRequest(t *testing.T) {
 								Timestamp: now,
 							},
 						},
-					}, {
+					},
+					{
 						Identity:       "my-identity-four",
 						Timestamp:      now,
 						Interval:       101,
@@ -327,7 +328,8 @@ func Test_newBatchRequest(t *testing.T) {
 								Timestamp: now,
 							},
 						},
-					}, {
+					},
+					{
 						Identity:       "my-identity-seven",
 						Timestamp:      now,
 						Interval:       101,
@@ -368,7 +370,8 @@ func Test_newBatchRequest(t *testing.T) {
 								Timestamp: now,
 							},
 						},
-					}, {
+					},
+					{
 						Identity:       "my-identity-ten",
 						Timestamp:      now,
 						Interval:       101,
@@ -409,7 +412,8 @@ func Test_newBatchRequest(t *testing.T) {
 								Timestamp: now,
 							},
 						},
-					}, {
+					},
+					{
 						Identity:       "my-identity-thirteen",
 						Timestamp:      now,
 						Interval:       101,
@@ -450,7 +454,8 @@ func Test_newBatchRequest(t *testing.T) {
 								Timestamp: now,
 							},
 						},
-					}, {
+					},
+					{
 						Identity:       "my-identity-sixteen",
 						Timestamp:      now,
 						Interval:       101,
@@ -504,6 +509,46 @@ func Test_newBatchRequest(t *testing.T) {
 				{xNRIEntityIdsHeader: "my-identity-thirteen,my-identity-fourteen"},
 				{xNRIEntityIdsHeader: "my-identity-fifteen,my-identity-sixteen"},
 				{xNRIEntityIdsHeader: "my-identity-seventeen,my-identity-eighteen"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "set-header-by-unique-entity-id",
+			args: args{
+				metrics: []metricBatch{
+					{
+						Identity:       "my-identity-one",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Count{
+								Name:      "my_count",
+								Value:     10,
+								Timestamp: now,
+								Interval:  101,
+							},
+						},
+					},
+					{
+						Identity:       "my-identity-one",
+						Timestamp:      now,
+						Interval:       101,
+						AttributesJSON: json.RawMessage(`12345678901234567890`),
+						Metrics: []Metric{
+							Summary{
+								Name:      "my_summary",
+								Count:     1,
+								Sum:       10,
+								Timestamp: now,
+								Interval:  101,
+							},
+						},
+					},
+				},
+			},
+			wantReqs: []testRequest{
+				{xNRIEntityIdsHeader: "my-identity-one"},
 			},
 			wantErr: false,
 		},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -856,6 +856,11 @@ type Config struct {
 	// Public: No
 	MaxMetricsBatchSizeBytes int `yaml:"max_metrics_batch_size_bytes" envconfig:"max_metrics_batch_size_bytes" public:"false"`
 
+	// MaxMetricBatchEntitiesCount Defined a max amount of entities to be submitted in a single metric-ingest request. Used to avoid reach max size in req Header.
+	// Default: 800
+	// Public: No
+	MaxMetricBatchEntitiesCount int `yaml:"max_metrics_batch_entities_count" envconfig:"max_metrics_batch_entities_count" public:"false"`
+
 	// ConnectEnabled It enables or disables the connect for the agent ID resolution given the agent fingerprint.
 	// If the config option is enabled it also reconnects to update the fingerprint with the given agent ID.
 	// In case this config is enabled then it adds the resolved agent ID in the header as X-NRI-Agent-Entity-Id.
@@ -1262,6 +1267,7 @@ func NewConfig() *Config {
 		DisableInventorySplit:       defaultDisableInventorySplit,
 		MaxInventorySize:            defaultMaxInventorySize,
 		MaxMetricsBatchSizeBytes:    DefaultMaxMetricsBatchSizeBytes,
+		MaxMetricBatchEntitiesCount: DefaultMaxMetricBatchEntitiesCount,
 		StartupConnectionRetries:    defaultStartupConnectionRetries,
 		DisableZeroRSSFilter:        defaultDisableZeroRSSFilter,
 		DisableWinSharedWMI:         defaultDisableWinSharedWMI,
@@ -1646,6 +1652,10 @@ func NormalizeConfig(cfg *Config, cfgMetadata config_loader.YAMLMetadata) (err e
 
 	if cfg.MaxMetricsBatchSizeBytes > DefaultMaxMetricsBatchSizeBytes || cfg.MaxMetricsBatchSizeBytes <= 0 {
 		cfg.MaxMetricsBatchSizeBytes = DefaultMaxMetricsBatchSizeBytes
+	}
+
+	if cfg.MaxMetricBatchEntitiesCount > DefaultMaxMetricBatchEntitiesCount || cfg.MaxMetricBatchEntitiesCount <= 0 {
+		cfg.MaxMetricBatchEntitiesCount = DefaultMaxMetricBatchEntitiesCount
 	}
 
 	// Avoid clients de-facto disabling inventory splitting when we remove the disable_inventory_split function

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -857,7 +857,7 @@ type Config struct {
 	MaxMetricsBatchSizeBytes int `yaml:"max_metrics_batch_size_bytes" envconfig:"max_metrics_batch_size_bytes" public:"false"`
 
 	// MaxMetricBatchEntitiesCount Defined a max amount of entities to be submitted in a single metric-ingest request. Used to avoid reach max size in req Header.
-	// Default: 800
+	// Default: 300
 	// Public: No
 	MaxMetricBatchEntitiesCount int `yaml:"max_metrics_batch_entities_count" envconfig:"max_metrics_batch_entities_count" public:"false"`
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -310,6 +310,7 @@ agent_dir: /my/overriden/agent/dir
 	c.Assert(cfg.DisableInventorySplit, Equals, defaultDisableInventorySplit)
 	c.Assert(cfg.MaxProcs, Equals, defaultMaxProcs)
 	c.Assert(cfg.IgnoreSystemProxy, Equals, false)
+	c.Assert(cfg.MaxMetricBatchEntitiesCount, Equals, 100)
 
 	var expectedMetricEndpoint = defaultMetricsIngestEndpoint
 	if cfg.ConnectEnabled {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -310,7 +310,7 @@ agent_dir: /my/overriden/agent/dir
 	c.Assert(cfg.DisableInventorySplit, Equals, defaultDisableInventorySplit)
 	c.Assert(cfg.MaxProcs, Equals, defaultMaxProcs)
 	c.Assert(cfg.IgnoreSystemProxy, Equals, false)
-	c.Assert(cfg.MaxMetricBatchEntitiesCount, Equals, 100)
+	c.Assert(cfg.MaxMetricBatchEntitiesCount, Equals, 300)
 
 	var expectedMetricEndpoint = defaultMetricsIngestEndpoint
 	if cfg.ConnectEnabled {

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -36,6 +36,7 @@ var (
 	DefaultHeartBeatFrequencySecs      = 60
 	DefaultDMPeriodSecs                = 5           // default telemetry SDK value
 	DefaultMaxMetricsBatchSizeBytes    = 1000 * 1000 // Size limit from Vortex collector service (1MB)
+	DefaultMaxMetricBatchEntitiesCount = 800         // Amount limit from Vortex collector service header (16k ~ 800 entities)
 	DefaultMetricsNFSSampleRate        = 20
 	DefaultOfflineTimeToReset          = "24h"
 	DefaultStorageSamplerRateSecs      = 20

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -36,7 +36,7 @@ var (
 	DefaultHeartBeatFrequencySecs      = 60
 	DefaultDMPeriodSecs                = 5           // default telemetry SDK value
 	DefaultMaxMetricsBatchSizeBytes    = 1000 * 1000 // Size limit from Vortex collector service (1MB)
-	DefaultMaxMetricBatchEntitiesCount = 800         // Amount limit from Vortex collector service header (16k ~ 800 entities)
+	DefaultMaxMetricBatchEntitiesCount = 300         // Amount limit from Vortex collector service header (8k ~ 300 entities)
 	DefaultMetricsNFSSampleRate        = 20
 	DefaultOfflineTimeToReset          = "24h"
 	DefaultStorageSamplerRateSecs      = 20

--- a/pkg/integrations/v4/dm/sender.go
+++ b/pkg/integrations/v4/dm/sender.go
@@ -26,13 +26,15 @@ type MetricsSenderConfig struct {
 	LicenseKey       string
 	MetricApiURL     string
 	SubmissionPeriod time.Duration
+	MaxEntities      int
 }
 
-func NewConfig(baseURL string, licenseKey string, submissionPeriod time.Duration) MetricsSenderConfig {
+func NewConfig(baseURL string, licenseKey string, submissionPeriod time.Duration, maxEntities int) MetricsSenderConfig {
 	return MetricsSenderConfig{
 		LicenseKey:       licenseKey,
 		MetricApiURL:     fmt.Sprintf("%s/metric/v1/infra", baseURL),
 		SubmissionPeriod: submissionPeriod,
+		MaxEntities:      maxEntities,
 	}
 }
 

--- a/pkg/integrations/v4/dm/sender_test.go
+++ b/pkg/integrations/v4/dm/sender_test.go
@@ -25,13 +25,13 @@ import (
 func Test_sender_Configuration_endpointURL(t *testing.T) {
 	prodUrl := "https://infra-api.newrelic.com/metric/v1/infra"
 
-	c := NewConfig("https://infra-api.newrelic.com", "licenseKey", time.Millisecond)
+	c := NewConfig("https://infra-api.newrelic.com", "licenseKey", time.Millisecond, 0)
 
 	assert.Equal(t, prodUrl, c.MetricApiURL)
 
 	stgUrl := "https://staging-metric-api.newrelic.com/metric/v1/infra"
 
-	c = NewConfig("https://staging-metric-api.newrelic.com", "licenseKey", time.Millisecond)
+	c = NewConfig("https://staging-metric-api.newrelic.com", "licenseKey", time.Millisecond, 0)
 
 	assert.Equal(t, stgUrl, c.MetricApiURL)
 }

--- a/pkg/integrations/v4/dm/telemetry.go
+++ b/pkg/integrations/v4/dm/telemetry.go
@@ -54,6 +54,7 @@ func newTelemetryHarverster(conf MetricsSenderConfig, transport http.RoundTrippe
 		telemetryHarvesterWithTransport(transport, conf.LicenseKey, idProvide),
 		telemetryHarvesterWithMetricApiUrl(conf.MetricApiURL),
 		telemetry.ConfigHarvestPeriod(conf.SubmissionPeriod),
+		telemetry.ConfigEntitiesPerBatch(conf.MaxEntities),
 	)
 }
 


### PR DESCRIPTION
Embedded telemetry API now split DM submission by number of entities following requested driven contract limitations.

A new internal configuration is added with a default value of `300` entities per batch request sent to New Relic. That will cover almost all maximum on http header values. [Ref](https://stackoverflow.com/questions/686217/maximum-on-http-header-values/8623061#8623061)

For more informations on the limits see the [docs](https://docs.newrelic.com/docs/telemetry-data-platform/get-data/apis/metric-api-limits-restricted-attributes).


Resolve #123 