### PR TITLE
feat(integrations): bump winService

### DIFF
--- a/build/nri-integrations
+++ b/build/nri-integrations
@@ -1,5 +1,5 @@
 #ohi-repo-name,version
 nri-docker,1.4.1
 nri-flex,1.3.10
-nri-winservices,v0.1.0-beta
+nri-winservices,v0.2.0-beta
 nri-prometheus,2.3.0


### PR DESCRIPTION
Bumping windows service version to v0.2.0-beta

https://github.com/newrelic/nri-winservices/releases/tag/v0.2.0-beta