### PR TITLE
Update logging download urls

### DIFF
--- a/assets/examples/logging/parsers.conf
+++ b/assets/examples/logging/parsers.conf
@@ -1,0 +1,24 @@
+[PARSER]
+    Name        rfc5424
+    Format      regex
+    Regex       ^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*)\]|-)) (?<message>.+)$
+    Time_Key    time
+    Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+    Time_Keep   On
+
+[PARSER]
+    Name        rfc3164-local
+    Format      regex
+    Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
+    Time_Key    time
+    Time_Format %b %d %H:%M:%S
+    Time_Keep   On
+
+[PARSER]
+    Name        rfc3164
+    Format      regex
+    Regex       /^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
+    Time_Key    time
+    Time_Format %b %d %H:%M:%S
+    Time_Format %Y-%m-%dT%H:%M:%S.%L
+    Time_Keep   On

--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -128,11 +128,11 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-      - src: 'target/fluent-bit/nrfb/fluent-bit'
+      - src: 'target/fluent-bit/amd64/fluent-bit'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
-      - src: 'target/fluent-bit/nrfb/out_newrelic.so'
+      - src: 'target/fluent-bit-plugin/amd64/out_newrelic.so'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
-      - src: 'target/fluent-bit/nrfb/parsers.conf'
+      - src: 'assets/examples/logging/parsers.conf'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
     empty_folders:
       - /var/db/newrelic-infra/custom-integrations
@@ -213,52 +213,6 @@ nfpms:
     replaces:
       - opspro-agent
       - opspro-agent-sysv
-    # Section.
-    section: default
-    # Priority.
-    priority: extra
-
-  - id: debian-infrastructure-agent-sysv
-    builds:
-      - linux-newrelic-infra
-      - linux-newrelic-infra-ctl
-      - linux-newrelic-infra-service
-    package_name: newrelic-infra
-    file_name_template: "newrelic-infra_sysv_{{ .Env.TAG }}_{{ .Arch }}"
-    vendor: 'New Relic, Inc.'
-    homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
-    maintainer: 'caos-team@newrelic.com'
-    description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
-    formats:
-      - deb
-    bindir: /usr/bin
-    contents:
-      - src: 'build/package/sysv/deb/newrelic-infra'
-        dst: '/etc/init.d/newrelic-infra'
-      - src: 'target/nridocker/etc/newrelic-infra/integrations.d/docker-config.yml'
-        dst: '/etc/newrelic-infra/integrations.d/docker-config.yml'
-      - src: 'LICENSE'
-        dst: '/var/db/newrelic-infra/LICENSE.txt'
-      - src: 'target/nridocker/var/db/newrelic-infra/newrelic-integrations/bin/nri-docker'
-        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-docker'
-      - src: 'target/nriflex/nri-flex'
-        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
-      - src: 'target/nriprometheus/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-      - src: 'target/fluent-bit/nrfb/fluent-bit'
-        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
-      - src: 'target/fluent-bit/nrfb/out_newrelic.so'
-        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
-      - src: 'target/fluent-bit/nrfb/parsers.conf'
-        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
-
-    empty_folders:
-      - /var/db/newrelic-infra/custom-integrations
-      - /var/db/newrelic-infra/integrations.d
-      - /var/log/newrelic-infra
-      - /var/run/newrelic-infra
-
     # Section.
     section: default
     # Priority.
@@ -368,11 +322,11 @@ nfpms:
       - src: 'target/nriprometheus/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
 
-      - src: 'target/fluent-bit/nrfb/fluent-bit'
+      - src: 'target/fluent-bit/amd64/fluent-bit'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
-      - src: 'target/fluent-bit/nrfb/out_newrelic.so'
+      - src: 'target/fluent-bit-plugin/amd64/out_newrelic.so'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
-      - src: 'target/fluent-bit/nrfb/parsers.conf'
+      - src: 'assets/examples/logging/parsers.conf'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
     empty_folders:
       - /var/db/newrelic-infra/custom-integrations
@@ -445,11 +399,11 @@ nfpms:
       - src: 'target/nriprometheus/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
 
