### PR TITLE
ci: fluentbit as agent pkg dependency

### DIFF
--- a/.github/workflows/prerelease_linux.yml
+++ b/.github/workflows/prerelease_linux.yml
@@ -141,7 +141,7 @@ jobs:
           username: ${{ env.DOCKER_HUB_ID }}
           password: ${{ env.DOCKER_HUB_PASSWORD }}
       - name: Publish ${{ matrix.assetsType }} to S3 action
-        uses: newrelic/infrastructure-publish-action@v1.0.10
+        uses: newrelic/infrastructure-publish-action@1.0.14
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_STAGING }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_STAGING }}

--- a/.github/workflows/prerelease_staged_publish.yml
+++ b/.github/workflows/prerelease_staged_publish.yml
@@ -48,7 +48,7 @@ jobs:
           password: ${{ env.DOCKER_HUB_PASSWORD }}
       - name: Publish ${{ matrix.assetsType }} to S3 action
         if: ${{ github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType }}
-        uses: newrelic/infrastructure-publish-action@v1.0.10
+        uses: newrelic/infrastructure-publish-action@v1.0.14
         env:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
@@ -92,7 +92,7 @@ jobs:
           password: ${{ env.DOCKER_HUB_PASSWORD }}
       - name: Publish ${{ matrix.assetsType }} to S3 action
         if: ${{ github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType }}
-        uses: newrelic/infrastructure-publish-action@v1.0.10
+        uses: newrelic/infrastructure-publish-action@v1.0.14
         env:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           username: ${{ env.DOCKER_HUB_ID }}
           password: ${{ env.DOCKER_HUB_PASSWORD }}
       - name: Publish ${{ matrix.assetsType }} to S3 action
-        uses: newrelic/infrastructure-publish-action@v1.0.10
+        uses: newrelic/infrastructure-publish-action@v1.0.14
         env:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
@@ -84,7 +84,7 @@ jobs:
           username: ${{ env.DOCKER_HUB_ID }}
           password: ${{ env.DOCKER_HUB_PASSWORD }}
       - name: Publish ${{ matrix.assetsType }} to S3 action
-        uses: newrelic/infrastructure-publish-action@v1.0.10
+        uses: newrelic/infrastructure-publish-action@v1.0.14
         env:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release_staged.yml
+++ b/.github/workflows/release_staged.yml
@@ -48,7 +48,7 @@ jobs:
           password: ${{ env.DOCKER_HUB_PASSWORD }}
       - name: Publish ${{ matrix.assetsType }} to S3 action
         if: ${{ github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType }}
-        uses: newrelic/infrastructure-publish-action@v1.0.10
+        uses: newrelic/infrastructure-publish-action@v1.0.14
         env:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
@@ -92,7 +92,7 @@ jobs:
           password: ${{ env.DOCKER_HUB_PASSWORD }}
       - name: Publish ${{ matrix.assetsType }} to S3 action
         if: ${{ github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType }}
-        uses: newrelic/infrastructure-publish-action@v1.0.10
+        uses: newrelic/infrastructure-publish-action@v1.0.14
         env:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}

--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -257,8 +257,6 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/amd64/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-      - src: 'target/fluent-bit/amd64/fluent-bit'
-        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
       - src: 'target/fluent-bit-plugin/amd64/out_newrelic.so'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
       - src: 'assets/examples/logging/parsers.conf'
@@ -282,6 +280,9 @@ nfpms:
     section: default
     # Priority.
     priority: extra
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+    recommends:
+      - td-agent-bit
 
   - id: debian-infrastructure-agent-upstart
     builds:
@@ -340,6 +341,9 @@ nfpms:
     section: default
     # Priority.
     priority: extra
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+    recommends:
+      - td-agent-bit
 
 ###############################################################################
 ###############################################################################
@@ -407,6 +411,10 @@ nfpms:
         posttrans: "build/package/rpm/postinst-upstart.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    # Required packages. rpm version 4.11.3 does not support weak dependencies.
