### PR TITLE
feat: changed location from where the agent executes fluent-bit

### DIFF
--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -37,9 +37,10 @@ func init() {
 		"index-1": {"tun", "tap"},
 	}
 
-	defaultLoggingBinDir = "logging"
+	defaultLoggingBinDir = "/opt/td-agent-bit/bin"
+	defaultLoggingHomeDir = "logging"
 	defaultLoggingConfigsDir = "logging.d"
-	defaultFluentBitExe = "fluent-bit"
+	defaultFluentBitExe = "td-agent-bit"
 	defaultFluentBitParsers = "parsers.conf"
 	defaultFluentBitNRLib = "out_newrelic.so"
 

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -39,6 +39,7 @@ func init() {
 	defaultPluginConfigFiles = []string{filepath.Join(defaultAgentDir, "newrelic-infra-plugins.yml")}
 
 	defaultLoggingBinDir = "logging"
+	defaultLoggingHomeDir = "logging"
 	defaultLoggingConfigsDir = "logging.d"
 
 	defaultFluentBitExe = "fluent-bit.exe"

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -111,6 +111,7 @@ var (
 	defaultConfigDir               string
 	defaultLoggingConfigsDir       string
 	defaultLoggingBinDir           string
+	defaultLoggingHomeDir          string
 	defaultFluentBitExe            string
 	defaultFluentBitParsers        string
 	defaultFluentBitNRLib          string

--- a/pkg/integrations/v4/logs/loader_test.go
+++ b/pkg/integrations/v4/logs/loader_test.go
@@ -391,7 +391,7 @@ logs:
 
 func newTestConf(folder string, troubleCfg config.Troubleshoot) config.LogForward {
 	cfg := &config.Config{
-		LoggingBinDir:     "/var/db/newrelic-infra/newrelic-integrations/logging",
+		LoggingHomeDir:    "/var/db/newrelic-infra/newrelic-integrations/logging",
 		LoggingConfigsDir: folder,
 		License:           "license",
 	}


### PR DESCRIPTION
This PR will change the default location for fluent-bit executable on Linux
from:
`/var/db/newrelic-infra/newrelic-integrations/logging/fluent-bit`
into:
`/opt/td-agent-bit/bin/td-agent-bit`
Windows path remain the same.