### PR TITLE
feat: Updated nri-flex to v1.3.6

### DIFF
--- a/build/nri-integrations
+++ b/build/nri-integrations
@@ -1,5 +1,5 @@
 #ohi-repo-name,version
 nri-docker,1.3.3
-nri-flex,1.3.5
+nri-flex,1.3.6
 nri-winservices,v0.1.0-beta
 nri-prometheus,2.3.0


### PR DESCRIPTION
Main new feature for flex is [HTML parsing](https://github.com/newrelic/nri-flex/pull/232). Have checked the diff between `v1.3.6` and `v1.3.5` and happy that changes should not affect existing behavior. There are some changes to experimental functions though.