### PR TITLE
fix: agent config plugin serialising only public fields

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,7 +56,7 @@ type IncludeMetricsMap map[string][]string
 // Use the 'public' annotation to specify the visibility of the config option: false/obfuscate [default: true]
 type Config struct {
 	// Databind provides varaiable (secrets, discovery) replacement capabilities for the configuration.
-	Databind databind.YAMLAgentConfig `yaml:",inline"`
+	Databind databind.YAMLAgentConfig `yaml:",inline" public:"false"`
 
 	// License specifies the license key for your New Relic account. The agent uses this key to associate your server's
 	// metrics with your New Relic account. This setting is created as part of the standard installation process.
@@ -1094,7 +1094,7 @@ func (c *Config) GetLogFile() string {
 // LogInfo will log the configuration.
 // It obfuscates sensitive information and hide private configs.
 func (c *Config) LogInfo() {
-	configFields, err := c.toLogInfo()
+	configFields, err := c.PublicFields()
 	if err != nil {
 		clog.WithError(err).Error("failed to log config")
 		return
@@ -1149,9 +1149,8 @@ func (c *Config) SetIntValueByYamlAttribute(attribute string, value int64) error
 	return fmt.Errorf("unknown field for yaml attribute '%s'", attribute)
 }
 
-// toLogInfo prepares the configuration to be logged.
-// It obfuscates sensitive information and hide private configs.
-func (c *Config) toLogInfo() (map[string]string, error) {
+// PublicFields returns public config fields values indexed by YAML name. It obfuscates sensitive info.
+func (c *Config) PublicFields() (map[string]string, error) {
 	valueOfC := reflect.ValueOf(c)
 
 	if valueOfC.Kind() != reflect.Ptr && valueOfC.Kind() != reflect.Interface {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -481,21 +481,21 @@ func (s *ConfigSuite) TestCalculateCmdChannelURL(c *C) {
 func TestLogInfo_Nil(t *testing.T) {
 	var config *Config
 
-	_, err := config.toLogInfo()
+	_, err := config.PublicFields()
 	assert.Error(t, err)
 }
 
 func TestLogInfo_Empty(t *testing.T) {
 	var config Config
 
-	_, err := config.toLogInfo()
+	_, err := config.PublicFields()
 	assert.NoError(t, err)
 }
 
 func TestLogInfo_New(t *testing.T) {
 	var config = NewConfig()
 
-	_, err := config.toLogInfo()
+	_, err := config.PublicFields()
 	assert.NoError(t, err)
 }
 
@@ -503,7 +503,7 @@ func TestLogInfo_HidePrivate(t *testing.T) {
 	var config = NewConfig()
 	config.CollectorURL = "test"
 
-	actual, err := config.toLogInfo()
+	actual, err := config.PublicFields()
 	assert.NoError(t, err)
 
 	_, exists := actual["collector_url"]
@@ -514,7 +514,7 @@ func TestLogInfo_Public(t *testing.T) {
 	var config = NewConfig()
 	config.Proxy = "test"
 
-	actual, err := config.toLogInfo()
+	actual, err := config.PublicFields()
 	assert.NoError(t, err)
 
 	actualVal, exists := actual["proxy"]
@@ -526,7 +526,7 @@ func TestLogInfo_Obfuscate(t *testing.T) {
 	var config = NewConfig()
 	config.License = "testabcd"
 
-	actual, err := config.toLogInfo()
+	actual, err := config.PublicFields()
 	assert.NoError(t, err)
 
 	actualVal, exists := actual["license_key"]

--- a/pkg/plugins/agent_config.go
+++ b/pkg/plugins/agent_config.go
@@ -4,8 +4,6 @@ package plugins
 
 import (
 	"github.com/newrelic/infrastructure-agent/pkg/entity"
-	"reflect"
-
 	"github.com/newrelic/infrastructure-agent/pkg/log"
 	"github.com/sirupsen/logrus"
 
@@ -30,8 +28,8 @@ func (ac ConfigAttrs) SortKey() string {
 
 func NewAgentConfigPlugin(id ids.PluginID, ctx agent.AgentContext) agent.Plugin {
 	return &AgentConfigPlugin{
-		agent.PluginCommon{ID: id, Context: ctx},
-		*ctx.Config(),
+		PluginCommon: agent.PluginCommon{ID: id, Context: ctx},
+		config:       *ctx.Config(),
 	}
 }
 
@@ -44,24 +42,20 @@ func (ac *AgentConfigPlugin) Run() {
 		ac.config.Proxy = "<proxy set>"
 	}
 
-	flat := map[string]interface{}{}
-	value := reflect.ValueOf(ac.config)
-	for i := 0; i < value.NumField(); i++ {
-		name := value.Type().Field(i).Name
-		switch name {
-		case "FilesConfigOn", "DebugLogSec", "OfflineLoggingMode":
-			continue
-		default:
-			if value.Field(i).CanInterface() {
-				fieldValue := value.Field(i).Interface()
-				flat[name] = map[string]interface{}{
-					"value": fieldValue,
-				}
-			}
+	fields, err := ac.config.PublicFields()
+	if err != nil {
+		aclog.WithError(err).Error("cannot retrieve public config fields")
+		return
+	}
+
+	inventoryItems := map[string]interface{}{}
+	for name, value := range fields {
+		inventoryItems[name] = map[string]interface{}{
+			"value": value,
 		}
 	}
 
-	helpers.LogStructureDetails(aclog, flat, "config", "raw", logrus.Fields{})
+	helpers.LogStructureDetails(aclog, inventoryItems, "config", "raw", logrus.Fields{})
 
-	ac.EmitInventory(agent.PluginInventoryDataset{ConfigAttrs(flat)}, entity.NewFromNameWithoutID(ac.Context.EntityKey()))
+	ac.EmitInventory(agent.PluginInventoryDataset{ConfigAttrs(inventoryItems)}, entity.NewFromNameWithoutID(ac.Context.EntityKey()))
 }

--- a/test/fixture/inventory/expect.go
+++ b/test/fixture/inventory/expect.go
@@ -33,10 +33,8 @@ var (
 				// Verifying some config we already set in the tests, as well as some
 				// fields we just know exist
 				"infrastructure": map[string]interface{}{
-					"DisplayName":           map[string]interface{}{"value": "display-name"},
-					"OverrideHostEtc":       map[string]interface{}{"value": ""},
-					"MaxProcs":              AnyValue,
-					"IgnoredInventoryPaths": AnyValue,
+					"display_name": map[string]interface{}{"value": "display-name"},
+					"max_procs":    AnyValue,
 				},
 			},
 		},


### PR DESCRIPTION
- agent-config plugin serialising now avoids non public config fields.
- agent-config plugin now submit inventory items in config format, ie. snake-case as YAML (instead of previous camel-case variable name).