### PR TITLE
Bump bundled nri-prometheus to v2.7.0

### DIFF
--- a/build/embed/integrations.version
+++ b/build/embed/integrations.version
@@ -2,4 +2,4 @@
 nri-docker,1.6.0
 nri-flex,1.4.1
 nri-winservices,v0.2.0-beta
-nri-prometheus,2.6.0
+nri-prometheus,2.7.0


### PR DESCRIPTION
This version upgrades most of the dependencies used by the project.

See the changelog here: https://github.com/newrelic/nri-prometheus/releases/tag/v2.7.0