### PR TITLE
feat: bump nri-docker version to v1.4.2

### DIFF
--- a/build/nri-integrations
+++ b/build/nri-integrations
@@ -1,5 +1,5 @@
 #ohi-repo-name,version
-nri-docker,1.4.1
+nri-docker,1.4.2
 nri-flex,1.4.0
 nri-winservices,v0.1.0-beta
 nri-prometheus,2.3.0


### PR DESCRIPTION
This PR bumps to the v1.4.2 nri-docker version just released with the GHA pipelines. These release includes arm binaries.