### PR TITLE
Update nri-docker to v1.3.3

### DIFF
--- a/build/nri-integrations
+++ b/build/nri-integrations
@@ -1,5 +1,5 @@
 #ohi-repo-name,version
-nri-docker,1.3.2
+nri-docker,1.3.3
 nri-flex,1.3.5
 nri-winservices,v0.1.0-beta
 nri-prometheus,2.3.0


### PR DESCRIPTION
This PR syncs the nri-docker integration shipped with the infra agent with version 1.3.3, which ships a fix for Fargate metadata.