### PR TITLE
Bump gopsutil major

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,14 +33,14 @@ require (
 	github.com/opencontainers/image-spec v1.0.2-0.20181029102219-09950c5fb1bb // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/procfs v0.2.0
-	github.com/shirou/gopsutil v2.18.12-0.20181220224138-a5ace91ccec8+incompatible
+	github.com/shirou/gopsutil v3.20.10+incompatible
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 // indirect
 	github.com/sirupsen/logrus v1.6.1-0.20200528085638-6699a89a232f
 	github.com/stretchr/testify v1.5.1
 	github.com/tevino/abool v1.2.0
 	golang.org/dl v0.0.0-20200901180525-35ca1c5c19fb // indirect
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
-	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd
+	golang.org/x/sys v0.0.0-20201101102859-da207088b7d1
 	golang.org/x/text v0.3.3-0.20190829152558-3d0f7978add9 // indirect
 	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c // indirect
 	google.golang.org/grpc v1.29.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/prometheus/procfs v0.2.0 h1:wH4vA7pcjKuZzjF7lM8awk4fnuJO6idemZXoKnULU
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/shirou/gopsutil v2.18.12-0.20181220224138-a5ace91ccec8+incompatible h1:7oID10A10X7TuswfvLpbCsRSzIow5SG5qWZMcXhwB5E=
 github.com/shirou/gopsutil v2.18.12-0.20181220224138-a5ace91ccec8+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+github.com/shirou/gopsutil v3.20.10+incompatible h1:kQuRhh6h6y4luXvnmtu/lJEGtdJ3q8lbu9NQY99GP+o=
+github.com/shirou/gopsutil v3.20.10+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 h1:udFKJ0aHUL60LboW/A+DfgoHVedieIzIXE8uylPue0U=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/sirupsen/logrus v1.6.1-0.20200528085638-6699a89a232f h1:qqqIhBDFUBrbMezIyJkKWIpf+E5CdObleGMjW1s19Hg=

--- a/pkg/metrics/process/snapshot_linux.go
+++ b/pkg/metrics/process/snapshot_linux.go
@@ -86,7 +86,7 @@ func init() {
 		pageSize = 4096 // default value
 	}
 
-	clockTicks = int64(cpu.CPUTick)
+	clockTicks = int64(cpu.ClocksPerSec)
 	if clockTicks <= 0 {
 		clockTicks = 100 // default value
 	}


### PR DESCRIPTION
Increase gopsutil major version removing pinned version for stdlib `sys`.

See pinned version at https://github.com/newrelic/infrastructure-agent/pull/207