+    # disabled as right now fb pkg is not built for centos-6
+#    dependencies:
+#      - td-agent-bit
 
   - id: centos-7-infrastructure-agent
     builds:
@@ -448,9 +456,6 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/amd64/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-
-      - src: 'target/fluent-bit/amd64/fluent-bit'
-        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
       - src: 'target/fluent-bit-plugin/amd64/out_newrelic.so'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
       - src: 'assets/examples/logging/parsers.conf'
@@ -483,6 +488,9 @@ nfpms:
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    # Required packages. rpm version 4.11.3 does not support weak dependencies
+    dependencies:
+      - td-agent-bit
 
   - id: centos-8-infrastructure-agent
     builds:
@@ -524,9 +532,6 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/amd64/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-
-      - src: 'target/fluent-bit/amd64/fluent-bit'
-        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
       - src: 'target/fluent-bit-plugin/amd64/out_newrelic.so'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
       - src: 'assets/examples/logging/parsers.conf'
@@ -560,6 +565,9 @@ nfpms:
 
       summary: "New Relic Infrastructure Agent"
       group: default
+    # Required packages. rpm version 4.11.3 does not support weak dependencies
+    dependencies:
+      - td-agent-bit
 
 ###############################################################################
 ###############################################################################
@@ -622,6 +630,9 @@ nfpms:
         posttrans: "build/package/rpm/postinst-sysv.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+    recommends:
+      - td-agent-bit
 
   - id: sle-12.1-infrastructure-agent
     builds:
@@ -664,8 +675,6 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/amd64/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-      - src: 'target/fluent-bit/amd64/fluent-bit'
-        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
       - src: 'target/fluent-bit-plugin/amd64/out_newrelic.so'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
       - src: 'assets/examples/logging/parsers.conf'
@@ -698,6 +707,9 @@ nfpms:
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+    recommends:
+      - td-agent-bit
 
   - id: sle-12.2-infrastructure-agent
     builds:
@@ -740,8 +752,6 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/amd64/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-      - src: 'target/fluent-bit/amd64/fluent-bit'
-        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
       - src: 'target/fluent-bit-plugin/amd64/out_newrelic.so'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
       - src: 'assets/examples/logging/parsers.conf'
@@ -774,6 +784,9 @@ nfpms:
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+    recommends:
+      - td-agent-bit
 
   - id: sle-12.3-infrastructure-agent
     builds:
@@ -816,8 +829,6 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/amd64/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-      - src: 'target/fluent-bit/amd64/fluent-bit'
-        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
       - src: 'target/fluent-bit-plugin/amd64/out_newrelic.so'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
       - src: 'assets/examples/logging/parsers.conf'
@@ -850,6 +861,9 @@ nfpms:
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+    recommends:
+      - td-agent-bit
 
   - id: sle-12.4-infrastructure-agent
     builds:
@@ -892,8 +906,6 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/amd64/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-      - src: 'target/fluent-bit/amd64/fluent-bit'
-        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
       - src: 'target/fluent-bit-plugin/amd64/out_newrelic.so'
         dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
       - src: 'assets/examples/logging/parsers.conf'
@@ -926,7 +938,92 @@ nfpms:
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+    recommends:
+      - td-agent-bit
 
