### PR TITLE
feat socket api

### DIFF
--- a/cmd/newrelic-infra/newrelic-infra.go
+++ b/cmd/newrelic-infra/newrelic-infra.go
@@ -322,7 +322,7 @@ func initializeAgentAndRun(c *config.Config, logFwCfg config.LogForward) error {
 	integrationEmitter := emitter.NewIntegrationEmittor(agt, dmEmitter, ffManager)
 	integrationManager := v4.NewManager(integrationCfg, integrationEmitter, il, definitionQ, tracker)
 
-	go socketapi.NewServer(integrationEmitter, il).Serve(agt.Context.Ctx)
+	go socketapi.NewServer(integrationEmitter).Serve(agt.Context.Ctx)
 
 	// log-forwarder
 	fbIntCfg := v4.FBSupervisorConfig{

--- a/cmd/newrelic-infra/newrelic-infra.go
+++ b/cmd/newrelic-infra/newrelic-infra.go
@@ -29,6 +29,7 @@ import (
 	"github.com/newrelic/infrastructure-agent/internal/integrations/v4/files"
 	"github.com/newrelic/infrastructure-agent/internal/integrations/v4/integration"
 	"github.com/newrelic/infrastructure-agent/internal/integrations/v4/v3legacy"
+	"github.com/newrelic/infrastructure-agent/internal/socketapi"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/stoppable"
 	"github.com/sirupsen/logrus"
 
@@ -320,6 +321,8 @@ func initializeAgentAndRun(c *config.Config, logFwCfg config.LogForward) error {
 	}
 	integrationEmitter := emitter.NewIntegrationEmittor(agt, dmEmitter, ffManager)
 	integrationManager := v4.NewManager(integrationCfg, integrationEmitter, il, definitionQ, tracker)
+
+	go socketapi.NewServer(integrationEmitter, il).Serve(agt.Context.Ctx)
 
 	// log-forwarder
 	fbIntCfg := v4.FBSupervisorConfig{

--- a/internal/integrations/v4/runner/runner.go
+++ b/internal/integrations/v4/runner/runner.go
@@ -262,7 +262,6 @@ func (r *runner) handleLines(stdout <-chan []byte, extraLabels data.Map, entityR
 			continue
 		}
 
-		llog.Debug("Received payload.")
 		err := r.emitter.Emit(r.definition, extraLabels, entityRewrite, line)
 		if err != nil {
 			llog.WithError(err).Warn("Cannot emit integration payload")

--- a/internal/integrations/v4/testhelp/testemit/testemit.go
+++ b/internal/integrations/v4/testhelp/testemit/testemit.go
@@ -8,10 +8,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/newrelic/infrastructure-agent/pkg/integrations/legacy"
-
+	"github.com/newrelic/infrastructure-agent/internal/agent/cmdchannel/fflag"
+	"github.com/newrelic/infrastructure-agent/internal/feature_flags"
 	"github.com/newrelic/infrastructure-agent/internal/integrations/v4/integration"
 	"github.com/newrelic/infrastructure-agent/pkg/databind/pkg/data"
+	"github.com/newrelic/infrastructure-agent/pkg/integrations/legacy"
+	"github.com/newrelic/infrastructure-agent/pkg/integrations/v4/dm"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/v4/protocol"
 )
 
@@ -35,6 +37,33 @@ type RecordEmitter struct {
 }
 
 func (t *RecordEmitter) Emit(metadata integration.Definition, extraLabels data.Map, entityRewrite []data.EntityRewrite, json []byte) error {
+	protocolVersion, err := protocol.VersionFromPayload(json, true)
+	if err != nil {
+		return err
+	}
+
+	// dimensional metrics
+	if protocolVersion == protocol.V4 {
+		ffMan := feature_flags.NewManager(map[string]bool{fflag.FlagProtocolV4: true})
+		data, err := dm.ParsePayloadV4(json, ffMan)
+		if err != nil {
+			return err
+		}
+		ch := t.channelFor(metadata.Name)
+		for _, ds := range data.DataSets {
+			ch <- EmittedData{
+				DataSet: protocol.PluginDataSetV3{PluginDataSet: protocol.PluginDataSet{
+					Entity: ds.Entity,
+					//Metrics: ds.Metrics, // TODO
+				}},
+				Metadata:      metadata,
+				ExtraLabels:   extraLabels,
+				EntityRewrite: entityRewrite,
+			}
+		}
+		return nil
+	}
+
 	data, _, err := legacy.ParsePayload(json, false)
 	if err != nil {
 		return err
@@ -48,6 +77,7 @@ func (t *RecordEmitter) Emit(metadata integration.Definition, extraLabels data.M
 			EntityRewrite: entityRewrite,
 		}
 	}
+
 	return nil
 }
 

--- a/internal/integrations/v4/testhelp/testemit/testemit.go
+++ b/internal/integrations/v4/testhelp/testemit/testemit.go
@@ -54,7 +54,8 @@ func (t *RecordEmitter) Emit(metadata integration.Definition, extraLabels data.M
 			ch <- EmittedData{
 				DataSet: protocol.PluginDataSetV3{PluginDataSet: protocol.PluginDataSet{
 					Entity: ds.Entity,
-					//Metrics: ds.Metrics, // TODO
+					// TODO but for now enough the assertion mechanism:
+					Metrics: make([]protocol.MetricData, len(ds.Metrics)),
 				}},
 				Metadata:      metadata,
 				ExtraLabels:   extraLabels,

--- a/internal/socketapi/socketapi.go
+++ b/internal/socketapi/socketapi.go
@@ -1,0 +1,94 @@
+package socketapi
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+
+	"github.com/newrelic/infrastructure-agent/internal/integrations/v4/integration"
+	"github.com/newrelic/infrastructure-agent/pkg/integrations/v4/config"
+	"github.com/newrelic/infrastructure-agent/pkg/integrations/v4/emitter"
+	"github.com/newrelic/infrastructure-agent/pkg/log"
+)
+
+const IntegrationName = "socket-api"
+
+// Server runtime for socket API server.
+type Server struct {
+	port    int
+	logger  log.Entry
+	emitter emitter.Emitter
+	il      integration.InstancesLookup
+}
+
+type sockHandleF func() error
+
+// NewServer creates a new socket API server.
+func NewServer(emitter emitter.Emitter, il integration.InstancesLookup) *Server {
+	logger := log.WithComponent("Server")
+	return &Server{
+		port:    7070,
+		logger:  logger,
+		il:      il,
+		emitter: emitter,
+	}
+}
+
+// Serve serves socket API requests.
+func (s *Server) Serve(ctx context.Context) {
+	def, err := integration.NewDefinition(config.ConfigEntry{
+		InstanceName: IntegrationName,
+	}, s.il, nil, nil)
+	if err != nil {
+		s.logger.WithError(err).Error("cannot create integration definition")
+		return
+	}
+
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", s.port))
+	if err != nil {
+		s.logger.WithField("port", s.port).WithError(err).Error("trying to listen")
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+
+		}
+
+		// this is a PoC! just handling 1 connection fir this purpose is enough
+		conn, err := listener.Accept()
+		if err != nil {
+			s.logger.WithField("port", s.port).WithError(err).Error("cannot accept connection")
+		}
+		defer func() {
+			if err = conn.Close(); err != nil {
+				s.logger.WithError(err).Error("cannot close connection")
+			}
+		}()
+
+		r := bufio.NewReader(conn)
+		for {
+			line, err := r.ReadString('\n')
+			if err == io.EOF {
+				break
+			}
+
+			if err != nil {
+				s.logger.WithError(err).Warn("cannot read connection")
+				break
+			}
+
+			line = strings.TrimSuffix(line, "\n")
+
+			err = s.emitter.Emit(def, nil, nil, []byte(line))
+			if err != nil {
+				s.logger.WithError(err).Error("cannot emit payload")
+			}
+		}
+	}
+}

--- a/internal/socketapi/socketapi.go
+++ b/internal/socketapi/socketapi.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/newrelic/infrastructure-agent/internal/integrations/v4/integration"
-	"github.com/newrelic/infrastructure-agent/pkg/integrations/v4/config"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/v4/emitter"
 	"github.com/newrelic/infrastructure-agent/pkg/log"
 )
@@ -21,27 +20,23 @@ type Server struct {
 	port    int
 	logger  log.Entry
 	emitter emitter.Emitter
-	il      integration.InstancesLookup
 }
 
 type sockHandleF func() error
 
 // NewServer creates a new socket API server.
-func NewServer(emitter emitter.Emitter, il integration.InstancesLookup) *Server {
+func NewServer(emitter emitter.Emitter) *Server {
 	logger := log.WithComponent("Server")
 	return &Server{
 		port:    7070,
 		logger:  logger,
-		il:      il,
 		emitter: emitter,
 	}
 }
 
 // Serve serves socket API requests.
 func (s *Server) Serve(ctx context.Context) {
-	def, err := integration.NewDefinition(config.ConfigEntry{
-		InstanceName: IntegrationName,
-	}, s.il, nil, nil)
+	def, err := integration.NewAPIDefinition(IntegrationName)
 	if err != nil {
 		s.logger.WithError(err).Error("cannot create integration definition")
 		return

--- a/internal/socketapi/socketapi_test.go
+++ b/internal/socketapi/socketapi_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestPayloadFwServer_Serve(t *testing.T) {
 	e := &testemit.RecordEmitter{}
-	pf := NewServer(e, il)
+	pf := NewServer(e)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/internal/socketapi/socketapi_test.go
+++ b/internal/socketapi/socketapi_test.go
@@ -1,0 +1,61 @@
+package socketapi
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/newrelic/infrastructure-agent/internal/integrations/v4/integration"
+	"github.com/newrelic/infrastructure-agent/internal/integrations/v4/testhelp/testemit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPayloadFwServer_Serve(t *testing.T) {
+	e := &testemit.RecordEmitter{}
+	pf := NewServer(e, il)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go pf.Serve(ctx)
+
+	payloadWritten := make(chan struct{})
+	go func() {
+		conn, err := net.Dial("tcp", "localhost:7070")
+		require.NoError(t, err)
+		_, err = conn.Write([]byte(strings.Replace(`{
+  "protocol_version": "4",
+  "integration": {
+    "name": "com.newrelic.foo",
+    "version": "0.1.0"
+  },
+  "data": [
+    {
+      "inventory": {
+        "foo": {
+          "k1": "v1",
+          "k2": false
+        }
+      }
+    }
+  ]
+}`, "\n", "", -1) + "\n"))
+		assert.NoError(t, err)
+		close(payloadWritten)
+	}()
+
+	<-payloadWritten
+	d, err := e.ReceiveFrom(IntegrationName)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, d)
+}
+
+var il = integration.InstancesLookup{
+	Legacy: func(_ integration.DefinitionCommandConfig) (integration.Definition, error) {
+		return integration.Definition{Name: "bar"}, nil
+	},
+	ByName: func(_ string) (string, error) {
+		return "foo", nil
+	},
+}

--- a/pkg/integrations/v4/emitter/emitter.go
+++ b/pkg/integrations/v4/emitter/emitter.go
@@ -54,6 +54,11 @@ type VersionAwareEmitter struct {
 }
 
 func (e *VersionAwareEmitter) Emit(definition integration.Definition, extraLabels data.Map, entityRewrite []data.EntityRewrite, integrationJSON []byte) error {
+	elog.
+		WithField("name", definition.Name).
+		WithField("payload", integrationJSON).
+		Debug("Received payload.")
+
 	protocolVersion, err := protocol.VersionFromPayload(integrationJSON, e.forceProtocolV2ToV3)
 	if err != nil {
 		elog.


### PR DESCRIPTION
**WIP**

Proof of concept of a simple socket API.

For now limited to validate PoC so current scope:
- ingests usual integration payloads (https://docs.newrelic.com/docs/create-integrations/infrastructure-integrations-sdk/specifications/host-integration-executable-file-json-specifications)
- ingest is done in fire'n'forget manner, no response on payload handling
- uses raw TCP, but it could be easily updated to use HTTP instead
- hardcoded listening TCP port at 7070
- payloads are ingested in a per line basis (as usual integration protocol)

You can start playing around by simply writting into netcat like `nc 127.0.0.1 7070`.