### PR TITLE
Update default frequency of process detail sampling

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1661,8 +1661,12 @@ func NormalizeConfig(cfg *Config, cfgMetadata config_loader.YAMLMetadata) (err e
 	}
 	nlog.WithField("MetricsNetworkSampleRate", cfg.MetricsNetworkSampleRate).Debug("Metrics Network Sample Rate.")
 
-	if cfg.MetricsProcessSampleRate < FREQ_INTERVAL_FLOOR_PROCESS_METRICS && cfg.MetricsProcessSampleRate > FREQ_DISABLE_SAMPLING {
-		cfg.MetricsProcessSampleRate = FREQ_INTERVAL_FLOOR_PROCESS_METRICS
+	if cfg.MetricsProcessSampleRate == 0 {
+		cfg.MetricsProcessSampleRate = 600
+	} else {
+		if cfg.MetricsProcessSampleRate < FREQ_INTERVAL_FLOOR_PROCESS_METRICS && cfg.MetricsProcessSampleRate > FREQ_DISABLE_SAMPLING {
+			cfg.MetricsProcessSampleRate = FREQ_INTERVAL_FLOOR_PROCESS_METRICS
+		}
 	}
 	nlog.WithField("MetricsNetworkSampleRate", cfg.MetricsProcessSampleRate).Debug("Metrics Process Sample Rate.")
 


### PR DESCRIPTION
Update the default frequency for MetricsProcessSampleRate from once every 20 second (max frequency) to once every 10 minutes.
