### PR TITLE
fix: service binary version info

### DIFF
--- a/cmd/newrelic-infra-service/newrelic-infra-service.go
+++ b/cmd/newrelic-infra-service/newrelic-infra-service.go
@@ -1,5 +1,7 @@
 // Copyright 2020 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+//go:generate goversioninfo
+
 package main
 
 import (


### PR DESCRIPTION
Missing Windows version info for the service binary.

Required for https://github.com/newrelic/infrastructure-agent/pull/282/files#diff-0b1289ef866dadf79c60612a2c21e5bba3dc7d123136b4e97d547f5b899da075R36