### PR TITLE
fix(pomiURL): standardize URL

### DIFF
--- a/build/embed/integrations.mk
+++ b/build/embed/integrations.mk
@@ -24,7 +24,7 @@ NRI_FLEX_URL       ?= https://github.com/newrelic/nri-flex/releases/download/v$(
 NRI_PROMETHEUS_VERSION   ?= $(call get-nri-version,nri-prometheus)
 NRI_PROMETHEUS_ARCH      ?= $(OHI_ARCH)
 NRI_PROMETHEUS_OS        ?= $(OHI_OS)
-NRI_PROMETHEUS_URL       ?= https://github.com/newrelic/nri-prometheus/releases/download/v$(NRI_PROMETHEUS_VERSION)/nri-prometheus_$(NRI_PROMETHEUS_OS)_$(NRI_PROMETHEUS_ARCH)_$(NRI_PROMETHEUS_VERSION).tar.gz
+NRI_PROMETHEUS_URL       ?= https://github.com/newrelic/nri-prometheus/releases/download/v$(NRI_PROMETHEUS_VERSION)/nri-prometheus_$(NRI_PROMETHEUS_OS)_$(NRI_PROMETHEUS_VERSION)_$(NRI_PROMETHEUS_ARCH).tar.gz
 
 .PHONY: get-integrations
 get-integrations: get-nri-docker

--- a/build/embed/integrations.version
+++ b/build/embed/integrations.version
@@ -2,4 +2,4 @@
 nri-docker,1.6.0
 nri-flex,1.4.1
 nri-winservices,v0.2.0-beta
-nri-prometheus,2.3.0
+nri-prometheus,2.6.0


### PR DESCRIPTION
The file Structure of POMI for the tar.gz changed since it was different from all the remaining integrations.

Example https://github.com/newrelic/nri-prometheus/releases/tag/v2.6.1

 - Old 
https://github.com/newrelic/nri-prometheus/releases/download/v2.3.0/nri-prometheus_linux_amd64_2.3.0.tar.gz
 - New 
https://github.com/newrelic/nri-prometheus/releases/download/v2.6.0/nri-prometheus_linux_2.6.0_amd64.tar.gz


