### PR TITLE
docs: fix repolinter issues

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,0 @@
-### Hello! We're glad you've joined us. 
-
-We believe participation in our community should be a harassment free experience for everyone. 
-
-Learn more about our guidelines and principles by reading our [Code of Conduct](https://opensource.newrelic.com/code-of-conduct/) on our Open Source Website. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
 # Contributing
 
 Contributions are always welcome. Before contributing please read the
-[code of conduct](./CODE_OF_CONDUCT.md) and [search the issue tracker](issues); your issue may have already been discussed or fixed in `main`. To contribute,
+[code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md) and [search the issue tracker](issues); your issue may have already been discussed or fixed in `main`. To contribute,
 [fork](https://help.github.com/articles/fork-a-repo/) this repository, commit your changes, and [send a Pull Request](https://help.github.com/articles/using-pull-requests/).
 
-Note that our [code of conduct](./CODE_OF_CONDUCT.md) applies to all platforms and venues related to this project; please follow it in all your interactions with the project and its participants.
+Note that our [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md) applies to all platforms and venues related to this project; please follow it in all your interactions with the project and its participants.
 
 ## Feature Requests
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![New Relic Community Plus header](https://raw.githubusercontent.com/newrelic/open-source-office/master/examples/categories/images/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
+[![Community Plus header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
 
 # New Relic infrastructure agent
 
@@ -7,16 +7,18 @@ The infrastructure agent (infra-agent) collects inventory data and metrics of yo
 [New Relic's infrastructure monitoring](https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/get-started/introduction-new-relic-infrastructure) provides flexible,
 dynamic monitoring of your entire infrastructure, from services running in the cloud or on dedicated hosts to containers running in orchestrated environments.
 
-* [Compatibility and requirements](#compatibility-and-requirements)
-* [Compile and build the agent](#compile-and-build-the-agent)
-* [Run the agent](#run-the-agent)
-* [Use the agent](#use-the-agent)
-* [Testing](#testing)
-* [Documentation](#docs)
-* [Support](#support)
-* [Contribute](#contribute)
-* [To-do](#to-do)
-* [License](#license)
+- [Compatibility and requirements](#compatibility-and-requirements)
+  - [Set up your license key](#set-up-your-license-key)
+- [Compile and build the agent](#compile-and-build-the-agent)
+- [Run the agent](#run-the-agent)
+- [Use the agent](#use-the-agent)
+- [Testing](#testing)
+- [Documentation](#documentation)
+- [To do](#to-do)
+- [Support](#support)
+- [Privacy](#privacy)
+- [Contribute](#contribute)
+- [License](#license)
 
 ## Compatibility and requirements
 


### PR DESCRIPTION
This PR closes https://github.com/newrelic/infrastructure-agent/issues/85 by removing the `CODE_OF_CONDUCT` file and updating the `README` header to point to the correct image.