### PR TITLE
feat: add fedramp flag & remove gov license prefix

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1043,6 +1043,7 @@ type LogForward struct {
 	ConfigsDir   string
 	HomeDir      string
 	License      string
+	IsFedramp    bool
 	IsStaging    bool
 	ProxyCfg     LogForwardProxy
 }
@@ -1062,6 +1063,7 @@ func NewLogForward(config *Config, troubleshoot Troubleshoot) LogForward {
 		ConfigsDir:   config.LoggingConfigsDir,
 		HomeDir:      config.LoggingBinDir,
 		License:      config.License,
+		IsFedramp:    config.Fedramp,
 		IsStaging:    config.Staging,
 		ProxyCfg: LogForwardProxy{
 			IgnoreSystemProxy: config.IgnoreSystemProxy,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -351,21 +351,22 @@ func (s *ConfigSuite) TestCalculateCollectorURL(c *C) {
 		license   string
 		expectURL string
 		staging   bool
+		fedramp   bool
 	}{
 		// non-region license, staging false
-		{license: "0123456789012345678901234567890123456789", expectURL: "https://infra-api.newrelic.com", staging: false},
+		{license: "0123456789012345678901234567890123456789", expectURL: "https://infra-api.newrelic.com", staging: false, fedramp: false},
 		// non-region license, staging true
-		{license: "0123456789012345678901234567890123456789", expectURL: "https://staging-infra-api.newrelic.com", staging: true},
+		{license: "0123456789012345678901234567890123456789", expectURL: "https://staging-infra-api.newrelic.com", staging: true, fedramp: false},
 		// four letter region
-		{license: "eu01xx6789012345678901234567890123456789", expectURL: "https://infra-api.eu.newrelic.com", staging: false},
+		{license: "eu01xx6789012345678901234567890123456789", expectURL: "https://infra-api.eu.newrelic.com", staging: false, fedramp: false},
 		// four letter region
-		{license: "eu01xx6789012345678901234567890123456789", expectURL: "https://staging-infra-api.eu.newrelic.com", staging: true},
-		//// five letter region
-		{license: "gov01x6789012345678901234567890123456789", expectURL: "https://gov-infra-api.newrelic.com", staging: true},
+		{license: "eu01xx6789012345678901234567890123456789", expectURL: "https://staging-infra-api.eu.newrelic.com", staging: true, fedramp: false},
+		// non-region license, fedramp true
+		{license: "0123456789012345678901234567890123456789", expectURL: "https://gov-infra-api.newrelic.com", staging: false, fedramp: true},
 	}
 
 	for _, tc := range testcases {
-		u := calculateCollectorURL(tc.license, tc.staging)
+		u := calculateCollectorURL(tc.license, tc.staging, tc.fedramp)
 		c.Assert(u, Equals, tc.expectURL)
 	}
 }
@@ -376,12 +377,14 @@ func (s *ConfigSuite) TestCalculateDimensionalMetricURL(c *C) {
 		license      string
 		collectorURL string
 		staging      bool
+		fedramp      bool
 		want         string
 	}{
 		{
 			"Default URL, no region license, no collector URL",
 			"0123456789012345678901234567890123456789",
 			"",
+			false,
 			false,
 			"https://metric-api.newrelic.com",
 		},
@@ -390,12 +393,14 @@ func (s *ConfigSuite) TestCalculateDimensionalMetricURL(c *C) {
 			"0123456789012345678901234567890123456789",
 			"",
 			true,
+			false,
 			"https://staging-metric-api.newrelic.com",
 		},
 		{
 			"Default URL, eu license region, no collector URL",
 			"eu01xx6789012345678901234567890123456789",
 			"",
+			false,
 			false,
 			"https://metric-api.eu.newrelic.com",
 		},
@@ -404,26 +409,29 @@ func (s *ConfigSuite) TestCalculateDimensionalMetricURL(c *C) {
 			"eu01xx6789012345678901234567890123456789",
 			"",
 			true,
+			false,
 			"https://staging-metric-api.eu.newrelic.com",
 		},
 		{
-			"Default URL, gov license region, no collector URL",
-			"gov01xx6789012345678901234567890123456789",
+			"Default URL, fedramp flag, no collector URL",
+			"0123456789012345678901234567890123456789",
 			"",
+			false,
 			true,
 			"https://gov-infra-api.newrelic.com",
 		},
 		{
-			"From Collector URL",
-			"gov01x6789012345678901234567890123456789",
-			"https://metric-api.test",
+			"Staging flag prevails over fedramp one",
+			"0123456789012345678901234567890123456789",
+			"",
 			true,
-			"https://metric-api.test",
+			true,
+			"https://staging-metric-api.newrelic.com",
 		},
 	}
 
 	for _, tc := range testCases {
-		u := calculateDimensionalMetricURL(tc.collectorURL, tc.license, tc.staging)
+		u := calculateDimensionalMetricURL(tc.collectorURL, tc.license, tc.staging, tc.fedramp)
 		c.Assert(u, Equals, tc.want)
 	}
 }