+###############################################################################
+###############################################################################
+###                              AMD64/AMAZON LINUX 2                       ###
+###############################################################################
+###############################################################################
+
+  - id: amazonlinux-2-infrastructure-agent
+    builds:
+      - linux-newrelic-infra-fpm
+      - linux-newrelic-infra-ctl-fpm
+      - linux-newrelic-infra-service-fpm
+    package_name: newrelic-infra
+    file_name_template: "newrelic-infra-{{ .Env.TAG }}-1.amazonlinux-2.{{ .Arch }}"
+    vendor: 'New Relic, Inc.'
+    homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
+    maintainer: 'caos-team@newrelic.com'
+    description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
+    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    formats:
+      - rpm
+    bindir: /usr/bin
+    contents:
+      - src: 'assets/examples/logging/linux/file.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/file.yml.example'
+      - src: 'assets/examples/logging/linux/fluentbit.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/fluentbit.yml.example'
+      - src: 'assets/examples/logging/linux/syslog.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/syslog.yml.example'
+      - src: 'assets/examples/logging/linux/systemd.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/systemd.yml.example'
+      - src: 'assets/examples/logging/linux/tcp.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/tcp.yml.example'
+
+      - src: 'build/package/systemd/newrelic-infra.service'
+        dst: '/etc/systemd/system/newrelic-infra.service'
+      - src: 'LICENSE'
+        dst: '/var/db/newrelic-infra/LICENSE.txt'
+      - src: 'target/nridocker/amd64/etc/newrelic-infra/integrations.d/docker-config.yml'
+        dst: '/etc/newrelic-infra/integrations.d/docker-config.yml'
+        type: config
+      - src: 'target/nridocker/amd64/var/db/newrelic-infra/newrelic-integrations/bin/nri-docker'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-docker'
+      - src: 'target/nriflex/amd64/nri-flex'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
+      - src: 'target/nriprometheus/amd64/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
+      - src: 'target/fluent-bit-plugin/amd64/out_newrelic.so'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
+      - src: 'assets/examples/logging/parsers.conf'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
+    empty_folders:
+      - /var/db/newrelic-infra/custom-integrations
+      - /var/db/newrelic-infra/integrations.d
+      - /var/log/newrelic-infra
+      - /var/run/newrelic-infra
+    epoch: 0
+    release: 1.amazonlinux-2
+    replacements:
+      amd64: x86_64
+
+    # Scripts to execute during the installation of the package.
+    scripts:
+      preinstall: "build/package/before-install.sh"
+      preremove: "build/package/rpm/prerm-systemd.sh"
+
+    # Packages to replace according to old packaging scripts.
+    replaces:
+      - opspro-agent
+      - opspro-agent-systemd
+    # Section.
+    section: default
+    # Priority.
+    priority: extra
+    rpm:
+      scripts:
+        posttrans: "build/package/rpm/postinst-systemd.sh"
+
+      summary: "New Relic Infrastructure Agent"
+      group: default
+    # Required packages. rpm version 4.11.3 does not support weak dependencies
+    dependencies:
+      - td-agent-bit
 
 ###############################################################################
 ###############################################################################
@@ -972,8 +1069,6 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/arm/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-#      - src: 'target/fluent-bit/arm/fluent-bit'
-#        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
 #      - src: 'target/fluent-bit-plugin/arm/out_newrelic.so'
 #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
 #      - src: 'assets/examples/logging/parsers.conf'
@@ -997,6 +1092,9 @@ nfpms:
     section: default
     # Priority.
     priority: extra
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+    recommends:
+      - td-agent-bit
 
 ###############################################################################
 ###############################################################################
@@ -1044,9 +1142,6 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/arm/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-
-#      - src: 'target/fluent-bit/arm/fluent-bit'
-#        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
 #      - src: 'target/fluent-bit-plugin/arm/out_newrelic.so'
 #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
 #      - src: 'assets/examples/logging/parsers.conf'
@@ -1077,6 +1172,10 @@ nfpms:
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    # Required packages. rpm version 4.11.3 does not support weak dependencies
+    # disabled until logging packaging is properly handled for arm
+#    dependencies:
+#      - td-agent-bit
 
   - id: centos-8-infrastructure-agent-arm
     builds:
@@ -1118,9 +1217,6 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/arm/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-
-#      - src: 'target/fluent-bit/arm/fluent-bit'
-#        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
 #      - src: 'target/fluent-bit-plugin/arm/out_newrelic.so'
 #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
 #      - src: 'assets/examples/logging/parsers.conf'
