### PR TITLE
ci: upgrade curl for docker image

### DIFF
--- a/build/container/Dockerfile
+++ b/build/container/Dockerfile
@@ -77,6 +77,6 @@ LABEL com.newrelic.nri-docker.version=$nri_docker_version \
 
 RUN apk add --no-cache \
         ntpsec=1.2.0-r1 \
-        curl=7.74.0-r1
+        curl=7.76.1-r0
 
 COPY $nri_pkg_dir /


### PR DESCRIPTION
This PR will upgrade the version of the curl package which is causing now failure in the pipeline