--- a/pkg/integrations/v4/logs/cfg.go
+++ b/pkg/integrations/v4/logs/cfg.go
@@ -22,6 +22,7 @@ var cfgLogger = log.WithComponent("integrations.Supervisor.Config").WithField("p
 // FluentBit default values.
 const (
 	euEndpoint              = "https://log-api.eu.newrelic.com/log/v1"
+	fedrampEndpoint         = "https://gov-log-api.newrelic.com"
 	stagingEndpoint         = "https://staging-log-api.newrelic.com/log/v1"
 	logRecordModifierSource = "nri-agent"
 	defaultBufferMaxSize    = 128
@@ -610,6 +611,10 @@ func newNROutput(cfg *config.LogForward) FBCfgOutput {
 		CABundleFile:      cfg.ProxyCfg.CABundleFile,
 		CABundleDir:       cfg.ProxyCfg.CABundleDir,
 		ValidateCerts:     cfg.ProxyCfg.ValidateCerts,
+	}
+
+	if cfg.IsFedramp {
+		ret.Endpoint = fedrampEndpoint
 	}
 
 	if cfg.IsStaging {

--- a/pkg/integrations/v4/logs/cfg.go
+++ b/pkg/integrations/v4/logs/cfg.go
@@ -613,12 +613,12 @@ func newNROutput(cfg *config.LogForward) FBCfgOutput {
 		ValidateCerts:     cfg.ProxyCfg.ValidateCerts,
 	}
 
-	if cfg.IsFedramp {
-		ret.Endpoint = fedrampEndpoint
-	}
-
 	if cfg.IsStaging {
 		ret.Endpoint = stagingEndpoint
+	}
+
+	if cfg.IsFedramp {
+		ret.Endpoint = fedrampEndpoint
 	}
 
 	if license.IsRegionEU(cfg.License) {

--- a/pkg/license/license_test.go
+++ b/pkg/license/license_test.go
@@ -6,21 +6,9 @@ import (
 )
 
 const (
-	basic   = "0123456789012345678901234567890123456789"
-	eu      = "eu01xx6789012345678901234567890123456789"
-	federal = "gov01x6789012345678901234567890123456789"
+	basic = "0123456789012345678901234567890123456789"
+	eu    = "eu01xx6789012345678901234567890123456789"
 )
-
-func TestLicense_IsFederalCompliance(t *testing.T) {
-	isFed := IsFederalCompliance(basic)
-	assert.Equal(t, isFed, false)
-
-	isFed = IsFederalCompliance(eu)
-	assert.Equal(t, isFed, false)
-
-	isFed = IsFederalCompliance(federal)
-	assert.Equal(t, isFed, true)
-}
 
 func TestLicense_GetRegion(t *testing.T) {
 	region := GetRegion(basic)
@@ -28,7 +16,4 @@ func TestLicense_GetRegion(t *testing.T) {
 
 	region = GetRegion(eu)
 	assert.Equal(t, region, "eu")
-
-	region = GetRegion(federal)
-	assert.Equal(t, region, "gov")
 }


### PR DESCRIPTION
- Adds `fedramp: true` flag.
- Removes `gov` license key prefix handling, as there are no such prefixes.

Details on endpoints: https://docs.newrelic.com/docs/security/security-privacy/compliance/fedramp-compliant-endpoints

Solves https://github.com/newrelic/infrastructure-agent/issues/278