-      - src: 'target/fluent-bit/nrfb/fluent-bit'
+      - src: 'target/fluent-bit/amd64/fluent-bit'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
-      - src: 'target/fluent-bit/nrfb/out_newrelic.so'
+      - src: 'target/fluent-bit-plugin/amd64/out_newrelic.so'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
-      - src: 'target/fluent-bit/nrfb/parsers.conf'
+      - src: 'assets/examples/logging/parsers.conf'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
     empty_folders:
       - /var/db/newrelic-infra/custom-integrations
@@ -577,11 +531,11 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-      - src: 'target/fluent-bit/nrfb/fluent-bit'
+      - src: 'target/fluent-bit/amd64/fluent-bit'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
-      - src: 'target/fluent-bit/nrfb/out_newrelic.so'
+      - src: 'target/fluent-bit-plugin/amd64/out_newrelic.so'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
-      - src: 'target/fluent-bit/nrfb/parsers.conf'
+      - src: 'assets/examples/logging/parsers.conf'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
     empty_folders:
       - /var/db/newrelic-infra/custom-integrations
@@ -654,11 +608,11 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-      - src: 'target/fluent-bit/nrfb/fluent-bit'
+      - src: 'target/fluent-bit/amd64/fluent-bit'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
-      - src: 'target/fluent-bit/nrfb/out_newrelic.so'
+      - src: 'target/fluent-bit-plugin/amd64/out_newrelic.so'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
-      - src: 'target/fluent-bit/nrfb/parsers.conf'
+      - src: 'assets/examples/logging/parsers.conf'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
     empty_folders:
       - /var/db/newrelic-infra/custom-integrations
@@ -731,11 +685,11 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-      - src: 'target/fluent-bit/nrfb/fluent-bit'
+      - src: 'target/fluent-bit/amd64/fluent-bit'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
-      - src: 'target/fluent-bit/nrfb/out_newrelic.so'
+      - src: 'target/fluent-bit-plugin/amd64/out_newrelic.so'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
-      - src: 'target/fluent-bit/nrfb/parsers.conf'
+      - src: 'assets/examples/logging/parsers.conf'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
     empty_folders:
       - /var/db/newrelic-infra/custom-integrations
@@ -808,11 +762,11 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-      - src: 'target/fluent-bit/nrfb/fluent-bit'
+      - src: 'target/fluent-bit/amd64/fluent-bit'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
-      - src: 'target/fluent-bit/nrfb/out_newrelic.so'
+      - src: 'target/fluent-bit-plugin/amd64/out_newrelic.so'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
-      - src: 'target/fluent-bit/nrfb/parsers.conf'
+      - src: 'assets/examples/logging/parsers.conf'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
     empty_folders:
       - /var/db/newrelic-infra/custom-integrations

--- a/build/embed/fluent-bit.mk
+++ b/build/embed/fluent-bit.mk
@@ -11,8 +11,8 @@ NR_PLUGIN_VERSION_LINUX ?= $(call get-fb_version,linux,2)
 
 ARCH                    ?= amd64
 
-NRFB_URL                 = https://github.com/newrelic-experimental/fluent-bit-package/releases/download/$(NRFB_VERSION_LINUX)/fb-linux-amd64.tar.gz
-NR_PLUGIN_URL            = https://github.com/newrelic/newrelic-fluent-bit-output/releases/download/v$(NR_PLUGIN_VERSION_LINUX)/out_newrelic-linux-amd64-$(NR_PLUGIN_VERSION_LINUX).so
+NRFB_URL                 = https://github.com/newrelic-experimental/fluent-bit-package/releases/download/$(NRFB_VERSION_LINUX)/fb-linux-$(ARCH).tar.gz
+NR_PLUGIN_URL            = https://github.com/newrelic/newrelic-fluent-bit-output/releases/download/v$(NR_PLUGIN_VERSION_LINUX)/out_newrelic-linux-$(ARCH)-$(NR_PLUGIN_VERSION_LINUX).so
 
 .PHONY: get-fluentbit-linux
 get-fluentbit-linux:

