### PR TITLE
ci: Enabled GitHub code scanning tool on the repo

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,28 @@
+---
+name: "Code Scanning - Action"
+
+on: [ push, pull_request ]
+
+jobs:
+
+  CodeQL-Build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.14.4'
+
+      - name: Validate code
+        run: make go-get
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: go
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/pkg/metrics/docker_sampler.go
+++ b/pkg/metrics/docker_sampler.go
@@ -129,7 +129,7 @@ func (d *decoratorImpl) topPids(container types.Container, pids map[int32]types.
 	}
 	cachedPids := make([]int32, 0, len(processes))
 	for _, process := range processes {
-		pid, err := strconv.Atoi(process[pidColumn])
+		pid, err := strconv.ParseInt(process[pidColumn], 10, 32)
 		if err != nil {
 			dslog.WithFieldsF(func() logrus.Fields {
 				return logrus.Fields{
@@ -140,8 +140,9 @@ func (d *decoratorImpl) topPids(container types.Container, pids map[int32]types.
 			}).Debug("Wrong PID number. Ignoring.")
 			continue
 		}
-		pids[int32(pid)] = container
-		cachedPids = append(cachedPids, int32(pid))
+		pidAsInt32 := int32(pid)
+		pids[pidAsInt32] = container
+		cachedPids = append(cachedPids, pidAsInt32)
 	}
 	// store fresh pids in the cache
 	d.cache.put(container.ID, cachedPids)


### PR DESCRIPTION
This PR enables [GitHub code scanning](https://github.blog/2020-09-30-code-scanning-is-now-available/) which is a useful tool for spotting potential security vulnerabilities. I've fixed a couple that looked very straight forward but the others will require a larger refactor.