### PR TITLE
Trace non dimensional metrics payload submissions

### DIFF
--- a/assets/examples/infrastructure/newrelic-infra-template.yml.example
+++ b/assets/examples/infrastructure/newrelic-infra-template.yml.example
@@ -707,13 +707,18 @@ license_key: your_license_key
 #            Traces are additional log entries used for debugging purposes of
 #            specific features, and are only shown when verbose is set to True.
 # Default  : []
-# Info     : Currently, only three features have traces defined: hostname,
-#            connect, and attributes.
 #
 #traces:
-#  - connect
+#  - connect (enabled by default)
 #  - attributes
 #  - hostname
+#  - dm.submission
+#  - v3.submission
+#  - metric.match
+#  - inventory
+#  - log.fw
+#  - cmdreq
+#  - proc
 
 #
 # Option   : container_cache_metadata_limit

--- a/internal/agent/event_sender.go
+++ b/internal/agent/event_sender.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/newrelic/infrastructure-agent/pkg/log"
+	"github.com/newrelic/infrastructure-agent/pkg/trace"
 	"github.com/sirupsen/logrus"
 
 	"github.com/newrelic/infrastructure-agent/pkg/backend/backoff"
@@ -457,6 +458,8 @@ func (sender *metricsIngestSender) doPost(post []*MetricPost, agentKey string) e
 		}
 		req.Header.Set(backendhttp.AgentEntityIdHeader, agentID.String())
 	}
+
+	trace.NonDMSubmission(postBytes)
 
 	resp, err := sender.HttpClient(req)
 	if err != nil {

--- a/internal/httpapi/httpapi_test.go
+++ b/internal/httpapi/httpapi_test.go
@@ -55,7 +55,6 @@ func TestServe_Status(t *testing.T) {
 	go s.Serve(ctx)
 
 	s.WaitUntilReady()
-	time.Sleep(100 * time.Millisecond)
 
 	// And a request to the status API is sent
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%d%s", port, statusAPIPath), bytes.NewReader([]byte{}))
@@ -114,7 +113,6 @@ func TestServe_OnlyErrors(t *testing.T) {
 	go s.Serve(ctx)
 
 	s.WaitUntilReady()
-	time.Sleep(100 * time.Millisecond)
 
 	// And a request to the status API is sent
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%d%s", port, statusOnlyErrorsAPIPath), bytes.NewReader([]byte{}))
@@ -164,7 +162,7 @@ func TestServe_IngestData(t *testing.T) {
 	}()
 
 	select {
-	case <-time.NewTimer(500 * time.Millisecond).C:
+	case <-time.NewTimer(1000 * time.Millisecond).C:
 		t.Error("timeout waiting for HTTP request to be submitted")
 	case <-payloadWritten:
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -679,7 +679,7 @@ type Config struct {
 
 	// FeatureTraces enables traces (verbose logs) for a given set of features, aimed to troubleshoot issues, available
 	// features at trace/features.go
-	// Default: "connect"
+	// Default: ["connect"]
 	// Public: No
 	FeatureTraces []string `yaml:"trace" envconfig:"trace" public:"false"`
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -679,7 +679,7 @@ type Config struct {
 
 	// FeatureTraces enables traces (verbose logs) for a given set of features, aimed to troubleshoot issues, available
 	// features at trace/features.go
-	// Default: Empty
+	// Default: "connect"
 	// Public: No
 	FeatureTraces []string `yaml:"trace" envconfig:"trace" public:"false"`
 

--- a/pkg/trace/features.go
+++ b/pkg/trace/features.go
@@ -16,6 +16,7 @@ const (
 	CONN           Feature = "connect"    // fingerprint connect
 	HOSTNAME       Feature = "hostname"
 	DM_SUBMISSION  Feature = "dm.submission" // dimensional metrics submission
+	V3_SUBMISSION  Feature = "v3.submission" // non dimensional metrics (integration protocol v3) submission
 	METRIC_MATCHER Feature = "metric.match"  // match metric by rule
 	INVENTORY      Feature = "inventory"
 	LOG_FWD        Feature = "log.fw"
@@ -44,6 +45,11 @@ func Connect(format string, args ...interface{}) {
 // Hostname always traces hostname feature.
 func Hostname(format string, args ...interface{}) {
 	On(func() bool { return true }, HOSTNAME, format, args...)
+}
+
+// NonDMSubmission traces NR platform non-dimensional metrics submission payloads.
+func NonDMSubmission(payload []byte) {
+	On(func() bool { return true }, V3_SUBMISSION, string(payload))
 }
 
 // Telemetry traces to "audit" (log payloads) on DM telemetry.


### PR DESCRIPTION
Add a trace to log non dimensional *metrics* payload submissions to NewRelic platform.

This trace is disabled by default, it should be enabled as defined below.

## Docs

Public link: https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/#debug-variables

Example: https://github.com/newrelic/infrastructure-agent/blob/master/assets/examples/infrastructure/newrelic-infra-template.yml.example#L704

## Usage

Via YAML config:

```yaml
trace:
- v3.submission
```

Or env-var:

```sh
NRIA_TRACE="v3.submission"
```