--- a/build/embed/fluent-bit.mk
+++ b/build/embed/fluent-bit.mk
@@ -4,11 +4,15 @@ current_dir := $(patsubst %/,%,$(dir $(mkfile_path)))
 fb_version_file       ?= $(current_dir)/fluent-bit.version
 
 # The second argument $(2) specifies which column to return
-get-fb_version         = $(shell awk -v col=$(2) -F, '/^$(1),/ {print $$col}' ${fb_version_file})
+get-fb_version          = $(shell awk -v col=$(2) -F, '/^$(1),/ {print $$col}' ${fb_version_file})
 
-NRFB_ARTIFACT_VERSION_LINUX  ?= $(call get-fb_version,linux,4)
+NRFB_VERSION_LINUX      ?= $(call get-fb_version,linux,3)
+NR_PLUGIN_VERSION_LINUX ?= $(call get-fb_version,linux,2)
 
-NRI_FB_URL                    = https://download.newrelic.com/infrastructure_agent/logging/linux/nrfb-$(NRFB_ARTIFACT_VERSION_LINUX)-linux-amd64.tar.gz
+ARCH                    ?= amd64
+
+NRFB_URL                 = https://github.com/newrelic-experimental/fluent-bit-package/releases/download/$(NRFB_VERSION_LINUX)/fb-linux-amd64.tar.gz
+NR_PLUGIN_URL            = https://github.com/newrelic/newrelic-fluent-bit-output/releases/download/v$(NR_PLUGIN_VERSION_LINUX)/out_newrelic-linux-amd64-$(NR_PLUGIN_VERSION_LINUX).so
 
 .PHONY: get-fluentbit-linux
 get-fluentbit-linux:
@@ -16,11 +20,22 @@ get-fluentbit-linux:
 	@printf 'Target: download nr fluentbit for linux'
 	@printf '\n================================================================\n'
 
-	@rm -rf $(TARGET_DIR)/fluent-bit/
-	@mkdir -p $(TARGET_DIR)/fluent-bit/
-	@if curl --output /dev/null --silent --head --fail '$(NRI_FB_URL)'; then \
-		curl -L --silent '$(NRI_FB_URL)' | tar xvz --no-same-owner -C $(TARGET_DIR)/fluent-bit ;\
+	@printf '\ndownload fluent-bit\n'
+	@rm -rf $(TARGET_DIR)/fluent-bit/$(ARCH)/
+	@mkdir -p $(TARGET_DIR)/fluent-bit/$(ARCH)/
+	@if curl --output /dev/null --silent --head --fail '$(NRFB_URL)'; then \
+		curl -L --silent '$(NRFB_URL)' | tar xvz --no-same-owner -C $(TARGET_DIR)/fluent-bit/$(ARCH) ;\
 	else \
-	  echo 'nrfb version $(NRI_FB_URL) URL does not exist: $(NRI_FB_URL)' ;\
+	  echo 'nrfb version $(NRFB_VERSION_LINUX) URL does not exist: $(NRFB_URL)' ;\
+	  exit 1 ;\
+	fi
+
+	@printf '\ndownload fluent-bit nr plugin\n'
+	@rm -rf $(TARGET_DIR)/fluent-bit-plugin/$(ARCH)/
+	@mkdir -p $(TARGET_DIR)/fluent-bit-plugin/$(ARCH)/
+	@if curl --output /dev/null --silent --head --fail '$(NR_PLUGIN_URL)'; then \
+		curl -L --silent '$(NR_PLUGIN_URL)' --output $(TARGET_DIR)/fluent-bit-plugin/$(ARCH)/out_newrelic.so ;\
+	else \
+	  echo 'nr plugin version $(NR_PLUGIN_VERSION_LINUX) URL does not exist: $(NR_PLUGIN_URL)' ;\
 	  exit 1 ;\
 	fi

--- a/build/embed/fluent-bit.version
+++ b/build/embed/fluent-bit.version
@@ -1,11 +1,8 @@
 ####
