### PR TITLE
feat(nri-docker): bumping version

### DIFF
--- a/build/nri-integrations
+++ b/build/nri-integrations
@@ -1,5 +1,5 @@
 #ohi-repo-name,version
-nri-docker,1.4.3
+nri-docker,1.5.0
 nri-flex,1.4.0
 nri-winservices,v0.2.0-beta
 nri-prometheus,2.3.0


### PR DESCRIPTION
Bumping docker version to include:

 - https://github.com/newrelic/nri-docker/commit/3c2a37150a475ff18d0275cb12ec4d3e09197598 Adding support for Task metadata endpoint v4 to include networking metrics for fargate
