### PR TITLE
Add identity and command channel gov endpoints (#529)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1456,9 +1456,12 @@ func calculateCollectorURL(licenseKey string, staging, fedramp bool) string {
 	return fmt.Sprintf(baseCollectorURL, urlEnvironmentPrefix(staging), urlRegionPrefix(licenseKey))
 }
 
-func calculateIdentityURL(licenseKey string, staging bool) string {
+func calculateIdentityURL(licenseKey string, staging, fedramp bool) string {
 	if staging {
 		return calculateIdentityStagingURL(licenseKey)
+	}
+	if fedramp {
+		return defaultSecureFedralIdentityURL
 	}
 	return calculateIdentityProductionURL(licenseKey)
 }
@@ -1479,9 +1482,12 @@ func calculateIdentityStagingURL(licenseKey string) string {
 	return defaultIdentityStagingURL
 }
 
-func calculateCmdChannelURL(licenseKey string, staging bool) string {
+func calculateCmdChannelURL(licenseKey string, staging, fedramp bool) string {
 	if staging {
 		return calculateCmdChannelStagingURL(licenseKey)
+	}
+	if fedramp {
+		return defaultSecureFedralCmdChannelURL
 	}
 	return calculateCmdChannelProductionURL(licenseKey)
 }
@@ -1580,11 +1586,11 @@ func NormalizeConfig(cfg *Config, cfgMetadata config_loader.YAMLMetadata) (err e
 	nlog.WithField("collectorURL", cfg.CollectorURL).Debug("Collector URL")
 
 	if cfg.IdentityURL == "" {
-		cfg.IdentityURL = calculateIdentityURL(cfg.License, cfg.Staging)
+		cfg.IdentityURL = calculateIdentityURL(cfg.License, cfg.Staging, cfg.Fedramp)
 	}
 
 	if cfg.CommandChannelURL == "" {
-		cfg.CommandChannelURL = calculateCmdChannelURL(cfg.License, cfg.Staging)
+		cfg.CommandChannelURL = calculateCmdChannelURL(cfg.License, cfg.Staging, cfg.Fedramp)
 	}
 
 	//InventoryIngestEndpoint default value defined in NewConfig

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -441,6 +441,7 @@ func (s *ConfigSuite) TestCalculateIdentityURL(c *C) {
 		license   string
 		expectURL string
 		staging   bool
+		fedramp   bool
 	}{
 		// non-region license
 		{license: "0123456789012345678901234567890123456789", expectURL: defaultIdentityURL, staging: false},
@@ -454,10 +455,12 @@ func (s *ConfigSuite) TestCalculateIdentityURL(c *C) {
 		{license: "gov01x6789012345678901234567890123456789", expectURL: defaultIdentityURL, staging: false},
 		// five letter region
 		{license: "gov01x6789012345678901234567890123456789", expectURL: defaultIdentityStagingURL, staging: true},
+		// non-region license, fedramp true
+		{license: "0123456789012345678901234567890123456789", expectURL: defaultSecureFedralIdentityURL, staging: false, fedramp: true},
 	}
 
 	for _, tc := range testcases {
-		c.Assert(calculateIdentityURL(tc.license, tc.staging), Equals, tc.expectURL)
+		c.Assert(calculateIdentityURL(tc.license, tc.staging, tc.fedramp), Equals, tc.expectURL)
 	}
 }
 
@@ -466,6 +469,7 @@ func (s *ConfigSuite) TestCalculateCmdChannelURL(c *C) {
 		license   string
 		expectURL string
 		staging   bool
+		fedramp   bool
 	}{
 		// non-region license
 		{license: "0123456789012345678901234567890123456789", expectURL: defaultCmdChannelURL, staging: false},
@@ -479,10 +483,12 @@ func (s *ConfigSuite) TestCalculateCmdChannelURL(c *C) {
 		{license: "gov01x6789012345678901234567890123456789", expectURL: defaultCmdChannelURL, staging: false},
 		// five letter region
 		{license: "gov01x6789012345678901234567890123456789", expectURL: defaultCmdChannelStagingURL, staging: true},
+		// non-region license, fedramp true
+		{license: "0123456789012345678901234567890123456789", expectURL: defaultSecureFedralCmdChannelURL, staging: false, fedramp: true},
 	}
 
 	for _, tc := range testcases {
-		c.Assert(calculateCmdChannelURL(tc.license, tc.staging), Equals, tc.expectURL)
+		c.Assert(calculateCmdChannelURL(tc.license, tc.staging, tc.fedramp), Equals, tc.expectURL)
 	}
 }
 

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -15,17 +15,19 @@ const (
 	LogFormatJSON = "json"
 
 	// Non configurable stuff
-	defaultIdentityURLEu          = "https://identity-api.eu.newrelic.com"
-	defaultIdentityStagingURLEu   = "https://staging-identity-api.eu.newrelic.com"
-	defaultCmdChannelURLEu        = "https://infrastructure-command-api.eu.newrelic.com"
-	defaultCmdChannelStagingURLEu = "https://staging-infrastructure-command-api.eu.newrelic.com"
-	defaultCmdChannelURL          = "https://infrastructure-command-api.newrelic.com"
-	defaultCmdChannelStagingURL   = "https://staging-infrastructure-command-api.newrelic.com"
-	defaultIdentityURL            = "https://identity-api.newrelic.com"
-	defaultIdentityStagingURL     = "https://staging-identity-api.newrelic.com"
-	baseCollectorURL              = "https://%sinfra-api.%snewrelic.com"
-	baseDimensionalMetricURL      = "https://%smetric-api.%snewrelic.com"
-	defaultSecureFederalURL       = "https://gov-infra-api.newrelic.com"
+	defaultIdentityURLEu             = "https://identity-api.eu.newrelic.com"
+	defaultIdentityStagingURLEu      = "https://staging-identity-api.eu.newrelic.com"
+	defaultCmdChannelURLEu           = "https://infrastructure-command-api.eu.newrelic.com"
+	defaultCmdChannelStagingURLEu    = "https://staging-infrastructure-command-api.eu.newrelic.com"
+	defaultCmdChannelURL             = "https://infrastructure-command-api.newrelic.com"
+	defaultCmdChannelStagingURL      = "https://staging-infrastructure-command-api.newrelic.com"
+	defaultIdentityURL               = "https://identity-api.newrelic.com"
+	defaultIdentityStagingURL        = "https://staging-identity-api.newrelic.com"
+	baseCollectorURL                 = "https://%sinfra-api.%snewrelic.com"
+	baseDimensionalMetricURL         = "https://%smetric-api.%snewrelic.com"
+	defaultSecureFederalURL          = "https://gov-infra-api.newrelic.com"
+	defaultSecureFedralIdentityURL   = "https://gov-identity-api.newrelic.com"
+	defaultSecureFedralCmdChannelURL = "https://gov-infrastructure-command-api.newrelic.com"
 )
 
 // Default configurable values


### PR DESCRIPTION
* feat: add identity and command channel gov endpoints

This will add default gov endpoints for the identity api and command channel api.