### PR TITLE
container/k8s-events-forwarder: set ConnectEnabled to false

### DIFF
--- a/build/container/Dockerfile
+++ b/build/container/Dockerfile
@@ -60,6 +60,7 @@ ENV NRIA_IS_SECURE_FORWARD_ONLY true
 FROM forwarder AS k8s-events-forwarder
 
 ENV NRIA_HTTP_SERVER_ENABLED true
+ENV NRIA_CONNECT_ENABLED false
 
 #################################
 # BASE


### PR DESCRIPTION
By setting the env `NRIA_CONNECT_ENABLED` to `false`, we prevent the agent from creating host entities  when running as a sidecar of `nri-kube-events`.

Thanks to @varas for pointing this out!