### PR TITLE
feat: limit amount of queued entities to be submitted

### DIFF
--- a/cmd/newrelic-infra/newrelic-infra.go
+++ b/cmd/newrelic-infra/newrelic-infra.go
@@ -306,7 +306,7 @@ func initializeAgentAndRun(c *config.Config, logFwCfg config.LogForward) error {
 		os.Exit(1)
 	}
 
-	metricsSenderConfig := dm.NewConfig(c.MetricURL, c.License, time.Duration(c.DMSubmissionPeriod)*time.Second, c.MaxMetricBatchEntitiesCount)
+	metricsSenderConfig := dm.NewConfig(c.MetricURL, c.License, time.Duration(c.DMSubmissionPeriod)*time.Second, c.MaxMetricBatchEntitiesCount, c.MaxMetricBatchEntitiesQueue)
 	dmSender, err := dm.NewDMSender(metricsSenderConfig, transport, agt.Context.IdContext().AgentIdentity)
 	if err != nil {
 		return err

--- a/internal/agent/event_sender.go
+++ b/internal/agent/event_sender.go
@@ -194,7 +194,7 @@ func (sender *metricsIngestSender) QueueEvent(event sample.Event, key entity.Key
 	case sender.eventQueue <- queuedEvent:
 		return nil
 	default:
-		return fmt.Errorf("Could not queue event: Queue is full.")
+		return fmt.Errorf("could not queue event: queue is full")
 	}
 }
 

--- a/pkg/backend/telemetryapi/config.go
+++ b/pkg/backend/telemetryapi/config.go
@@ -17,6 +17,7 @@ const (
 	// MaxConns.
 	DefaultMaxConns              = 2
 	DefaultMaxEntitiesPerRequest = 100
+	DefaultMaxEntitiesPerBatch   = 1000
 )
 
 // Config customizes the behavior of a Harvester.
@@ -48,7 +49,6 @@ type Config struct {
 	// MetricsURLOverride overrides the metrics endpoint if not not empty.
 	MetricsURLOverride string
 	// SpansURLOverride overrides the spans endpoint if not not empty.
-	//
 	// To enable Infinite Tracing on the New Relic Edge, set this field to your
 	// Trace Observer URL.  See
 	// https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/enable-configure/enable-distributed-tracing
@@ -62,8 +62,11 @@ type Config struct {
 	MaxConns int
 	// Context is the Context to use for making requests
 	Context context.Context
-	// MaxEntitiesPerBatch limits the total number of entities per request when submitting metric
+	// MaxEntitiesPerRequest limits the total number of entities per request when submitting metric
 	// If zero, DefaultMaxEntitiesPerRequest is used (100 entities).
+	MaxEntitiesPerRequest int
+	// MaxEntitiesPerBatch limits the total of metrics to queue
+	// If zero, DefaultMaxEntitiesPerBatch is used (1000 entities).
 	MaxEntitiesPerBatch int
 }
 
@@ -91,11 +94,19 @@ func ConfigCommonAttributes(attributes map[string]interface{}) func(*Config) {
 	}
 }
 
-// ConfigEntitiesPerBatch sets the Config's MaxEntitiesPerBatch field which controls the
+// ConfigMaxEntitiesPerRequest sets the Config's MaxEntitiesPerRequest field which controls the
 // amount of entities that is submitted to New Relic per request.
-func ConfigEntitiesPerBatch(quantity int) func(*Config) {
+func ConfigMaxEntitiesPerRequest(n int) func(*Config) {
 	return func(cfg *Config) {
-		cfg.MaxEntitiesPerBatch = quantity
+		cfg.MaxEntitiesPerRequest = n
+	}
+}
+
+// ConfigMaxEntitiesPerBatch sets the Config's MaxEntitiesPerBatch field which controls the
+// amount of entities that will be queued to process before submitted to New Relic.
+func ConfigMaxEntitiesPerBatch(n int) func(*Config) {
+	return func(c *Config) {
+		c.MaxEntitiesPerBatch = n
 	}
 }
 

--- a/pkg/backend/telemetryapi/config_test.go
+++ b/pkg/backend/telemetryapi/config_test.go
@@ -192,3 +192,61 @@ func TestConfigUserAgent(t *testing.T) {
 		}
 	}
 }
