### PR TITLE
resume default network filter on testing

### DIFF
--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -33,8 +33,7 @@ func init() {
 	defaultAgentDir = filepath.Join("/var", "db", "newrelic-infra")
 	defaultLogFile = filepath.Join("/var", "db", "newrelic-infra", "newrelic-infra.log")
 	defaultNetworkInterfaceFilters = map[string][]string{
-		"prefix":  {"dummy", "lo", "vmnet", "sit", "tun", "tap", "veth"},
-		"index-1": {"tun", "tap"},
+		"prefix": {"dummy", "lo", "vmnet", "sit", "tun", "tap", "veth"},
 	}
 
 	defaultLoggingBinDir = "logging"


### PR DESCRIPTION
### Problem
Motivate by build [failing](https://github.com/newrelic/infrastructure-agent/runs/1870008741?check_suite_focus=true#step:5:159) on GHA centos5. 

### Explanation
We use go1.9.4 version to run centos-5 tests. maps are printed in randomly what cause random failures on test assertion between expected and actual value.

### Proposed 'solution'
Since testconfig.go is checking that configurations are well in place, with only one index in map for ```NetworkInterfaceFilters``` is enough to pass acceptance and criteria.
