### PR TITLE
ci: fixed wrong pkg conclits config

### DIFF
--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -186,9 +186,6 @@ nfpms:
       postinstall: "build/package/rpm/postinst-systemd.sh"
       preremove: "build/package/rpm/prerm-systemd.sh"
       postremove: "build/package/after-remove.sh"
-    # Packages that conflict with your package.
-    conflicts:
-      - newrelic-infra
     # Packages to replace according to old packaging scripts.
     replaces:
       - opspro-agent
@@ -247,9 +244,6 @@ nfpms:
       postinstall: "build/package/deb/postinst-upstart.sh"
       preremove: "build/package/deb/prerm.sh"
       postremove: "build/package/after-remove.sh"
-    # Packages that conflict with your package.
-    conflicts:
-      - newrelic-infra
     # Packages to replace according to old packaging scripts.
     replaces:
       - opspro-agent
@@ -306,9 +300,6 @@ nfpms:
     scripts:
       preinstall: "build/package/before-install.sh"
       preremove: "build/package/rpm/prerm-upstart.sh"
-    # Packages that conflict with your package.
-    conflicts:
-      - newrelic-infra
     # Packages to replace according to old packaging scripts.
     replaces:
       - opspro-agent
@@ -385,9 +376,6 @@ nfpms:
       preinstall: "build/package/before-install.sh"
       preremove: "build/package/rpm/prerm-systemd.sh"
 
-    # Packages that conflict with your package.
-    conflicts:
-      - newrelic-infra
     # Packages to replace according to old packaging scripts.
     replaces:
       - opspro-agent
@@ -463,9 +451,7 @@ nfpms:
     scripts:
       preinstall: "build/package/before-install.sh"
       preremove: "build/package/rpm/prerm-systemd.sh"
-    # Packages that conflict with your package.
-    conflicts:
-      - newrelic-infra
+
     # Packages to replace according to old packaging scripts.
     replaces:
       - opspro-agent
@@ -598,9 +584,7 @@ nfpms:
     scripts:
       preinstall: "build/package/before-install.sh"
       preremove: "build/package/rpm/prerm-systemd.sh"
-    # Packages that conflict with your package.
-    conflicts:
-      - newrelic-infra
+
     # Packages to replace according to old packaging scripts.
     replaces:
       - opspro-agent
@@ -676,9 +660,7 @@ nfpms:
     scripts:
       preinstall: "build/package/before-install.sh"
       preremove: "build/package/rpm/prerm-systemd.sh"
-    # Packages that conflict with your package.
-    conflicts:
-      - newrelic-infra
+
     # Packages to replace according to old packaging scripts.
     replaces:
       - opspro-agent
@@ -754,9 +736,7 @@ nfpms:
     scripts:
       preinstall: "build/package/before-install.sh"
       preremove: "build/package/rpm/prerm-systemd.sh"
-    # Packages that conflict with your package.
-    conflicts:
-      - newrelic-infra
+
     # Packages to replace according to old packaging scripts.
     replaces:
       - opspro-agent
@@ -832,9 +812,7 @@ nfpms:
     scripts:
       preinstall: "build/package/before-install.sh"
       preremove: "build/package/rpm/prerm-systemd.sh"
-    # Packages that conflict with your package.
-    conflicts:
-      - newrelic-infra
+
     # Packages to replace according to old packaging scripts.
     replaces:
       - opspro-agent


### PR DESCRIPTION
This PR will fix the issue with the new packages conflicting with newrelic-infra
In the old pipeline we defined a conflict with pkg newrelic-infra for packages that were suffixed. e.g. newrelic-infra-rc1.
Since we don't have the suffix anymore, we should remove the conflicts