### PR TITLE
ci: increase the logging tool version

### DIFF
--- a/build/embed/fluent-bit.version
+++ b/build/embed/fluent-bit.version
@@ -4,5 +4,5 @@
 # nrfb_artifact_version   - https://github.com/newrelic-experimental/fluent-bit-package/releases
 #
 # OS,newrelic_plugin_version,nrfb_artifact_version
-linux,1.1.0,1.3.0
-windows,1.4.6,1.4.1
+linux,1.4.6,1.7.3
+windows,1.4.6,1.7.3


### PR DESCRIPTION
This PR will increase the fluent-bit version to 1.7.3 and also the newrelic output plugin to 1.4.6