### PR TITLE
feat: deployment experience integration allow list for cmd API

### DIFF
--- a/internal/agent/cmdchannel/runintegration/runintegration.go
+++ b/internal/agent/cmdchannel/runintegration/runintegration.go
@@ -28,7 +28,7 @@ const cmdName = "run_integration"
 // Errors
 var (
 	ErrNoIntName     = errors.New("missing required \"integration_name\"")
-	ErrIntNotAllowed = errors.New("integration now allowed to run/stop from command channel")
+	ErrIntNotAllowed = errors.New("integration not allowed to run/stop from command channel")
 )
 
 type RunIntArgs struct {

--- a/internal/agent/cmdchannel/runintegration/runintegration.go
+++ b/internal/agent/cmdchannel/runintegration/runintegration.go
@@ -14,6 +14,7 @@ import (
 	"github.com/newrelic/infrastructure-agent/internal/integrations/v4/integration"
 	"github.com/newrelic/infrastructure-agent/pkg/backend/commandapi"
 	"github.com/newrelic/infrastructure-agent/pkg/fwrequest"
+	"github.com/newrelic/infrastructure-agent/pkg/integrations/cmdapi"
 	ctx2 "github.com/newrelic/infrastructure-agent/pkg/integrations/track/ctx"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/v4/config"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/v4/dm"
@@ -26,7 +27,8 @@ const cmdName = "run_integration"
 
 // Errors
 var (
-	ErrNoIntName = errors.New("missing required \"integration_name\"")
+	ErrNoIntName     = errors.New("missing required \"integration_name\"")
+	ErrIntNotAllowed = errors.New("integration now allowed to run/stop from command channel")
 )
 
 type RunIntArgs struct {
@@ -52,6 +54,10 @@ func NewHandler(definitionQ chan<- integration.Definition, il integration.Instan
 		if args.IntegrationName == "" {
 			err = cmdchannel.NewArgsErr(ErrNoIntName)
 			return
+		}
+
+		if cmdapi.IsAllowedToRunStopFromCmdAPI(args.IntegrationName) {
+			return ErrIntNotAllowed
 		}
 
 		def, err := integration.NewDefinition(NewConfigFromCmdChannelRunInt(args), il, nil, nil)

--- a/internal/agent/cmdchannel/stopintegration/stopintegration.go
+++ b/internal/agent/cmdchannel/stopintegration/stopintegration.go
@@ -12,6 +12,7 @@ import (
 	"github.com/newrelic/infrastructure-agent/internal/agent/cmdchannel/runintegration"
 	"github.com/newrelic/infrastructure-agent/internal/integrations/v4/integration"
 	"github.com/newrelic/infrastructure-agent/pkg/backend/commandapi"
+	"github.com/newrelic/infrastructure-agent/pkg/integrations/cmdapi"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/track"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/track/ctx"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/v4/dm"
@@ -43,6 +44,10 @@ func NewHandler(tracker *track.Tracker, il integration.InstancesLookup, dmEmitte
 		if args.IntegrationName == "" {
 			err = cmdchannel.NewArgsErr(runintegration.ErrNoIntName)
 			return
+		}
+
+		if cmdapi.IsAllowedToRunStopFromCmdAPI(args.IntegrationName) {
+			return runintegration.ErrIntNotAllowed
 		}
 
 		pidC, tracked := tracker.PIDReadChan(args.Hash())

--- a/pkg/integrations/cmdapi/cmdapi.go
+++ b/pkg/integrations/cmdapi/cmdapi.go
@@ -1,0 +1,13 @@
+package cmdapi
+
+var (
+	integrationsAllowedToRunStopFromCmdAPI = map[string]struct{}{
+		"nri-lsi-java": {},
+	}
+)
+
+func IsAllowedToRunStopFromCmdAPI(integrationName string) bool {
+	_, ok := integrationsAllowedToRunStopFromCmdAPI[integrationName]
+
+	return ok
+}

--- a/pkg/integrations/cmdapi/cmdapi.go
+++ b/pkg/integrations/cmdapi/cmdapi.go
@@ -2,7 +2,8 @@ package cmdapi
 
 var (
 	integrationsAllowedToRunStopFromCmdAPI = map[string]struct{}{
-		"nri-lsi-java": {},
+		"nri-lsi-java":         {},
+		"nri-process-detector": {},
 	}
 )
 

--- a/pkg/integrations/cmdapi/cmdapi_test.go
+++ b/pkg/integrations/cmdapi/cmdapi_test.go
@@ -1,0 +1,25 @@
+package cmdapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsAllowedToRunStopFromCmdAPI(t *testing.T) {
+	tests := []struct {
+		name            string
+		integrationName string
+		want            bool
+	}{
+		{"empty", "", false},
+		{"allowed", "nri-lsi-java", true},
+		{"not allowed", "", false},
+		{"extra suffix", "nri-lsi-java-foo", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsAllowedToRunStopFromCmdAPI(tt.integrationName))
+		})
+	}
+}

--- a/pkg/integrations/cmdapi/cmdapi_test.go
+++ b/pkg/integrations/cmdapi/cmdapi_test.go
@@ -13,7 +13,8 @@ func TestIsAllowedToRunStopFromCmdAPI(t *testing.T) {
 		want            bool
 	}{
 		{"empty", "", false},
-		{"allowed", "nri-lsi-java", true},
+		{"allowed 1", "nri-process-detector", true},
+		{"allowed 2", "nri-lsi-java", true},
 		{"not allowed", "nri-foo", false},
 		{"extra suffix", "nri-lsi-java-foo", false},
 	}

--- a/pkg/integrations/cmdapi/cmdapi_test.go
+++ b/pkg/integrations/cmdapi/cmdapi_test.go
@@ -14,7 +14,7 @@ func TestIsAllowedToRunStopFromCmdAPI(t *testing.T) {
 	}{
 		{"empty", "", false},
 		{"allowed", "nri-lsi-java", true},
-		{"not allowed", "", false},
+		{"not allowed", "nri-foo", false},
 		{"extra suffix", "nri-lsi-java-foo", false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
For security reasons, command channel won't allow arbitrary integration executions. These ones should be listed in the allow-list.