### PR TITLE
added log line when disconnect call finished

### DIFF
--- a/internal/agent/connect_service.go
+++ b/internal/agent/connect_service.go
@@ -138,5 +138,6 @@ func (ic *identityConnectService) Disconnect(agentID entity.ID, state identityap
 		return err
 	}
 
+	logger.WithField("state", state).Info("disconnect call finished")
 	return nil
 }


### PR DESCRIPTION
We cannot see in the info logs if the agent passed the point of performing the disconnect call