### PR TITLE
feat: pass the interval though env var to integrations

### DIFF
--- a/internal/agent/cmdchannel/runintegration/runintegration_test.go
+++ b/internal/agent/cmdchannel/runintegration/runintegration_test.go
@@ -5,6 +5,7 @@ package runintegration
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/newrelic/infrastructure-agent/internal/agent/cmdchannel"
 	"github.com/newrelic/infrastructure-agent/internal/integrations/v4/integration"
@@ -52,6 +53,7 @@ func TestHandle_queuesIntegrationToBeRun(t *testing.T) {
 
 	d := <-defQueue
 	assert.Equal(t, "nri-process-discovery", d.Name)
+	assert.Equal(t, time.Duration(0), d.Interval)
 	// Definition won't allow assert further
 }
 

--- a/internal/integrations/v4/integration/integration.go
+++ b/internal/integrations/v4/integration/integration.go
@@ -24,6 +24,7 @@ const (
 	defaultIntegrationInterval = config.FREQ_PLUGIN_EXTERNAL_PLUGINS * time.Second
 	defaultTimeout             = 120 * time.Second
 	minimumTimeout             = 100 * time.Millisecond
+	intervalEnvVarName         = "NRI_CONFIG_INTERVAL"
 )
 
 var minimumIntegrationIntervalOverride = ""
@@ -61,6 +62,11 @@ func newDefinitionWithoutLookup(ce config2.ConfigEntry, passthroughEnv []string,
 	if err := ce.Sanitize(); err != nil {
 		return Definition{}, err
 	}
+
+	interval := getInterval(ce.Interval)
+	// Reading this env the integration can know configured interval.
+	ce.Env[intervalEnvVarName] = fmt.Sprintf("%v", interval)
+
 	d := Definition{
 		ExecutorConfig: executor.Config{
 			User:        ce.User,
@@ -70,7 +76,7 @@ func newDefinitionWithoutLookup(ce config2.ConfigEntry, passthroughEnv []string,
 		},
 		Labels:         ce.Labels,
 		Name:           ce.InstanceName,
-		Interval:       getInterval(ce.Interval),
+		Interval:       interval,
 		WhenConditions: conditions(ce.When),
 		ConfigTemplate: configTemplate,
 		newTempFile:    newTempFile,

--- a/internal/integrations/v4/integration/integration_test.go
+++ b/internal/integrations/v4/integration/integration_test.go
@@ -163,6 +163,15 @@ func TestTimeout_Default(t *testing.T) {
 	// THEN the integration has a default timeout
 	assert.Equal(t, defaultTimeout, i.Timeout)
 }
+func TestInterval_EnvironmentVariableCustom(t *testing.T) {
+	// GIVEN a configuration with custom interval
+	// WHEN an integration is loaded from it
+	i, err := NewDefinition(config2.ConfigEntry{InstanceName: "foo", Interval: "55s", Exec: config2.ShlexOpt{"bar"}}, ErrLookup, nil, nil)
+	require.NoError(t, err)
+
+	// THEN the integration has an environment variable with the interval value
+	assert.Equal(t, "55s", i.ExecutorConfig.Environment[intervalEnvVarName])
+}
 
 func TestTimeout_TooLow(t *testing.T) {
 	// GIVEN a configured timeout where the user forgot to write a suffix

--- a/internal/integrations/v4/integration/integration_test.go
+++ b/internal/integrations/v4/integration/integration_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"runtime"
 	"testing"
@@ -171,6 +172,24 @@ func TestInterval_EnvironmentVariableCustom(t *testing.T) {
 
 	// THEN the integration has an environment variable with the interval value
 	assert.Equal(t, "55s", i.ExecutorConfig.Environment[intervalEnvVarName])
+}
+func TestInterval_EnvironmentVariableCero(t *testing.T) {
+	// GIVEN a configuration with custom interval
+	// WHEN an integration is loaded from it
+	i, err := NewDefinition(config2.ConfigEntry{InstanceName: "foo", Interval: "0", Exec: config2.ShlexOpt{"bar"}}, ErrLookup, nil, nil)
+	require.NoError(t, err)
+
+	// THEN the integration has an environment variable with the interval value
+	assert.Equal(t, "0s", i.ExecutorConfig.Environment[intervalEnvVarName])
+}
+func TestInterval_EnvironmentVariableDefault(t *testing.T) {
+	// GIVEN a configuration with custom interval
+	// WHEN an integration is loaded from it
+	i, err := NewDefinition(config2.ConfigEntry{InstanceName: "foo", Exec: config2.ShlexOpt{"bar"}}, ErrLookup, nil, nil)
+	require.NoError(t, err)
+
+	// THEN the integration has an environment variable with the interval value
+	assert.Equal(t, fmt.Sprintf("%v", defaultIntegrationInterval), i.ExecutorConfig.Environment[intervalEnvVarName])
 }
 
 func TestTimeout_TooLow(t *testing.T) {


### PR DESCRIPTION
Context: Currently an integration has no way to know which is the interval configured for it to be launched.

This PR adds an environment variable to integrations called `NRI_CONFIG_INTERVAL` which has the interval configured for that integration. So the integration can read this env variable and have that context if needed.

One of the use case is detailed in this [doc](https://newrelic.atlassian.net/wiki/spaces/INST/pages/2073657633/Config+generator+refinement) and will allow spawned integrations to inherit the interval from the parent (generator) one. 