@@ -1151,6 +1247,9 @@ nfpms:
 
       summary: "New Relic Infrastructure Agent"
       group: default
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+    recommends:
+      - td-agent-bit
 
 ###############################################################################
 ###############################################################################
@@ -1199,8 +1298,6 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/arm/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-#      - src: 'target/fluent-bit/arm/fluent-bit'
-#        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
 #      - src: 'target/fluent-bit-plugin/arm/out_newrelic.so'
 #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
 #      - src: 'assets/examples/logging/parsers.conf'
@@ -1230,6 +1327,9 @@ nfpms:
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+    recommends:
+      - td-agent-bit
 
   - id: sle-12.3-infrastructure-agent-arm
     builds:
@@ -1272,8 +1372,6 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/arm/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-#      - src: 'target/fluent-bit/arm/fluent-bit'
-#        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
 #      - src: 'target/fluent-bit-plugin/arm/out_newrelic.so'
 #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
 #      - src: 'assets/examples/logging/parsers.conf'
@@ -1303,6 +1401,9 @@ nfpms:
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+    recommends:
+      - td-agent-bit
 
   - id: sle-12.4-infrastructure-agent-arm
     builds:
@@ -1345,8 +1446,6 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/arm/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-#      - src: 'target/fluent-bit/arm/fluent-bit'
-#        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
 #      - src: 'target/fluent-bit-plugin/arm/out_newrelic.so'
 #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
 #      - src: 'assets/examples/logging/parsers.conf'
@@ -1376,6 +1475,89 @@ nfpms:
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+    recommends:
+      - td-agent-bit
+
+###############################################################################
+###############################################################################
+###                              ARM/AMAZON LINUX 2                         ###
+###############################################################################
+###############################################################################
+  - id: amazonlinux-2-infrastructure-agent-arm
+    builds:
+      - linux-newrelic-infra-fpm-arm
+      - linux-newrelic-infra-ctl-fpm-arm
+      - linux-newrelic-infra-service-fpm-arm
+    package_name: newrelic-infra
+    file_name_template: "newrelic-infra-{{ .Env.TAG }}-1.amazonlinux-2.{{ .Arch }}"
+    vendor: 'New Relic, Inc.'
+    homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
+    maintainer: 'caos-team@newrelic.com'
+    description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
+    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    formats:
+      - rpm
+    bindir: /usr/bin
+    contents:
+#      - src: 'assets/examples/logging/linux/file.yml.example'
+#        dst: '/etc/newrelic-infra/logging.d/file.yml.example'
+#      - src: 'assets/examples/logging/linux/fluentbit.yml.example'
+#        dst: '/etc/newrelic-infra/logging.d/fluentbit.yml.example'
+#      - src: 'assets/examples/logging/linux/syslog.yml.example'
+#        dst: '/etc/newrelic-infra/logging.d/syslog.yml.example'
+#      - src: 'assets/examples/logging/linux/systemd.yml.example'
+#        dst: '/etc/newrelic-infra/logging.d/systemd.yml.example'
+#      - src: 'assets/examples/logging/linux/tcp.yml.example'
+#        dst: '/etc/newrelic-infra/logging.d/tcp.yml.example'
+
+      - src: 'build/package/systemd/newrelic-infra.service'
+        dst: '/etc/systemd/system/newrelic-infra.service'
+      - src: 'LICENSE'
+        dst: '/var/db/newrelic-infra/LICENSE.txt'
+      - src: 'target/nridocker/arm/etc/newrelic-infra/integrations.d/docker-config.yml'
+        dst: '/etc/newrelic-infra/integrations.d/docker-config.yml'
+        type: config
+
+      - src: 'target/nridocker/arm/var/db/newrelic-infra/newrelic-integrations/bin/nri-docker'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-docker'
+      - src: 'target/nriflex/arm/nri-flex'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
+      - src: 'target/nriprometheus/arm/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
+#      - src: 'target/fluent-bit-plugin/arm/out_newrelic.so'
+#        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
+#      - src: 'assets/examples/logging/parsers.conf'
+#        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
+    empty_folders:
+      - /var/db/newrelic-infra/custom-integrations
+      - /var/db/newrelic-infra/integrations.d
+      - /var/log/newrelic-infra
+      - /var/run/newrelic-infra
+    epoch: 0
+    release: 1.amazonlinux-2
+
+    # Scripts to execute during the installation of the package.
+    scripts:
+      preinstall: "build/package/before-install.sh"
+      preremove: "build/package/rpm/prerm-systemd.sh"
+    # Packages to replace according to old packaging scripts.
+    replaces:
+      - opspro-agent
+      - opspro-agent-systemd
+    # Section.
+    section: default
+    # Priority.
+    priority: extra
+    rpm:
+      scripts:
+        posttrans: "build/package/rpm/postinst-systemd.sh"
+
+      summary: "New Relic Infrastructure Agent"
+      group: default
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+    recommends:
+      - td-agent-bit
 
 ###############################################################################
 ###############################################################################
