### PR TITLE
fix: Samples from Docker process now correctly filtered as host processes

### DIFF
--- a/pkg/metrics/process/sampler_linux.go
+++ b/pkg/metrics/process/sampler_linux.go
@@ -90,7 +90,6 @@ func (ps *processSampler) Sample() (results sample.EventBatch, err error) {
 
 	var dockerDecorator metrics.ProcessDecorator = nil
 	if ps.containerSampler.Enabled() {
-		mplog.Info("Running Docker sampler")
 		dockerDecorator, err = ps.containerSampler.NewDecorator()
 		if err != nil {
 			if id := containerIDFromNotRunningErr(err); id != "" {

--- a/pkg/metrics/process/sampler_linux.go
+++ b/pkg/metrics/process/sampler_linux.go
@@ -10,9 +10,8 @@ import (
 
 	"github.com/newrelic/infrastructure-agent/internal/agent"
 	"github.com/newrelic/infrastructure-agent/pkg/config"
-	"github.com/newrelic/infrastructure-agent/pkg/entity"
-	metrics "github.com/newrelic/infrastructure-agent/pkg/metrics"
-	sampler "github.com/newrelic/infrastructure-agent/pkg/metrics/sampler"
+	"github.com/newrelic/infrastructure-agent/pkg/metrics"
+	"github.com/newrelic/infrastructure-agent/pkg/metrics/sampler"
 	"github.com/newrelic/infrastructure-agent/pkg/metrics/types"
 	"github.com/newrelic/infrastructure-agent/pkg/sample"
 )
@@ -91,6 +90,7 @@ func (ps *processSampler) Sample() (results sample.EventBatch, err error) {
 
 	var dockerDecorator metrics.ProcessDecorator = nil
 	if ps.containerSampler.Enabled() {
+		mplog.Info("Running Docker sampler")
 		dockerDecorator, err = ps.containerSampler.NewDecorator()
 		if err != nil {
 			if id := containerIDFromNotRunningErr(err); id != "" {
@@ -108,20 +108,20 @@ func (ps *processSampler) Sample() (results sample.EventBatch, err error) {
 	}
 
 	for _, pid := range pids {
-		var sample *types.ProcessSample
+		var processSample *types.ProcessSample
 		var err error
 
-		sample, err = ps.harvest.Do(pid, elapsedSeconds)
+		processSample, err = ps.harvest.Do(pid, elapsedSeconds)
 		if err != nil {
 			mplog.WithError(err).WithField("pid", pid).Debug("Skipping process.")
 			continue
 		}
 
 		if dockerDecorator != nil {
-			dockerDecorator.Decorate(sample)
+			dockerDecorator.Decorate(processSample)
 		}
 
-		results = append(results, ps.normalizeSample(sample))
+		results = append(results, ps.normalizeSample(processSample))
 	}
 
 	ps.cache.items.RemoveUntilLen(len(pids))
@@ -129,11 +129,11 @@ func (ps *processSampler) Sample() (results sample.EventBatch, err error) {
 	return results, nil
 }
 
-func (self *processSampler) normalizeSample(s *types.ProcessSample) sample.Event {
+func (ps *processSampler) normalizeSample(s *types.ProcessSample) sample.Event {
 	if len(s.ContainerLabels) > 0 {
 		sb, err := json.Marshal(s)
 		if err == nil {
-			bm := &FlatProcessSample{}
+			bm := &types.FlatProcessSample{}
 			if err = json.Unmarshal(sb, bm); err == nil {
 				for name, value := range s.ContainerLabels {
 					key := fmt.Sprintf("containerLabel_%s", name)
@@ -146,23 +146,6 @@ func (self *processSampler) normalizeSample(s *types.ProcessSample) sample.Event
 		}
 	}
 	return s
-}
-
-// FlatProcessSample stores the process sampling information as a map
-type FlatProcessSample map[string]interface{}
-
-var _ sample.Event = &FlatProcessSample{} // FlatProcessSample implements sample.Event
-
-func (f *FlatProcessSample) Type(eventType string) {
-	(*f)["eventType"] = eventType
-}
-
-func (f *FlatProcessSample) Entity(key entity.Key) {
-	(*f)["entityKey"] = key
-}
-
-func (f *FlatProcessSample) Timestamp(timestamp int64) {
-	(*f)["timestamp"] = timestamp
 }
 
 func containerIDFromNotRunningErr(err error) string {

--- a/pkg/metrics/process/sampler_linux_test.go
+++ b/pkg/metrics/process/sampler_linux_test.go
@@ -8,10 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/newrelic/infrastructure-agent/pkg/entity/host"
-	"github.com/newrelic/infrastructure-agent/pkg/metrics/types"
-	"github.com/newrelic/infrastructure-agent/pkg/sysinfo"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -20,9 +16,12 @@ import (
 	"github.com/newrelic/infrastructure-agent/internal/agent/mocks"
 	"github.com/newrelic/infrastructure-agent/pkg/config"
 	"github.com/newrelic/infrastructure-agent/pkg/entity"
+	"github.com/newrelic/infrastructure-agent/pkg/entity/host"
 	"github.com/newrelic/infrastructure-agent/pkg/metrics"
+	"github.com/newrelic/infrastructure-agent/pkg/metrics/types"
 	"github.com/newrelic/infrastructure-agent/pkg/plugins/ids"
 	"github.com/newrelic/infrastructure-agent/pkg/sample"
+	"github.com/newrelic/infrastructure-agent/pkg/sysinfo"
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/hostname"
 )
 
@@ -52,18 +51,18 @@ func TestProcessSampler_DockerDecorator(t *testing.T) {
 	require.Len(t, samples, 2)
 
 	for i := range samples {
-		sample := samples[i].(*FlatProcessSample)
-		switch int32((*sample)["processId"].(float64)) {
+		flatProcessSample := samples[i].(*types.FlatProcessSample)
+		switch int32((*flatProcessSample)["processId"].(float64)) {
 		case 1:
-			assert.Equal(t, "Hello", (*sample)["processDisplayName"])
+			assert.Equal(t, "Hello", (*flatProcessSample)["processDisplayName"])
 		case 2:
-			assert.Equal(t, "Bye", (*sample)["processDisplayName"])
+			assert.Equal(t, "Bye", (*flatProcessSample)["processDisplayName"])
 		default:
-			assert.Failf(t, fmt.Sprintf("Unknown process: %#v", *sample), "")
+			assert.Failf(t, fmt.Sprintf("Unknown process: %#v", *flatProcessSample), "")
 		}
-		assert.Equal(t, "decorated", (*sample)["containerImage"])
-		assert.Equal(t, "value1", (*sample)["containerLabel_label1"])
-		assert.Equal(t, "value2", (*sample)["containerLabel_label2"])
+		assert.Equal(t, "decorated", (*flatProcessSample)["containerImage"])
+		assert.Equal(t, "value1", (*flatProcessSample)["containerLabel_label1"])
+		assert.Equal(t, "value2", (*flatProcessSample)["containerLabel_label2"])
 	}
 }
 
@@ -79,7 +78,7 @@ func (hm *harvesterMock) Pids() ([]int32, error) {
 	return keys, nil
 }
 
-func (hm *harvesterMock) Do(pid int32, elapsedSeconds float64) (*types.ProcessSample, error) {
+func (hm *harvesterMock) Do(pid int32, _ float64) (*types.ProcessSample, error) {
 	return hm.samples[pid], nil
 }
 

--- a/pkg/metrics/sampler/sampler.go
+++ b/pkg/metrics/sampler/sampler.go
@@ -3,8 +3,9 @@
 package sampler
 
 import (
-	"github.com/newrelic/infrastructure-agent/pkg/sample"
 	"time"
+
+	"github.com/newrelic/infrastructure-agent/pkg/sample"
 )
 
 type Sampler interface {

--- a/pkg/metrics/types/process_sample.go
+++ b/pkg/metrics/types/process_sample.go
@@ -4,8 +4,10 @@
 package types
 
 import (
-	"github.com/newrelic/infrastructure-agent/pkg/sample"
 	"github.com/shirou/gopsutil/process"
+
+	"github.com/newrelic/infrastructure-agent/pkg/entity"
+	"github.com/newrelic/infrastructure-agent/pkg/sample"
 )
 
 // ProcessSample data type storing all the data harvested for a process.
@@ -42,4 +44,21 @@ type ProcessSample struct {
 	// Auxiliary values, not to be reported
 	LastIOCounters  *process.IOCountersStat `json:"-"`
 	ContainerLabels map[string]string       `json:"-"`
+}
+
+// FlatProcessSample stores the process sampling information as a map
+type FlatProcessSample map[string]interface{}
+
+var _ sample.Event = &FlatProcessSample{} // FlatProcessSample implements sample.Event
+
+func (f *FlatProcessSample) Type(eventType string) {
+	(*f)["eventType"] = eventType
+}
+
+func (f *FlatProcessSample) Entity(key entity.Key) {
+	(*f)["entityKey"] = key
+}
+
+func (f *FlatProcessSample) Timestamp(timestamp int64) {
+	(*f)["timestamp"] = timestamp
 }

--- a/test/fixture/sample/processes.go
+++ b/test/fixture/sample/processes.go
@@ -27,4 +27,11 @@ var (
 		ContainerID:        "qux",
 		Contained:          "true",
 	}
+
+	FlatProcessSample = types.FlatProcessSample{
+		"processDisplayName": "foo",
+		"commandLine":        "/usr/bin/foo",
+		"commandName":        "bar",
+		"userName":           "baz",
+	}
 )


### PR DESCRIPTION
This fixes issue #167, where process samples that have been decorated with Docker labels are not filtered.