-#
-# fluentbit_version       - https://docs.fluentbit.io/manual/installation/linux
-#                         - https://docs.fluentbit.io/manual/installation/windows
 # newrelic_plugin_version - https://github.com/newrelic/newrelic-fluent-bit-output/releases
 #
-# nrfb_artifact_version   - https://artifacts.datanerd.us/webapp/#/artifacts/browse/tree/General/ohai-repo/logging
+# nrfb_artifact_version   - https://github.com/newrelic-experimental/fluent-bit-package/releases
 #
-# OS,fluentbit_version,newrelic_plugin_version,nrfb_artifact_version
-linux,1.6.3,1.4.3,1.4.0
-windows,1.6.3,1.4.3,1.4.0
+# OS,newrelic_plugin_version,nrfb_artifact_version
+linux,1.4.6,1.4.1
+windows,1.4.6,1.4.1

--- a/build/package/windows/newrelic-infra-386-installer/newrelic-infra/Product.wxs
+++ b/build/package/windows/newrelic-infra-386-installer/newrelic-infra/Product.wxs
@@ -211,7 +211,7 @@
         </Component>
         <Component Id="CMP_NR_LOGGING_TOOL_PARSERS" Guid="34BF1E45-4AC5-45C4-AB80-D7C457A9B601" Win64="no">
           <File Id="FILE_NR_LOGGING_TOOL_PARSERS"
-              Source="$(var.EmbedBinariesPath)logging\nrfb\parsers.conf"
+              Source="$(var.ExternalFilesPath)examples\logging\parsers.conf"
                 KeyPath="yes" />
         </Component>
     </ComponentGroup>

--- a/build/package/windows/newrelic-infra-amd64-installer/newrelic-infra/Product.wxs
+++ b/build/package/windows/newrelic-infra-amd64-installer/newrelic-infra/Product.wxs
@@ -194,7 +194,7 @@
         </Component>
         <Component Id="CMP_NR_LOGGING_TOOL_PARSERS" Guid="34BF1E45-4AC5-45C4-AB80-D7C457A9B601" Win64="yes">
           <File Id="FILE_NR_LOGGING_TOOL_PARSERS"
-              Source="$(var.EmbedBinariesPath)logging\nrfb\parsers.conf"
+              Source="$(var.ExternalFilesPath)examples\logging\parsers.conf"
                 KeyPath="yes" />
         </Component>
     </ComponentGroup>