@@ -1421,8 +1603,6 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/arm64/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-#      - src: 'target/fluent-bit/arm64/fluent-bit'
-#        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
 #      - src: 'target/fluent-bit-plugin/arm64/out_newrelic.so'
 #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
 #      - src: 'assets/examples/logging/parsers.conf'
@@ -1446,6 +1626,9 @@ nfpms:
     section: default
     # Priority.
     priority: extra
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+    recommends:
+      - td-agent-bit
 
 ###############################################################################
 ###############################################################################
@@ -1493,9 +1676,6 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/arm64/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-
-#      - src: 'target/fluent-bit/arm64/fluent-bit'
-#        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
 #      - src: 'target/fluent-bit-plugin/arm64/out_newrelic.so'
 #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
 #      - src: 'assets/examples/logging/parsers.conf'
@@ -1526,6 +1706,10 @@ nfpms:
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    # Required packages. rpm version 4.11.3 does not support weak dependencies
+    # disabled until logging packaging is properly handled for arm
+#    dependencies:
+#      - td-agent-bit
 
   - id: centos-8-infrastructure-agent-arm64
     builds:
@@ -1567,9 +1751,6 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/arm64/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-
-#      - src: 'target/fluent-bit/arm64/fluent-bit'
-#        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
 #      - src: 'target/fluent-bit-plugin/arm64/out_newrelic.so'
 #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
 #      - src: 'assets/examples/logging/parsers.conf'
@@ -1600,6 +1781,9 @@ nfpms:
 
       summary: "New Relic Infrastructure Agent"
       group: default
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+    recommends:
+      - td-agent-bit
 
 ###############################################################################
 ###############################################################################
@@ -1648,8 +1832,6 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/arm64/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-#      - src: 'target/fluent-bit/arm64/fluent-bit'
-#        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
 #      - src: 'target/fluent-bit-plugin/arm64/out_newrelic.so'
 #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
 #      - src: 'assets/examples/logging/parsers.conf'
@@ -1679,6 +1861,9 @@ nfpms:
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+    recommends:
+      - td-agent-bit
 
   - id: sle-12.3-infrastructure-agent-arm64
     builds:
@@ -1721,8 +1906,6 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/arm64/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-#      - src: 'target/fluent-bit/arm64/fluent-bit'
-#        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
 #      - src: 'target/fluent-bit-plugin/arm64/out_newrelic.so'
 #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
 #      - src: 'assets/examples/logging/parsers.conf'
@@ -1752,6 +1935,9 @@ nfpms:
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+    recommends:
+      - td-agent-bit
 
   - id: sle-12.4-infrastructure-agent-arm64
     builds:
@@ -1794,8 +1980,6 @@ nfpms:
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/arm64/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-#      - src: 'target/fluent-bit/arm64/fluent-bit'
-#        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit'
 #      - src: 'target/fluent-bit-plugin/arm64/out_newrelic.so'
 #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
 #      - src: 'assets/examples/logging/parsers.conf'
@@ -1825,6 +2009,88 @@ nfpms:
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+    recommends:
+      - td-agent-bit
+
+###############################################################################
+###############################################################################
+###                              ARM64/AMAZONLINUX                          ###
+###############################################################################
+###############################################################################
+  - id: amazonlinux-2-infrastructure-agent-arm64
+    builds:
+      - linux-newrelic-infra-fpm-arm64
+      - linux-newrelic-infra-ctl-fpm-arm64
+      - linux-newrelic-infra-service-fpm-arm64
+    package_name: newrelic-infra
+    file_name_template: "newrelic-infra-{{ .Env.TAG }}-1.amazonlinux-2.{{ .Arch }}"
+    vendor: 'New Relic, Inc.'
+    homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
+    maintainer: 'caos-team@newrelic.com'
+    description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
+    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    formats:
+      - rpm
+    bindir: /usr/bin
+    contents:
+#      - src: 'assets/examples/logging/linux/file.yml.example'
+#        dst: '/etc/newrelic-infra/logging.d/file.yml.example'
+#      - src: 'assets/examples/logging/linux/fluentbit.yml.example'
+#        dst: '/etc/newrelic-infra/logging.d/fluentbit.yml.example'
+#      - src: 'assets/examples/logging/linux/syslog.yml.example'
+#        dst: '/etc/newrelic-infra/logging.d/syslog.yml.example'
+#      - src: 'assets/examples/logging/linux/systemd.yml.example'
+#        dst: '/etc/newrelic-infra/logging.d/systemd.yml.example'
+#      - src: 'assets/examples/logging/linux/tcp.yml.example'
+#        dst: '/etc/newrelic-infra/logging.d/tcp.yml.example'
+
+      - src: 'build/package/systemd/newrelic-infra.service'
+        dst: '/etc/systemd/system/newrelic-infra.service'
+      - src: 'LICENSE'
+        dst: '/var/db/newrelic-infra/LICENSE.txt'
+      - src: 'target/nridocker/arm64/etc/newrelic-infra/integrations.d/docker-config.yml'
+        dst: '/etc/newrelic-infra/integrations.d/docker-config.yml'
+        type: config
+      - src: 'target/nridocker/arm64/var/db/newrelic-infra/newrelic-integrations/bin/nri-docker'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-docker'
+      - src: 'target/nriflex/arm64/nri-flex'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
+      - src: 'target/nriprometheus/arm64/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
+#      - src: 'target/fluent-bit-plugin/arm64/out_newrelic.so'
+#        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
+#      - src: 'assets/examples/logging/parsers.conf'
+#        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
+    empty_folders:
+      - /var/db/newrelic-infra/custom-integrations
+      - /var/db/newrelic-infra/integrations.d
+      - /var/log/newrelic-infra
+      - /var/run/newrelic-infra
+    epoch: 0
+    release: 1.amazonlinux-2
+
+    # Scripts to execute during the installation of the package.
+    scripts:
+      preinstall: "build/package/before-install.sh"
+      preremove: "build/package/rpm/prerm-systemd.sh"
+    # Packages to replace according to old packaging scripts.
+    replaces:
+      - opspro-agent
+      - opspro-agent-systemd
+    # Section.
+    section: default
+    # Priority.
+    priority: extra
+    rpm:
+      scripts:
+        posttrans: "build/package/rpm/postinst-systemd.sh"
+
+      summary: "New Relic Infrastructure Agent"
+      group: default
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+    recommends:
+      - td-agent-bit
 
 release:
   disable: true

