### PR TITLE
test: add cleanup for repository before adding new one in installation tests

### DIFF
--- a/build/container/Dockerfile
+++ b/build/container/Dockerfile
@@ -77,6 +77,6 @@ LABEL com.newrelic.nri-docker.version=$nri_docker_version \
 
 RUN apk add --no-cache \
         ntpsec=1.2.0-r1 \
-        curl=7.77.0-r0
+        curl=7.77.0-r1
 
 COPY $nri_pkg_dir /

--- a/test/packaging/ansible/roles/repo-setup/tasks/repo-Amazon.yaml
+++ b/test/packaging/ansible/roles/repo-setup/tasks/repo-Amazon.yaml
@@ -1,5 +1,10 @@
 ---
 
+- name: remove infra-agent YUM repository (from previous runs)
+  yum_repository:
+    name: newrelic-infra
+    state: absent
+
 - name: install infra-agent YUM repository
   yum_repository:
     name: newrelic-infra

--- a/test/packaging/ansible/roles/repo-setup/tasks/repo-CentOS.yaml
+++ b/test/packaging/ansible/roles/repo-setup/tasks/repo-CentOS.yaml
@@ -1,5 +1,10 @@
 ---
 
+- name: remove infra-agent YUM repository (from previous runs)
+  yum_repository:
+    name: newrelic-infra
+    state: absent
+
 - name: install infra-agent YUM repository
   yum_repository:
     name: newrelic-infra

--- a/test/packaging/ansible/roles/repo-setup/tasks/repo-Debian.yaml
+++ b/test/packaging/ansible/roles/repo-setup/tasks/repo-Debian.yaml
@@ -4,6 +4,13 @@
   apt_key:
     url: https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg
 
+- name: remove infra-agent APT repository (from previous runs)
+  apt_repository:
+    filename: newrelic-infra
+    repo: "deb {{ item }}/linux/apt {{ ansible_distribution_release }} main"
+    state: absent
+  loop: "{{ repos_to_clean }}"
+
 - name: install infra-agent APT repository
   apt_repository:
     repo: "deb {{ repo_endpoint }}/linux/apt {{ ansible_distribution_release }} main"

--- a/test/packaging/ansible/roles/repo-setup/tasks/repo-RedHat.yaml
+++ b/test/packaging/ansible/roles/repo-setup/tasks/repo-RedHat.yaml
@@ -1,5 +1,10 @@
 ---
 
+- name: remove infra-agent YUM repository (from previous runs)
+  yum_repository:
+    name: newrelic-infra
+    state: absent
+
 - name: install infra-agent YUM repository
   yum_repository:
     name: newrelic-infra

--- a/test/packaging/ansible/roles/repo-setup/tasks/repo-Suse.yaml
+++ b/test/packaging/ansible/roles/repo-setup/tasks/repo-Suse.yaml
@@ -1,5 +1,10 @@
 ---
 
+- name: remove infra-agent Zypper repository (from previous runs)
+  zypper_repository:
+    name: newrelic-infra
+    state: absent
+
 - name: install infra-agent Zypper repository
   zypper_repository:
     name: newrelic-infra

--- a/test/packaging/ansible/roles/repo-setup/tasks/repo-Ubuntu.yaml
+++ b/test/packaging/ansible/roles/repo-setup/tasks/repo-Ubuntu.yaml
@@ -4,6 +4,13 @@
   apt_key:
     url: https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg
 
+- name: remove infra-agent APT repository (from previous runs)
+  apt_repository:
+    filename: newrelic-infra
+    repo: "deb {{ item }}/linux/apt {{ ansible_distribution_release }} main"
+    state: absent
+  loop: "{{ repos_to_clean }}"
+
 - name: install infra-agent APT repository
   apt_repository:
     repo: "deb {{ repo_endpoint }}/linux/apt {{ ansible_distribution_release }} main"

--- a/test/packaging/ansible/roles/repo-setup/vars/main.yaml
+++ b/test/packaging/ansible/roles/repo-setup/vars/main.yaml
@@ -1,5 +1,9 @@
 ---
 
-repo_endpoint: "http://nr-downloads-ohai-testing.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
+repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
 
+repos_to_clean:
+  - "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
+  - "http://nr-downloads-ohai-testing.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
+  - "https://downloads.newrelic.com/infrastructure_agent"
 ...


### PR DESCRIPTION
problem: we set repository for each run and if we want to execute tests with testing/staging/prod repos, we have to clean manually boxes from old repos.