+
+func TestConfigMaxEntitiesPerRequest(t *testing.T) {
+	// Default
+	h, err := NewHarvester(
+		ConfigAPIKey("TestConfigMaxEntitiesPerRequest"))
+
+	if h == nil || err != nil {
+		t.Error("Failed to initialize harvester with err: ", err)
+	}
+
+	if h.config.MaxEntitiesPerRequest != DefaultMaxEntitiesPerRequest {
+		t.Error("Expected to 'MaxEntitiesPerRequest' setting be: ", DefaultMaxEntitiesPerRequest)
+	}
+
+	// With expected value
+	expectedMax := 1
+
+	h, err = NewHarvester(
+		ConfigAPIKey("TestConfigMax"),
+		ConfigMaxEntitiesPerRequest(expectedMax))
+
+	if h == nil || err != nil {
+		t.Error("Failed to initialize harvester with err: ", err)
+	}
+
+	if h.config.MaxEntitiesPerRequest != expectedMax {
+		t.Error("Expected to 'MaxEntitiesPerRequest' setting be: ", expectedMax)
+	}
+}
+
+func TestConfigMaxEntitiesPerBatch(t *testing.T) {
+	// Default
+	h, err := NewHarvester(
+		ConfigAPIKey("TestConfigMaxEntitiesPerBatch"))
+
+	if h == nil || err != nil {
+		t.Error("Failed to initialize harvester with err: ", err)
+	}
+
+	if h.config.MaxEntitiesPerBatch != DefaultMaxEntitiesPerBatch {
+		t.Error("Expected to 'MaxEntitiesPerBatch' setting be: ", DefaultMaxEntitiesPerBatch)
+	}
+
+	// With expected value
+	expectedMax := 1
+
+	h, err = NewHarvester(
+		ConfigAPIKey("TestConfigMax"),
+		ConfigMaxEntitiesPerBatch(expectedMax))
+
+	if h == nil || err != nil {
+		t.Error("Failed to initialize harvester with err: ", err)
+	}
+
+	if h.config.MaxEntitiesPerBatch != expectedMax {
+		t.Error("Expected to 'MaxEntitiesPerBatch' setting be: ", expectedMax)
+	}
+}

--- a/pkg/backend/telemetryapi/harvester.go
+++ b/pkg/backend/telemetryapi/harvester.go
@@ -596,7 +596,7 @@ func (m *metricBatchHandler) enqueue(metric metricBatch) error {
 	defer m.lock.Unlock()
 
 	if m.index == cap(m.queue) {
-		return errors.New("could not queue event: queue is full")
+		return errors.New("could not queue metric: queue is full")
 	}
 
 	m.queue[m.index] = metric
@@ -610,5 +610,6 @@ func (m *metricBatchHandler) dequeue() []metricBatch {
 
 	res := m.queue[:m.index]
 	m.queue = make([]metricBatch, cap(m.queue))
+	m.index = 0
 	return res
 }

--- a/pkg/backend/telemetryapi/harvester_test.go
+++ b/pkg/backend/telemetryapi/harvester_test.go
@@ -689,7 +689,7 @@ func TestRequestRetryBody(t *testing.T) {
 func TestRecordInfraMetrics_MaxEntitiesPerBatchReached_returnError(t *testing.T) {
 	// GIVEN a harvester configured max event deep queue to 1
 	h, err := NewHarvester(
-		ConfigAPIKey("TestRecordInfraMetrics_MaxEventQueued_returnError"),
+		ConfigAPIKey("TestRecordInfraMetrics_MaxEntitiesPerBatchReached_returnError"),
 		ConfigMaxEntitiesPerBatch(1))
 	if err != nil {
 		t.Error("Failed to initialize harvester with error: ", err)

--- a/pkg/backend/telemetryapi/harvester_test.go
+++ b/pkg/backend/telemetryapi/harvester_test.go
@@ -18,8 +18,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"github.com/newrelic/infrastructure-agent/pkg/backend/telemetryapi/internal"
 )
 
 // compactJSONString removes the whitespace from a JSON string.  This function
@@ -222,20 +220,6 @@ func emptyResponse(status int) *http.Response {
 		StatusCode: status,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}
-}
-
-func uncompressBody(req *http.Request) (string, error) {
-	body, err := ioutil.ReadAll(req.Body)
-	defer req.Body.Close()
-
-	if err != nil {
-		return "", fmt.Errorf("unable to read body: %v", err)
-	}
-	uncompressed, err := internal.Uncompress(body)
-	if err != nil {
-		return "", fmt.Errorf("unable to uncompress body: %v", err)
-	}
-	return string(uncompressed), nil
 }
 
 // sortedMetricsHelper is used to sort metrics for JSON comparison.
@@ -700,6 +684,29 @@ func TestRequestRetryBody(t *testing.T) {
 	})
 	h.RecordMetric(Count{})
 	h.HarvestNow(context.Background())
+}
+
+func TestRecordInfraMetrics_MaxEntitiesPerBatchReached_returnError(t *testing.T) {
+	// GIVEN a harvester configured max event deep queue to 1
+	h, err := NewHarvester(
+		ConfigAPIKey("TestRecordInfraMetrics_MaxEventQueued_returnError"),
+		ConfigMaxEntitiesPerBatch(1))
+	if err != nil {
+		t.Error("Failed to initialize harvester with error: ", err)
+	}
+
+	// AND a recorded metric
+	_ = h.RecordInfraMetrics(Attributes{}, []Metric{Count{Name: "count-metric"}})
+
+	// WHEN try to record more metrics
+	err = h.RecordInfraMetrics(Attributes{}, []Metric{
+		Summary{Name: "summary-metric"},
+	})
+
+	// THEN returns a queue busy error
+	if err == nil {
+		t.Error("Expected to failed due a max entities per batch reached")
+	}
 }
 
 // multiAttemptRoundTripper will fail the first n requests after reading

