### PR TITLE
feat: add config template and passthrough env to child runners

### DIFF
--- a/test/cfgprotocol/agent/emulator.go
+++ b/test/cfgprotocol/agent/emulator.go
@@ -52,12 +52,7 @@ func New(configsDir, tempBinDir string) *Emulator {
 		config.LogFormat = "text"
 		config.LogToStdout = true
 		config.Debug = true
-		config.MetricsSystemSampleRate = 2
-		config.MetricsProcessSampleRate = 2
-		config.MetricsNetworkSampleRate = 2
-		config.HeartBeatSampleRate = 2
-		config.MetricsNFSSampleRate = 2
-		config.MetricsStorageSampleRate = 2
+		config.IsForwardOnly = true
 		config.Features = map[string]bool{
 			fflag.FlagProtocolV4: true,
 		}

--- a/test/cfgprotocol/testdata/go/spawner.go
+++ b/test/cfgprotocol/testdata/go/spawner.go
@@ -7,8 +7,11 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v2"
 )
 
 func main() {
@@ -17,8 +20,26 @@ func main() {
 	times := flag.Int("times", 100, "")
 	sleepTime := flag.Duration("sleepTime", 2*time.Second, "")
 	mode := flag.String("mode", "short", "")
+	configPath := os.Getenv("CONFIG_PATH")
 	flag.String("nri-process-name", "unknown", "")
 	flag.Parse()
+
+	// If config file is present it replace the configs from flag for testing pourposes.
+	if configPath != "" {
+		cfgFile, err := ioutil.ReadFile(configPath)
+		if err != nil {
+			panic("fail to read config file!")
+		}
+		var m map[string]interface{}
+		if err := yaml.Unmarshal(cfgFile, &m); err != nil {
+			panic("fail to unmarshal config file!")
+		}
+
+		if p, ok := m["path"]; ok {
+			*path = fmt.Sprintf("%v", p)
+		}
+	}
+
 	content, err := ioutil.ReadFile(*path)
 	if err != nil {
 		panic(err)

--- a/test/cfgprotocol/testdata/scenarios/scenario5/nri-config.json
+++ b/test/cfgprotocol/testdata/scenarios/scenario5/nri-config.json
@@ -1,0 +1,20 @@
+{
+  "config_protocol_version": "1",
+  "action": "register_config",
+  "config_name": "myconfig",
+  "config": {
+    "integrations": [
+      {
+        "name": "spawner",
+        "config": {
+          "path": "testdata/scenarios/shared/nri-out.json"
+        },
+        "cli_args": [
+          "-nri-process-name",
+          "nri-config-template"
+        ],
+        "interval": "2s"
+      }
+    ]
+  }
+}

--- a/test/cfgprotocol/testdata/scenarios/scenario5/settings.yml
+++ b/test/cfgprotocol/testdata/scenarios/scenario5/settings.yml
@@ -1,0 +1,8 @@
+integrations:
+  - name: spawner
+    cli_args:
+      - "-path"
+      - "testdata/scenarios/scenario5/nri-config.json"
+      - "-nri-process-name"
+      - "nri-config"
+    interval: "2s"


### PR DESCRIPTION
This PR adds the config template and passthrough environment variables to the spawned integrations of the config protocol . This will allow spawned integrations to use the config parameter of configuration as they do when spawned from config files. 