### PR TITLE
feat: add cfg parent context to emmiter logs

### DIFF
--- a/pkg/integrations/v4/emitter/emitter.go
+++ b/pkg/integrations/v4/emitter/emitter.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/newrelic/infrastructure-agent/pkg/fwrequest"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/legacy"
+	"github.com/sirupsen/logrus"
 
 	"github.com/newrelic/infrastructure-agent/internal/feature_flags"
 	"github.com/newrelic/infrastructure-agent/pkg/databind/pkg/data"
@@ -54,18 +55,20 @@ type VersionAwareEmitter struct {
 }
 
 func (e *VersionAwareEmitter) Emit(definition integration.Definition, extraLabels data.Map, entityRewrite []data.EntityRewrite, integrationJSON []byte) error {
-	elog.
-		WithField("name", definition.Name).
-		WithField("payload", string(integrationJSON)).
-		Debug("Received payload.")
+	fields := logrus.Fields{
+		"integration_name": definition.Name,
+		"payload":          string(integrationJSON),
+	}
+	if definition.CfgProtocol != nil {
+		fields["cfg_protocol_name"] = definition.CfgProtocol.ConfigName
+		fields["parent_integration_name"] = definition.CfgProtocol.ParentName
+	}
+
+	elog.WithFields(fields).Debug("Received payload.")
 
 	protocolVersion, err := protocol.VersionFromPayload(integrationJSON, e.forceProtocolV2ToV3)
 	if err != nil {
-		elog.
-			WithError(err).
-			WithField("protocol", protocolVersion).
-			WithField("output", string(integrationJSON)).
-			Warn("error retrieving integration protocol version")
+		elog.WithError(err).WithFields(fields).Warn("error retrieving integration protocol version")
 		return err
 	}
 
@@ -73,7 +76,7 @@ func (e *VersionAwareEmitter) Emit(definition integration.Definition, extraLabel
 	if protocolVersion == protocol.V4 {
 		pluginDataV4, err := dm.ParsePayloadV4(integrationJSON, e.ffRetriever)
 		if err != nil {
-			elog.WithError(err).WithField("output", string(integrationJSON)).Warn("can't parse v4 integration output")
+			elog.WithError(err).WithFields(fields).Warn("can't parse v4 integration output")
 			return err
 		}
 
@@ -83,7 +86,7 @@ func (e *VersionAwareEmitter) Emit(definition integration.Definition, extraLabel
 
 	pluginDataV3, err := protocol.ParsePayload(integrationJSON, protocolVersion)
 	if err != nil {
-		elog.WithError(err).WithField("output", string(integrationJSON)).Warn("can't parse integration output")
+		elog.WithError(err).WithFields(fields).Warn("can't parse integration output")
 		return err
 	}
 


### PR DESCRIPTION
Adds the context of the parent integration if exist. 
Replaces the log field `name` for `integration_name` to be similar to the fields in the runner.go