### PR TITLE
fix: RemoveYAMLComments considering hashtag within strings as comment

### DIFF
--- a/pkg/config/envvar/envvar.go
+++ b/pkg/config/envvar/envvar.go
@@ -11,7 +11,7 @@ import (
 )
 
 func ExpandInContent(content []byte) ([]byte, error) {
-	content, err := RemoveYAMLComments(content)
+	content, err := removeYAMLComments(content)
 	if err != nil {
 		return nil, fmt.Errorf("cannot remove configuration commented lines, error: %w", err)
 	}
@@ -49,13 +49,13 @@ func ExpandInContent(content []byte) ([]byte, error) {
 	return newContent, nil
 }
 
-// RemoveYAMLComments removes comments from YAML content
+// removeYAMLComments removes comments from YAML content
 // golang does not support negative lookaheads
 // there's an alternative library https://github.com/dlclark/regexp2 but here we stick to stdlib
 // for this reason it's required:
 // - several regexes
 // - several capture groups that will be discarded
-func RemoveYAMLComments(content []byte) ([]byte, error) {
+func removeYAMLComments(content []byte) ([]byte, error) {
 	rLines := regexp.MustCompile(`(?m:^[ \t]*#.*\n)`) // ?m: = multiline flag
 	matches := rLines.FindAllIndex(content, -1)
 

--- a/pkg/config/envvar/envvar_test.go
+++ b/pkg/config/envvar/envvar_test.go
@@ -52,7 +52,7 @@ func TestExpandInContent(t *testing.T) {
 	}
 }
 
-func TestRemoveYAMLComments(t *testing.T) {
+func Test_removeYAMLComments(t *testing.T) {
 	noComments := `integration_name: com.newrelic.mysql
 	
 	instances:
@@ -72,7 +72,7 @@ instances:
      k5: "f#oo"# comment
      k6: "f#oo" # comment
      k7: "foo"# comment "foo"
-     k8: "87l#154NUp"
+     k8: "foo#bar"
      k9: ["foo#bar", "baz" ]  # another inline comment
      q1: 'foo' # comment
      q2: 'foo'# comment
@@ -80,7 +80,7 @@ instances:
      q4: 'f#oo'# comment
      q5: 'f#oo' # comment
      q6: 'foo'# comment "foo"
-     q7: '87l#154NUp'
+     q7: 'foo#bar'
      q8: ['foo#bar', 'baz' ]  # another inline comment
      # some comments
      # some comments
@@ -101,7 +101,7 @@ instances:
      k5: "f#oo"
      k6: "f#oo" 
      k7: "foo"
-     k8: "87l#154NUp"
+     k8: "foo#bar"
      k9: ["foo#bar", "baz" ]  
      q1: 'foo' 
      q2: 'foo'
@@ -109,7 +109,7 @@ instances:
      q4: 'f#oo'
      q5: 'f#oo' 
      q6: 'foo'
-     q7: '87l#154NUp'
+     q7: 'foo#bar'
      q8: ['foo#bar', 'baz' ]  
     labels:
       foo: bar
@@ -127,7 +127,7 @@ instances:
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := RemoveYAMLComments([]byte(tt.content))
+			got, err := removeYAMLComments([]byte(tt.content))
 			assert.Equal(t, tt.want, string(got))
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/pkg/config/envvar/envvar_test.go
+++ b/pkg/config/envvar/envvar_test.go
@@ -34,7 +34,7 @@ func TestExpandInContent(t *testing.T) {
 		{"1 placeholder within comment lines are stripped", emptyEnv, "#foo: {{BAR}}\nbaz", "baz", false},
 		{"comment lines starting with spaces are stripped", emptyEnv, "  #foo: {{BAR}}\nbaz", "baz", false},
 		{"comment lines starting with tab are stripped", emptyEnv, "\t #foo: {{BAR}}\nbaz", "baz", false},
-		{"comment part of the line is dropped while previous content is kept", emptyEnv, "foo: bar # {{BAR}}\nbaz", "foo: bar\nbaz", false},
+		{"comment part of the line is dropped while previous content is kept", emptyEnv, "foo: bar # {{BAR}}\nbaz", "foo: bar \nbaz", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -48,6 +48,92 @@ func TestExpandInContent(t *testing.T) {
 				require.NoError(t, gotErr)
 			}
 			assert.Equal(t, tt.want, string(gotContent))
+		})
+	}
+}
+
+func TestRemoveYAMLComments(t *testing.T) {
+	noComments := `integration_name: com.newrelic.mysql
+	
+	instances:
+	- name: foo-bar
+	`
+	comments := `integration_name: com.newrelic.mysql
+
+instances:
+  - name: foo
+    command: bar
+    arguments:
+     k0: foo # comment
+     k1: foo # comment
+     k2: "foo" # comment
+     k3: "foo"# comment
+     k4: "foo" # comment
+     k5: "f#oo"# comment
+     k6: "f#oo" # comment
+     k7: "foo"# comment "foo"
+     k8: "87l#154NUp"
+     k9: ["foo#bar", "baz" ]  # another inline comment
+     q1: 'foo' # comment
+     q2: 'foo'# comment
+     q3: 'foo' # comment
+     q4: 'f#oo'# comment
+     q5: 'f#oo' # comment
+     q6: 'foo'# comment "foo"
+     q7: '87l#154NUp'
+     q8: ['foo#bar', 'baz' ]  # another inline comment
+     # some comments
+     # some comments
+    labels:
+      foo: bar
+`
+	commentsStripped := `integration_name: com.newrelic.mysql
+
+instances:
+  - name: foo
+    command: bar
+    arguments:
+     k0: foo 
+     k1: foo 
+     k2: "foo" 
+     k3: "foo"
+     k4: "foo" 
+     k5: "f#oo"
+     k6: "f#oo" 
+     k7: "foo"
+     k8: "87l#154NUp"
+     k9: ["foo#bar", "baz" ]  
+     q1: 'foo' 
+     q2: 'foo'
+     q3: 'foo' 
+     q4: 'f#oo'
+     q5: 'f#oo' 
+     q6: 'foo'
+     q7: '87l#154NUp'
+     q8: ['foo#bar', 'baz' ]  
+    labels:
+      foo: bar
+`
+
+	tests := []struct {
+		name    string
+		content string
+		want    string
+		wantErr bool
+	}{
+		{"empty", ``, ``, false},
+		{"no comments", noComments, noComments, false},
+		{"comments", comments, commentsStripped, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := RemoveYAMLComments([]byte(tt.content))
+			assert.Equal(t, tt.want, string(got))
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/pkg/integrations/legacy/registry.go
+++ b/pkg/integrations/legacy/registry.go
@@ -100,7 +100,7 @@ func (pr *PluginRegistry) loadPluginInstance(dir string, dirOrFile os.FileInfo) 
 	pflog.Debug("Found integration config file.")
 	instanceWrapper, err := loadPluginInstanceWrapper(dirOrFilePath)
 	if err != nil {
-		pflog.Error("cannot load integration config file")
+		pflog.WithError(err).Error("cannot load integration config file")
 		return
 	}
 


### PR DESCRIPTION
RemoveYAMLComments considering hashtag within strings as comment.

Golang does not support negative lookaheads https://github.com/golang/go/issues/18868
There's an alternative library https://github.com/dlclark/regexp2 but here we are sticking to stdlib.
For this reason it's required:
 - several regexes
 - several capture groups that will be discarded
 
 We are not trimming whitespaces for simplicity.

---

This also logs the (previously shadowed) original error on config error.