### PR TITLE
test: packaging install pinned version

### DIFF
--- a/test/packaging/ansible/installation-pinned.yml
+++ b/test/packaging/ansible/installation-pinned.yml
@@ -1,0 +1,30 @@
+---
+
+- hosts: all
+  become: true
+  gather_facts: yes
+
+  pre_tasks:
+    - name: Initial cleanup # Only required for shared infra.
+      include_role:
+        name: cleanup
+
+  tasks:
+    - name: Installation tests suite
+      vars:
+        initial_agent_version: "1.18.5" # TODO : Change it to specific version before merging to master
+        env_vars:
+
+      block:
+
+        - name: install agent
+          include_role:
+            name: agent-install
+
+      always:
+        - name: Final cleanup # Only required for shared infra.
+          include_role:
+            name: cleanup
+
+
+...


### PR DESCRIPTION
Not sure if it makes sense to have it as a playbook or if it's enough running install playbook with `initial_agent_version` as parameter