### PR TITLE
fix: Fix logging fedRamp endpoint

### DIFF
--- a/pkg/integrations/v4/logs/cfg.go
+++ b/pkg/integrations/v4/logs/cfg.go
@@ -22,7 +22,7 @@ var cfgLogger = log.WithComponent("integrations.Supervisor.Config").WithField("p
 // FluentBit default values.
 const (
 	euEndpoint              = "https://log-api.eu.newrelic.com/log/v1"
-	fedrampEndpoint         = "https://gov-log-api.newrelic.com"
+	fedrampEndpoint         = "https://gov-log-api.newrelic.com/log/v1"
 	stagingEndpoint         = "https://staging-log-api.newrelic.com/log/v1"
 	logRecordModifierSource = "nri-agent"
 	defaultBufferMaxSize    = 128


### PR DESCRIPTION
Customers are experiencing 403s because the logging endpoint is not complete.  This PR fixes the endpoint