### PR TITLE
feat(nri-docker): bump nri-docker to v1.6.0

### DIFF
--- a/build/embed/integrations.version
+++ b/build/embed/integrations.version
@@ -1,5 +1,5 @@
 #ohi-repo-name,version
-nri-docker,1.4.3
+nri-docker,1.6.0
 nri-flex,1.4.0
 nri-winservices,v0.2.0-beta
 nri-prometheus,2.3.0


### PR DESCRIPTION
Bumps the integration to v1.6.0 

## Breaking 
This version contains a change in the way some existing metrics are calculated. All details in the [Release notes](https://github.com/newrelic/nri-docker/releases/tag/v1.6.0)