### PR TITLE
command API spec updates

### DIFF
--- a/internal/agent/cmdchannel/runintegration/runintegration.go
+++ b/internal/agent/cmdchannel/runintegration/runintegration.go
@@ -14,6 +14,7 @@ import (
 	"github.com/newrelic/infrastructure-agent/pkg/backend/commandapi"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/v4/config"
 	"github.com/newrelic/infrastructure-agent/pkg/log"
+	"github.com/newrelic/infrastructure-agent/pkg/trace"
 )
 
 // Errors
@@ -34,6 +35,7 @@ func (a *RunIntArgs) Hash() string {
 // NewHandler creates a cmd-channel handler for run-integration requests.
 func NewHandler(definitionQ chan<- integration.Definition, il integration.InstancesLookup, logger log.Entry) *cmdchannel.CmdHandler {
 	handleF := func(ctx context.Context, cmd commandapi.Command, initialFetch bool) (err error) {
+		trace.CmdReq("run integration request received")
 		var args RunIntArgs
 		if err = json.Unmarshal(cmd.Args, &args); err != nil {
 			err = cmdchannel.NewArgsErr(err)

--- a/internal/agent/cmdchannel/service/service.go
+++ b/internal/agent/cmdchannel/service/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/newrelic/infrastructure-agent/pkg/backend/commandapi"
 	"github.com/newrelic/infrastructure-agent/pkg/entity"
 	"github.com/newrelic/infrastructure-agent/pkg/log"
+	"github.com/newrelic/infrastructure-agent/pkg/trace"
 )
 
 const (
@@ -27,7 +28,7 @@ type srv struct {
 	pollDelaySecsC    <-chan int
 	client            commandapi.Client
 	handlersByCmdName map[string]*cmdchannel.CmdHandler
-	acks              map[int]struct{} // command IDs successfully ack'd
+	acks              map[string]struct{} // command hashes successfully ack'd
 	acksLock          sync.RWMutex
 }
 
@@ -47,7 +48,7 @@ func NewService(
 		pollDelaySecs:     pollDelaySecs,
 		pollDelaySecsC:    backoffSecsC,
 		handlersByCmdName: handlersByName,
-		acks:              make(map[int]struct{}),
+		acks:              make(map[string]struct{}),
 		acksLock:          sync.RWMutex{},
 	}
 }
@@ -116,7 +117,7 @@ func (s *srv) handle(ctx context.Context, c commandapi.Command, initialFetch boo
 	if s.requiresAck(c, agentID) {
 		if err := s.ack(agentID, c); err != nil {
 			ccsLogger.
-				WithField("cmd_id", c.ID).
+				WithField("cmd_hash", c.Hash).
 				WithField("cmd_name", c.Name).
 				WithField("cmd_args", string(c.Args)).
 				WithError(err).
@@ -132,7 +133,7 @@ func (s *srv) handle(ctx context.Context, c commandapi.Command, initialFetch boo
 	h, ok := s.handlersByCmdName[c.Name]
 	if !ok {
 		ccsLogger.
-			WithField("cmd_id", c.ID).
+			WithField("cmd_hash", c.Hash).
 			WithField("cmd_name", c.Name).
 			Error("no handler for command-channel cmd")
 		return
@@ -152,7 +153,7 @@ func (s *srv) handleWrap(h *cmdchannel.CmdHandler, ctx context.Context, c comman
 	err := h.Handle(ctx, c, initialFetch)
 	if err != nil {
 		ccsLogger.
-			WithField("cmd_id", c.ID).
+			WithField("cmd_hash", c.Hash).
 			WithField("cmd_name", c.Name).
 			WithField("cmd_args", string(c.Args)).
 			WithError(err).
@@ -166,18 +167,20 @@ func (s *srv) notReadyToHandle(c commandapi.Command, agentID entity.ID) bool {
 }
 
 func (s *srv) requiresAck(c commandapi.Command, agentID entity.ID) bool {
-	if c.ID == 0 || agentID.IsEmpty() {
+	if c.Hash == "" || agentID.IsEmpty() {
 		return false
 	}
+	trace.CmdReq("ACK required for cmd: %s, hash: %s, args: %s", c.Name, c.Hash.string(c.Args))
 
-	_, ok := s.acks[c.ID]
+	_, ok := s.acks[c.Hash]
 	return !ok
 }
 
 func (s *srv) ack(agentID entity.ID, c commandapi.Command) error {
-	err := s.client.AckCommand(agentID, c.ID)
+	trace.CmdReq("triggering ACK for cmd: %s, hash: %s, args: %s", c.Name, c.Hash.string(c.Args))
+	err := s.client.AckCommand(agentID, c.Hash)
 	if err == nil {
-		s.acks[c.ID] = struct{}{}
+		s.acks[c.Hash] = struct{}{}
 	}
 	return err
 }

--- a/internal/agent/cmdchannel/service/service_test.go
+++ b/internal/agent/cmdchannel/service/service_test.go
@@ -290,7 +290,8 @@ func TestSrv_Run_HandlesRunIntegrationAndACKs(t *testing.T) {
 	{
 		"return_value": [
 			{
-				"id":   1,
+				"id":   0,
+				"hash": "xyz",
 				"name": "run_integration",
 				"arguments": {
 					"integration_name": "nri-foo"
@@ -313,8 +314,8 @@ func TestSrv_Run_HandlesRunIntegrationAndACKs(t *testing.T) {
 	req2 := <-requestsCh
 	cancel()
 
-	assert.Equal(t, http.MethodGet, req1.Method, "get-commands request is expected")
-	assert.Equal(t, http.MethodPost, req2.Method, "ack post submission is expected")
+	assert.Equal(t, http.MethodGet, req1.Method, "GET commands request is expected")
+	assert.Equal(t, http.MethodPost, req2.Method, "POST ack submission is expected")
 
 	d := <-defQueue
 	assert.Equal(t, "nri-foo", d.Name)

--- a/internal/agent/cmdchannel/stopintegration/stopintegration.go
+++ b/internal/agent/cmdchannel/stopintegration/stopintegration.go
@@ -14,6 +14,7 @@ import (
 	"github.com/newrelic/infrastructure-agent/pkg/backend/commandapi"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/stoppable"
 	"github.com/newrelic/infrastructure-agent/pkg/log"
+	"github.com/newrelic/infrastructure-agent/pkg/trace"
 	"github.com/shirou/gopsutil/process"
 )
 
@@ -27,6 +28,8 @@ func NewHandler(tracker *stoppable.Tracker, l log.Entry) *cmdchannel.CmdHandler 
 		if runtime.GOOS == "windows" {
 			return cmdchannel.ErrOSNotSupported
 		}
+
+		trace.CmdReq("stop integration request received")
 
 		var args runintegration.RunIntArgs
 		if err = json.Unmarshal(cmd.Args, &args); err != nil {

--- a/pkg/backend/commandapi/client.go
+++ b/pkg/backend/commandapi/client.go
@@ -15,11 +15,12 @@ import (
 
 type Client interface {
 	GetCommands(agentID entity.ID) ([]Command, error)
-	AckCommand(agentID entity.ID, cmdID int) error
+	AckCommand(agentID entity.ID, cmdHash string) error
 }
 
 type Command struct {
 	ID   int             `json:"id"`
+	Hash string          `json:"hash"`
 	Name string          `json:"name"`
 	Args json.RawMessage `json:"arguments"`
 }
@@ -67,8 +68,8 @@ func (c *client) GetCommands(agentID entity.ID) ([]Command, error) {
 	return unmarshalCmdChannelPayload(body)
 }
 
-func (c *client) AckCommand(agentID entity.ID, cmdID int) error {
-	payload := strings.NewReader(fmt.Sprintf(`{ "id": %d, "name": "ack" }`, cmdID))
+func (c *client) AckCommand(agentID entity.ID, cmdHash string) error {
+	payload := strings.NewReader(fmt.Sprintf(`{ "hash": "%s", "name": "ack" }`, cmdHash))
 
 	req, err := http.NewRequest("POST", c.svcURL, payload)
 	if err != nil {

--- a/pkg/backend/commandapi/client_test.go
+++ b/pkg/backend/commandapi/client_test.go
@@ -15,7 +15,7 @@ const serializedCmds = `
 	{
 		"return_value": [
 			{
-				"id": 0,
+				"hash": "xyz",
 				"name": "set_feature_flag",
 				"arguments": {
 					"category": "Infra_Agent",
@@ -24,7 +24,7 @@ const serializedCmds = `
 				}
 			},
 			{
-				"id": 0,
+				"hash": "xyz",
 				"name": "backoff_command_channel",
 				"arguments": {
 					"delay": 3000
@@ -55,7 +55,7 @@ func TestClient_AckCommand(t *testing.T) {
 	type testCase struct {
 		name          string
 		agentID       entity.ID
-		cmdID         int
+		cmdHash       string
 		expectErr     bool
 		expectPayload string
 		client        *commandapitest.HttpClient
@@ -64,49 +64,49 @@ func TestClient_AckCommand(t *testing.T) {
 		{
 			"empty IDs",
 			entity.EmptyID,
-			0,
+			"0",
 			false,
-			`{"id":0,"name":"ack"}`,
+			`{"hash":"0","name":"ack"}`,
 			commandapitest.ClientReturns(200, serializedCmds, nil),
 		},
 		{
 			"empty agent ID",
 			entity.EmptyID,
-			1,
+			"1",
 			false,
-			`{"id":1,"name":"ack"}`,
+			`{"hash":"1","name":"ack"}`,
 			commandapitest.ClientReturns(200, serializedCmds, nil),
 		},
 		{
 			"empty cmd ID",
 			1,
-			0,
+			"0",
 			false,
-			`{"id":0,"name":"ack"}`,
+			`{"hash":"0","name":"ack"}`,
 			commandapitest.ClientReturns(200, serializedCmds, nil),
 		},
 		{
 			"happy path",
 			1,
-			1,
+			"1",
 			false,
-			`{"id":1,"name":"ack"}`,
+			`{"hash":"1","name":"ack"}`,
 			commandapitest.ClientReturns(200, serializedCmds, nil),
 		},
 		{
 			"http client returns 500",
 			1,
-			1,
+			"1",
 			true,
-			`{"id":1,"name":"ack"}`,
+			`{"hash":"1","name":"ack"}`,
 			commandapitest.ClientReturns(500, "", nil),
 		},
 		{
 			"http client returns error",
 			1,
-			123,
+			"123",
 			true,
-			`{"id":123,"name":"ack"}`,
+			`{"hash":"123","name":"ack"}`,
 			commandapitest.ClientReturns(200, "", errors.New("foo")),
 		},
 	}
@@ -114,7 +114,7 @@ func TestClient_AckCommand(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			client := NewClient("https://foo", "123", "Agent v0", tc.client.Do)
 
-			err := client.AckCommand(tc.agentID, tc.cmdID)
+			err := client.AckCommand(tc.agentID, tc.cmdHash)
 
 			if tc.expectErr {
 				assert.Error(t, err)


### PR DESCRIPTION
- replace ACK mechanism from ID (int) to Hash (string)
- ACK every time hash is received (not just once)
- for cmds with hash, run only those which weren't already successfully ACKed