### PR TITLE
Update nri-docker to 1.4.0

### DIFF
--- a/build/nri-integrations
+++ b/build/nri-integrations
@@ -1,5 +1,5 @@
 #ohi-repo-name,version
-nri-docker,1.3.3
+nri-docker,1.4.0
 nri-flex,1.3.5
 nri-winservices,v0.1.0-beta
 nri-prometheus,2.3.0


### PR DESCRIPTION
To be merged when nri-docker v1.4.0 is released. 