--- a/build/embed/fluent-bit.mk
+++ b/build/embed/fluent-bit.mk
@@ -6,29 +6,17 @@ fb_version_file       ?= $(current_dir)/fluent-bit.version
 # The second argument $(2) specifies which column to return
 get-fb_version          = $(shell awk -v col=$(2) -F, '/^$(1),/ {print $$col}' ${fb_version_file})
 
-NRFB_VERSION_LINUX      ?= $(call get-fb_version,linux,3)
 NR_PLUGIN_VERSION_LINUX ?= $(call get-fb_version,linux,2)
 
 FB_ARCH                 ?= amd64
 
-NRFB_URL                 = https://github.com/newrelic-experimental/fluent-bit-package/releases/download/$(NRFB_VERSION_LINUX)/fb-linux-$(FB_ARCH).tar.gz
 NR_PLUGIN_URL            = https://github.com/newrelic/newrelic-fluent-bit-output/releases/download/v$(NR_PLUGIN_VERSION_LINUX)/out_newrelic-linux-$(FB_ARCH)-$(NR_PLUGIN_VERSION_LINUX).so
 
 .PHONY: get-fluentbit-linux
 get-fluentbit-linux:
 	@printf '\n================================================================\n'
-	@printf 'Target: download nr fluentbit for linux'
+	@printf 'Target: download nr fluentbit plugin for linux'
 	@printf '\n================================================================\n'
-
-	@printf '\ndownload fluent-bit\n'
-	@rm -rf $(TARGET_DIR)/fluent-bit/$(FB_ARCH)/
-	@mkdir -p $(TARGET_DIR)/fluent-bit/$(FB_ARCH)/
-	@if curl --output /dev/null --silent --head --fail '$(NRFB_URL)'; then \
-		curl -L --silent '$(NRFB_URL)' | tar xvz --no-same-owner -C $(TARGET_DIR)/fluent-bit/$(FB_ARCH) ;\
-	else \
-	  echo 'nrfb version $(NRFB_VERSION_LINUX) URL does not exist: $(NRFB_URL)' ;\
-	  exit 1 ;\
-	fi
 
 	@printf '\ndownload fluent-bit nr plugin\n'
 	@rm -rf $(TARGET_DIR)/fluent-bit-plugin/$(FB_ARCH)/

--- a/build/embed/fluent-bit.version
+++ b/build/embed/fluent-bit.version
@@ -1,8 +1,6 @@
 ####
 # newrelic_plugin_version - https://github.com/newrelic/newrelic-fluent-bit-output/releases
 #
-# nrfb_artifact_version   - https://github.com/newrelic-experimental/fluent-bit-package/releases
-#
-# OS,newrelic_plugin_version,nrfb_artifact_version
-linux,1.1.0,1.3.0
-windows,1.4.6,1.7.3
+# OS,newrelic_plugin_version
+linux,1.1.0
+windows,1.4.6

--- a/build/upload-schema-linux-rpm.yml
+++ b/build/upload-schema-linux-rpm.yml
@@ -45,3 +45,14 @@
         - 12.2
         - 12.3
         - 12.4
+
+- src: "newrelic-infra-{version}-1.amazonlinux-{os_version}.{arch}.rpm"
+  arch:
+    - x86_64
+    - arm
+    - arm64
+  uploads:
+    - type: yum
+      dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"
+      os_version:
+        - 2


### PR DESCRIPTION
### FB as package weak dependency
Added fluent-bit as infra-agent package weak dependency. If the fb package `td-agent-bit` is not found, the agent installation will not be interrupted.

For distributions that do not support weak dependencies ( rpm version < 4.12.0 ) for fb package is added as a required dependency:
* Red Hat 7
* Centos 7 
* Amazon Linux 2

### Publish action upgrade
Publish action is upgraded to latest version which uses `centos-8` as base image. The version of `createrepo` included in `debian buster` based image didn't support rpm weak dependencies.

### Amazon Linux 2 own package
Amazon Linux 2 rpm packages will be distributed from their own repository (until now centos-7 one was used) as FB has separated packages for AL2.