### PR TITLE
[LOGGING-2544] Removes deprecated folder parameter

### DIFF
--- a/pkg/integrations/v4/logs/cfg_test.go
+++ b/pkg/integrations/v4/logs/cfg_test.go
@@ -5,7 +5,6 @@ package logs
 import (
 	"github.com/newrelic/infrastructure-agent/pkg/config"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -140,37 +139,6 @@ func TestNewFBConf(t *testing.T) {
 					Name:  "grep",
 					Match: "some_system",
 					Regex: "MESSAGE foo",
-				},
-				parserEntityBlock,
-			},
-			Output: outputBlock,
-		}},
-		{"input folder with files", LogsCfg{
-			{
-				Name:      "some-folder",
-				Folder:    "/path/to/folder",
-				MaxLineKb: 32,
-				Pattern:   "foo",
-			},
-		}, FBCfg{
-			Inputs: []FBCfgInput{
-				{
-					Name: "tail",
-					Tag:  "some-folder",
-					DB:   dbDbPath,
-					// filepath.Join used here as the test outputs the result as \path\to\folder\* when executing on Windows
-					Path:          filepath.Join("/path/to/folder", "*"),
-					BufferMaxSize: "32k",
-					SkipLongLines: "On",
-					PathKey:       "filePath",
-				},
-			},
-			Parsers: []FBCfgParser{
-				inputRecordModifier("tail", "some-folder"),
-				{
-					Name:  "grep",
-					Match: "some-folder",
-					Regex: "log foo",
 				},
 				parserEntityBlock,
 			},

--- a/pkg/integrations/v4/logs/loader_test.go
+++ b/pkg/integrations/v4/logs/loader_test.go
@@ -222,18 +222,6 @@ logs:
 		},
 	}
 
-	ymlWithFolder := []byte(`
-logs:
-  - name: baz
-    folder: /folder
-`)
-	structWithFolder := LogsCfg{
-		{
-			Name:   "baz",
-			Folder: "/folder",
-		},
-	}
-
 	ymlInvalid := []byte(`
 nooo:
   - name: fuuu
@@ -381,7 +369,6 @@ logs:
 		{"empty file", []byte{}, nil, nil},
 		{"input with file", ymlWithFile, structWithFile, nil},
 		{"input with systemd and grep", ymlWithSystemd, structWithSystemd, nil},
-		{"input with folder", ymlWithFolder, structWithFolder, nil},
 		{"input invalid", ymlInvalid, nil, nil},
 		{"input partially invalid", ymlPartiallyInvalid, nil, nil},
 		{"file with attributes", ymlWithAttributes, structWithAttributes, nil},


### PR DESCRIPTION
Removes deprecated "folder" parameter from the Log Forwarder integration. This parameter was originally included during the beta phase, but was later removed when we discovered that we could use wildcards when specifying a file path in FluentBit.