--- a/build/windows/scripts/embed_ohis.ps1
+++ b/build/windows/scripts/embed_ohis.ps1
@@ -74,15 +74,14 @@ Function EmbedPrometheus {
 Function EmbedFluentBit {
     Write-Output "--- Embedding fluent-bit"
 
-    $versionArray = GetFluentBitVersion
-    $pluginVersion = versionArray[0]
-    $nrfbVersion = versionArray[1]
+    $pluginVersion = GetFluentBitPluginVersion
+    $nrfbVersion = GetFluentBitVersion
 
     [string]$pluginUrl = "https://github.com/newrelic/newrelic-fluent-bit-output/releases/download/v$pluginVersion/out_newrelic-windows-$arch-$pluginVersion.dll"
-    DownloadFile -dest:"$downloadPath\logging\nrfb" -url:"$url"
+    DownloadFile -dest:"$downloadPath\logging\nrfb" -outFile:"out_newrelic.dll" -url:"$pluginUrl"
 
-    [string]$url = "https://github.com/newrelic-experimental/fluent-bit-package/releases/download/$version/fb-windows-$arch.zip"
-    DownloadAndExtractZip -dest:"$downloadPath\logging\nrfb" -url:"$url"
+    [string]$nrfbUrl = "https://github.com/newrelic-experimental/fluent-bit-package/releases/download/$nrfbVersion/fb-windows-$arch.zip"
+    DownloadAndExtractZip -dest:"$downloadPath\logging\nrfb" -url:"$nrfbUrl"
     
     if (-Not $skipSigning) {
         SignExecutable -executable "$downloadPath\logging\nrfb\fluent-bit.exe"

--- a/build/windows/scripts/embed_ohis.ps1
+++ b/build/windows/scripts/embed_ohis.ps1
@@ -25,7 +25,7 @@ Function EmbedFlex {
 
     [string]$url="https://github.com/newrelic/nri-flex/releases/download/v${version}/nri-flex_${version}_Windows_x86_64.zip"
 
-    DownloadAndExtractZip -arch:"$arch" -dest:"$downloadPath\nri-flex" -url:"$url"
+    DownloadAndExtractZip -dest:"$downloadPath\nri-flex" -url:"$url"
 
     if (-Not $skipSigning) {
         SignExecutable -executable "$downloadPath\nri-flex\nri-flex.exe"
@@ -42,7 +42,7 @@ Function EmbedWindowsServices {
 
     [string]$url="https://github.com/newrelic/nri-winservices/releases/download/${version}/${file}"
 
-    DownloadAndExtractZip -arch:"$arch" -dest:"$downloadPath\nri-winservices" -url:"$url"
+    DownloadAndExtractZip -dest:"$downloadPath\nri-winservices" -url:"$url"
 
     if (-Not $skipSigning) {
         SignExecutable -executable "$downloadPath\nri-winservices\nri-winservices.exe"
@@ -60,7 +60,7 @@ Function EmbedPrometheus {
     [string]$file="nri-prometheus-$arch.${version}.zip"
     $url="https://github.com/newrelic/nri-prometheus/releases/download/v${version}/${file}"
  
-    DownloadAndExtractZip -arch:"$arch" -dest:"$downloadPath\nri-prometheus" -url:"$url"
+    DownloadAndExtractZip -dest:"$downloadPath\nri-prometheus" -url:"$url"
 
     Copy-Item -Path "$downloadPath\nri-prometheus\New Relic\newrelic-infra\newrelic-integrations\bin\nri-prometheus.exe" -Destination "$downloadPath\nri-prometheus\nri-prometheus.exe" -Recurse -Force
     Remove-Item -Path "$downloadPath\nri-prometheus\New Relic" -Force -Recurse
@@ -74,15 +74,15 @@ Function EmbedPrometheus {
 Function EmbedFluentBit {
     Write-Output "--- Embedding fluent-bit"
 
-    $fbArch = "win64"
-    if($arch -eq "386") {
-        $fbArch = "win32"
-    }
+    $versionArray = GetFluentBitVersion
+    $pluginVersion = versionArray[0]
+    $nrfbVersion = versionArray[1]
 
-    $version = GetFluentBitVersion
-    [string]$url = "https://download.newrelic.com/infrastructure_agent/logging/windows/nrfb-$version-$fbArch.zip"
-    
-    DownloadAndExtractZip -arch:"$arch" -dest:"$downloadPath\logging" -url:"$url"
+    [string]$pluginUrl = "https://github.com/newrelic/newrelic-fluent-bit-output/releases/download/v$pluginVersion/out_newrelic-windows-$arch-$pluginVersion.dll"
+    DownloadFile -dest:"$downloadPath\logging\nrfb" -url:"$url"
+
+    [string]$url = "https://github.com/newrelic-experimental/fluent-bit-package/releases/download/$version/fb-windows-$arch.zip"
+    DownloadAndExtractZip -dest:"$downloadPath\logging\nrfb" -url:"$url"
     
     if (-Not $skipSigning) {
         SignExecutable -executable "$downloadPath\logging\nrfb\fluent-bit.exe"
@@ -98,7 +98,7 @@ Function EmbedWinpkg {
     }
 
     [string]$url = "https://download.newrelic.com/infrastructure_agent/$UrlPath"
-    DownloadAndExtractZip -arch:"$arch" -dest:"$downloadPath" -url:"$url"
+    DownloadAndExtractZip -dest:"$downloadPath" -url:"$url"
     
     if (-Not $skipSigning) {
         SignExecutable -executable "$downloadPath\winpkg\nr-winpkg.exe"


### PR DESCRIPTION
This PR will update the pipeline for building infra-agent packages to be able to download the fluent-bit component and newrelic fb output plugin from the new locations