--- a/pkg/backend/telemetryapi/harvester_test.go
+++ b/pkg/backend/telemetryapi/harvester_test.go
@@ -690,7 +690,8 @@ func TestRecordInfraMetrics_MaxEntitiesPerBatchReached_returnError(t *testing.T)
 	// GIVEN a harvester configured max event deep queue to 1
 	h, err := NewHarvester(
 		ConfigAPIKey("TestRecordInfraMetrics_MaxEntitiesPerBatchReached_returnError"),
-		ConfigMaxEntitiesPerBatch(1))
+		ConfigMaxEntitiesPerBatch(1),
+		ConfigHarvestPeriod(1*time.Millisecond))
 	if err != nil {
 		t.Error("Failed to initialize harvester with error: ", err)
 	}
@@ -706,6 +707,12 @@ func TestRecordInfraMetrics_MaxEntitiesPerBatchReached_returnError(t *testing.T)
 	// THEN returns a queue busy error
 	if err == nil {
 		t.Error("Expected to failed due a max entities per batch reached")
+	}
+
+	time.Sleep(25 * time.Millisecond)
+
+	if h.metricBatch.index != 0 {
+		t.Error("Expected to queue be consumed when harvester start to process metrics")
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -861,6 +861,11 @@ type Config struct {
 	// Public: No
 	MaxMetricBatchEntitiesCount int `yaml:"max_metrics_batch_entities_count" envconfig:"max_metrics_batch_entities_count" public:"false"`
 
+	// MaxMetricBatchEntitiesQueue Defined a max amount of queued entities to be submited. Used to avoid memory consumption if metrics could not be submitted.
+	// Default: 1000
+	// Public: No
+	MaxMetricBatchEntitiesQueue int `yaml:"max_metrics_batch_entities_queue" envconfig:"max_metrics_batch_entities_queue" public:"false"`
+
 	// ConnectEnabled It enables or disables the connect for the agent ID resolution given the agent fingerprint.
 	// If the config option is enabled it also reconnects to update the fingerprint with the given agent ID.
 	// In case this config is enabled then it adds the resolved agent ID in the header as X-NRI-Agent-Entity-Id.
@@ -1268,6 +1273,7 @@ func NewConfig() *Config {
 		MaxInventorySize:            defaultMaxInventorySize,
 		MaxMetricsBatchSizeBytes:    DefaultMaxMetricsBatchSizeBytes,
 		MaxMetricBatchEntitiesCount: DefaultMaxMetricBatchEntitiesCount,
+		MaxMetricBatchEntitiesQueue: DefaultMaxMetricBatchEntitiesQueue,
 		StartupConnectionRetries:    defaultStartupConnectionRetries,
 		DisableZeroRSSFilter:        defaultDisableZeroRSSFilter,
 		DisableWinSharedWMI:         defaultDisableWinSharedWMI,
@@ -1656,6 +1662,10 @@ func NormalizeConfig(cfg *Config, cfgMetadata config_loader.YAMLMetadata) (err e
 
 	if cfg.MaxMetricBatchEntitiesCount > DefaultMaxMetricBatchEntitiesCount || cfg.MaxMetricBatchEntitiesCount <= 0 {
 		cfg.MaxMetricBatchEntitiesCount = DefaultMaxMetricBatchEntitiesCount
+	}
+
+	if cfg.MaxMetricBatchEntitiesQueue > DefaultMaxMetricBatchEntitiesQueue || cfg.MaxMetricBatchEntitiesQueue <= 0 {
+		cfg.MaxMetricBatchEntitiesQueue = DefaultMaxMetricBatchEntitiesQueue
 	}
 
 	// Avoid clients de-facto disabling inventory splitting when we remove the disable_inventory_split function

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -311,6 +311,7 @@ agent_dir: /my/overriden/agent/dir
 	c.Assert(cfg.MaxProcs, Equals, defaultMaxProcs)
 	c.Assert(cfg.IgnoreSystemProxy, Equals, false)
 	c.Assert(cfg.MaxMetricBatchEntitiesCount, Equals, 300)
+	c.Assert(cfg.MaxMetricBatchEntitiesQueue, Equals, 1000)
 
 	var expectedMetricEndpoint = defaultMetricsIngestEndpoint
 	if cfg.ConnectEnabled {

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -37,6 +37,7 @@ var (
 	DefaultDMPeriodSecs                = 5           // default telemetry SDK value
 	DefaultMaxMetricsBatchSizeBytes    = 1000 * 1000 // Size limit from Vortex collector service (1MB)
 	DefaultMaxMetricBatchEntitiesCount = 300         // Amount limit from Vortex collector service header (8k ~ 300 entities)
+	DefaultMaxMetricBatchEntitiesQueue = 1000        // Limit the amount of queued entities to be processed by Vortex collector service
 	DefaultMetricsNFSSampleRate        = 20
 	DefaultOfflineTimeToReset          = "24h"
 	DefaultStorageSamplerRateSecs      = 20

--- a/pkg/integrations/legacy/runner_test.go
+++ b/pkg/integrations/legacy/runner_test.go
@@ -1155,11 +1155,11 @@ func TestGenerateExecCmdWithDatabind_FetchError(t *testing.T) {
 	plugin.updateCmdWrappers("")
 	cmds := plugin.getCmdWrappers()
 	assert.Empty(t, cmds)
-	require.NotEmpty(t, hook.Entries)
+	require.NotEmpty(t, hook.AllEntries())
 	var found bool
-	for i := range hook.Entries {
-		if hook.Entries[i].Level == logrus.WarnLevel {
-			if val, ok := hook.Entries[i].Data["error"]; ok {
+	for i := range hook.AllEntries() {
+		if hook.AllEntries()[i].Level == logrus.WarnLevel {
+			if val, ok := hook.AllEntries()[i].Data["error"]; ok {
 				if val.(error).Error() == "fetch error with password=<HIDDEN>" {
 					found = true
 				}
@@ -1191,11 +1191,11 @@ func TestGenerateExecCmdWithDatabind_ReplaceError(t *testing.T) {
 	plugin.updateCmdWrappers("")
 	cmds := plugin.getCmdWrappers()
 	assert.Empty(t, cmds)
-	require.NotEmpty(t, hook.Entries)
+	require.NotEmpty(t, hook.AllEntries())
 	var found bool
-	for i := range hook.Entries {
-		if hook.Entries[i].Level == logrus.WarnLevel {
-			if val, ok := hook.Entries[i].Data["error"]; ok {
+	for i := range hook.AllEntries() {
+		if hook.AllEntries()[i].Level == logrus.WarnLevel {
+			if val, ok := hook.AllEntries()[i].Data["error"]; ok {
 				if val.(error).Error() == "replace error with password=<HIDDEN>" {
 					found = true
 				}

--- a/pkg/integrations/v4/dm/emitter.go
+++ b/pkg/integrations/v4/dm/emitter.go
@@ -230,7 +230,7 @@ func (e *emitter) processEntityFwRequest(r fwrequest.EntityFwRequest) {
 
 	metrics := dmProcessor.ProcessMetrics(r.Data.Metrics, r.Data.Common, r.Data.Entity)
 	if err := e.metricsSender.SendMetricsWithCommonAttributes(r.Data.Common, metrics); err != nil {
-		// TODO error handling
+		elog.WithField("entity", r.ID()).WithError(err).Warn("discarding metrics")
 	}
 }
 

--- a/pkg/integrations/v4/dm/emitter_test.go
+++ b/pkg/integrations/v4/dm/emitter_test.go
@@ -250,7 +250,7 @@ func TestEmitter_Send_failedToSubmitMetrics_dropAndLog(t *testing.T) {
 	ctx.SendDataWg.Wait()
 
 	entry := hook.LastEntry()
-	require.NotEmpty(t, hook.Entries)
+	require.NotEmpty(t, hook.AllEntries())
 	assert.Equal(t, "DimensionalMetricsEmitter", entry.Data["component"])
 	assert.Equal(t, "discarding metrics", entry.Message)
 	assert.Equal(t, identity.ID, entry.Data["entity"])
@@ -279,7 +279,7 @@ func TestEmitEvent_InvalidPayload(t *testing.T) {
 	emitEvent(&plugin, d, protocol.Dataset{Events: []protocol.EventData{{"value": "foo"}}}, nil, entity.ID(0))
 
 	entry := hook.LastEntry()
-	require.NotEmpty(t, hook.Entries)
+	require.NotEmpty(t, hook.AllEntries())
 	assert.Equal(t, "DimensionalMetricsEmitter", entry.Data["component"])
 	assert.Equal(t, "discarding event, failed building event data.", entry.Message)
 	assert.EqualError(t, entry.Data["error"].(error), "invalid event format: missing required 'summary' field")

--- a/pkg/integrations/v4/dm/sender.go
+++ b/pkg/integrations/v4/dm/sender.go
@@ -23,18 +23,20 @@ type MetricsSender interface {
 }
 
 type MetricsSenderConfig struct {
-	LicenseKey       string
-	MetricApiURL     string
-	SubmissionPeriod time.Duration
-	MaxEntities      int
+	LicenseKey          string
+	MetricApiURL        string
+	SubmissionPeriod    time.Duration
+	MaxEntitiesPerReq   int
+	MaxEntitiesPerBatch int
 }
 
-func NewConfig(baseURL string, licenseKey string, submissionPeriod time.Duration, maxEntities int) MetricsSenderConfig {
+func NewConfig(baseURL string, licenseKey string, submissionPeriod time.Duration, maxEntitiesPerReq int, maxEntitiesPerBatch int) MetricsSenderConfig {
 	return MetricsSenderConfig{
-		LicenseKey:       licenseKey,
-		MetricApiURL:     fmt.Sprintf("%s/metric/v1/infra", baseURL),
-		SubmissionPeriod: submissionPeriod,
-		MaxEntities:      maxEntities,
+		LicenseKey:          licenseKey,
+		MetricApiURL:        fmt.Sprintf("%s/metric/v1/infra", baseURL),
+		SubmissionPeriod:    submissionPeriod,
+		MaxEntitiesPerReq:   maxEntitiesPerReq,
+		MaxEntitiesPerBatch: maxEntitiesPerBatch,
 	}
 }
 

--- a/pkg/integrations/v4/dm/sender_test.go
+++ b/pkg/integrations/v4/dm/sender_test.go
@@ -451,7 +451,7 @@ func Test_sender_SendMetric_cumulative_count_invalid_metric(t *testing.T) {
 	harvester.AssertNotCalled(t, "RecordInfraMetrics", mock.AnythingOfType("telemetryapi.Attributes"), mock.AnythingOfType("[]telemetry.Metric"))
 
 	// THEN one long entry found
-	require.NotEmpty(t, hook.Entries)
+	require.NotEmpty(t, hook.AllEntries())
 	entry := hook.LastEntry()
 	assert.Equal(t, "CumulativeCountInvalidMetric", entry.Data["name"])
 	assert.Equal(t, noCalculationMadeErrMsg, entry.Message)
@@ -498,7 +498,7 @@ func Test_sender_SendMetric_cumulative_count_invalid_metric_value(t *testing.T) 
 	harvester.AssertNotCalled(t, "RecordInfraMetrics", mock.AnythingOfType("telemetryapi.Attributes"), mock.AnythingOfType("[]telemetry.Metric"))
 
 	// THEN one long entry found
-	require.NotEmpty(t, hook.Entries)
+	require.NotEmpty(t, hook.AllEntries())
 	entry := hook.LastEntry()
 	assert.Equal(t, name, entry.Data["name"])
 	assert.Equal(t, cumulativeType, entry.Data["metric-type"])
@@ -652,7 +652,7 @@ func Test_sender_SendMetric_rate_cumulative_invalid_metric(t *testing.T) {
 			harvester.AssertNotCalled(t, "RecordInfraMetrics", mock.AnythingOfType("telemetryapi.Attributes"), mock.AnythingOfType("[]telemetry.Metric"))
 
 			// THEN one long entry found
-			require.NotEmpty(t, hook.Entries)
+			require.NotEmpty(t, hook.AllEntries())
 			entry := hook.LastEntry()
 			assert.Equal(t, tt.name, entry.Data["name"])
 			assert.Equal(t, tt.metricType, entry.Data["metric-type"])
@@ -717,7 +717,7 @@ func Test_sender_SendMetric_rate_cumulative_invalid_metric_value(t *testing.T) {
 			harvester.AssertNotCalled(t, "RecordInfraMetrics", mock.AnythingOfType("telemetryapi.Attributes"), mock.AnythingOfType("protocol.Metric"))
 
 			// THEN one long entry found
-			require.NotEmpty(t, hook.Entries)
+			require.NotEmpty(t, hook.AllEntries())
 			entry := hook.LastEntry()
 			assert.Equal(t, tt.name, entry.Data["name"])
 			assert.Equal(t, tt.metricType, entry.Data["metric-type"])
@@ -762,7 +762,7 @@ func TestSender_SendMetrics_invalid_metric_type(t *testing.T) {
 	harvester.AssertNotCalled(t, "RecordInfraMetrics", mock.AnythingOfType("telemetryapi.Attributes"), mock.AnythingOfType("[]telemetry.Metrics"))
 
 	// THEN one long entry found
-	require.NotEmpty(t, hook.Entries)
+	require.NotEmpty(t, hook.AllEntries())
 	entry := hook.LastEntry()
 	assert.Equal(t, "received an unknown metric type", entry.Message)
 	assert.Equal(t, entry.Data["name"], "InvalidMetric")

--- a/pkg/integrations/v4/dm/sender_test.go
+++ b/pkg/integrations/v4/dm/sender_test.go
@@ -25,13 +25,13 @@ import (
 func Test_sender_Configuration_endpointURL(t *testing.T) {
 	prodUrl := "https://infra-api.newrelic.com/metric/v1/infra"
 
-	c := NewConfig("https://infra-api.newrelic.com", "licenseKey", time.Millisecond, 0)
+	c := NewConfig("https://infra-api.newrelic.com", "licenseKey", time.Millisecond, 0, 0)
 
 	assert.Equal(t, prodUrl, c.MetricApiURL)
 
 	stgUrl := "https://staging-metric-api.newrelic.com/metric/v1/infra"
 
-	c = NewConfig("https://staging-metric-api.newrelic.com", "licenseKey", time.Millisecond, 0)
+	c = NewConfig("https://staging-metric-api.newrelic.com", "licenseKey", time.Millisecond, 0, 0)
 
 	assert.Equal(t, stgUrl, c.MetricApiURL)
 }

--- a/pkg/integrations/v4/dm/telemetry.go
+++ b/pkg/integrations/v4/dm/telemetry.go
@@ -54,7 +54,8 @@ func newTelemetryHarverster(conf MetricsSenderConfig, transport http.RoundTrippe
 		telemetryHarvesterWithTransport(transport, conf.LicenseKey, idProvide),
 		telemetryHarvesterWithMetricApiUrl(conf.MetricApiURL),
 		telemetry.ConfigHarvestPeriod(conf.SubmissionPeriod),
-		telemetry.ConfigEntitiesPerBatch(conf.MaxEntities),
+		telemetry.ConfigMaxEntitiesPerRequest(conf.MaxEntitiesPerReq),
+		telemetry.ConfigMaxEntitiesPerBatch(conf.MaxEntitiesPerBatch),
 	)
 }
 

--- a/pkg/integrations/v4/manager_test.go
+++ b/pkg/integrations/v4/manager_test.go
@@ -235,10 +235,10 @@ func TestManager_SkipLoadingV3IntegrationsWithNoWarnings(t *testing.T) {
 	_ = NewManager(Configuration{ConfigFolders: []string{dir}}, emitter, integration.ErrLookup, definitionQ, stoppable.NewTracker())
 
 	// THEN no long entries found
-	for i := range hook.Entries {
-		fmt.Println(hook.Entries[i]) // Use stdout as logger is in discard mode and we never run tests in verbose
+	for i := range hook.AllEntries() {
+		fmt.Println(hook.AllEntries()[i]) // Use stdout as logger is in discard mode and we never run tests in verbose
 	}
-	assert.Empty(t, hook.Entries)
+	assert.Empty(t, hook.AllEntries())
 }
 
 func TestManager_LogWarningForInvalidYaml(t *testing.T) {
@@ -258,7 +258,7 @@ func TestManager_LogWarningForInvalidYaml(t *testing.T) {
 	_ = NewManager(Configuration{ConfigFolders: []string{dir}}, emitter, integration.ErrLookup, definitionQ, stoppable.NewTracker())
 
 	// THEN one long entry found
-	require.NotEmpty(t, hook.Entries)
+	require.NotEmpty(t, hook.AllEntries())
 	entry := hook.LastEntry()
 	assert.Equal(t, "can't load integrations file", entry.Message)
 	assert.Equal(t, logrus.WarnLevel, entry.Level)

--- a/pkg/metrics/procs_windows_test.go
+++ b/pkg/metrics/procs_windows_test.go
@@ -193,7 +193,7 @@ func TestProcess_WithoutPath(t *testing.T) {
 	}
 
 	for _, p := range processes {
-		assertLogProcessData(t, p.Name, p.ProcessID, hook.Entries)
+		assertLogProcessData(t, p.Name, p.ProcessID, hook.AllEntries())
 	}
 
 	le := hook.LastEntry()

--- a/pkg/metrics/procs_windows_test.go
+++ b/pkg/metrics/procs_windows_test.go
@@ -204,7 +204,7 @@ func TestProcess_WithoutPath(t *testing.T) {
 	assert.Equal(t, "ProcessSampler", le.Data["sampler"])
 }
 
-func assertLogProcessData(t *testing.T, name string, id uint32, logEntries []logrus.Entry) {
+func assertLogProcessData(t *testing.T, name string, id uint32, logEntries []*logrus.Entry) {
 	const logNotFound = -1
 	i := sort.Search(len(logEntries), func(i int) bool {
 		return logEntries[i].Data["name"] == name && logEntries[i].Data["process_id"] == id

--- a/pkg/metrics/sampler/matcher_test.go
+++ b/pkg/metrics/sampler/matcher_test.go
@@ -556,7 +556,7 @@ func Test_EvaluatorChain_LogTraceMatcher(t *testing.T) {
 	assert.Len(t, ec.Matchers, len(rule))
 	assert.EqualValues(t, true, ec.Evaluate(javaProcessSample))
 
-	require.NotEmpty(t, hook.Entries)
+	require.NotEmpty(t, hook.AllEntries())
 	entry := hook.LastEntry()
 	assert.Equal(t, "[metric.match] 'java' matches expression [ProcessDisplayName processDisplayName] >> 'java': true", entry.Message)
 	assert.Equal(t, logrus.TraceLevel, entry.Level)


### PR DESCRIPTION
The telemetryapi embedded in the agent now limits the amount of queued entities by configuration.

This feature is tended to avoid memory consumption in case metrics could not be submitted to NR.

Resolve #126 