### PR TITLE
add gov metric API URL

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1514,7 +1514,7 @@ func calculateDimensionalMetricURL(collectorURL string, licenseKey string, stagi
 	}
 
 	if fedramp && !staging {
-		return defaultSecureFederalURL
+		return defaultSecureFederalMetricURL
 	}
 
 	return fmt.Sprintf(baseDimensionalMetricURL, urlEnvironmentPrefix(staging), urlRegionPrefix(licenseKey))

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -418,7 +418,7 @@ func (s *ConfigSuite) TestCalculateDimensionalMetricURL(c *C) {
 			"",
 			false,
 			true,
-			"https://gov-infra-api.newrelic.com",
+			"https://gov-metric-api.newrelic.com",
 		},
 		{
 			"Staging flag prevails over fedramp one",

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -26,6 +26,7 @@ const (
 	baseCollectorURL                 = "https://%sinfra-api.%snewrelic.com"
 	baseDimensionalMetricURL         = "https://%smetric-api.%snewrelic.com"
 	defaultSecureFederalURL          = "https://gov-infra-api.newrelic.com"
+	defaultSecureFederalMetricURL    = "https://gov-metric-api.newrelic.com"
 	defaultSecureFedralIdentityURL   = "https://gov-identity-api.newrelic.com"
 	defaultSecureFedralCmdChannelURL = "https://gov-infrastructure-command-api.newrelic.com"
 )


### PR DESCRIPTION
The shim for DM in infra-api is no longer needed for gov customers as gov-metric-api has been launched some time ago. I'm following the same pattern for the rest of the gov URLs, though I know there could be some cleanup here as to how they are generated. This seems easier / cleaner.