### PR TITLE
feat: structure traces feature into proper field

### DIFF
--- a/pkg/metrics/sampler/matcher_test.go
+++ b/pkg/metrics/sampler/matcher_test.go
@@ -558,7 +558,7 @@ func Test_EvaluatorChain_LogTraceMatcher(t *testing.T) {
 
 	require.NotEmpty(t, hook.AllEntries())
 	entry := hook.LastEntry()
-	assert.Equal(t, "[metric.match] 'java' matches expression [ProcessDisplayName processDisplayName] >> 'java': true", entry.Message)
+	assert.Equal(t, "'java' matches expression [ProcessDisplayName processDisplayName] >> 'java': true", entry.Message)
 	assert.Equal(t, logrus.TraceLevel, entry.Level)
 }
 

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -3,8 +3,6 @@
 package trace
 
 import (
-	"fmt"
-
 	"github.com/sirupsen/logrus"
 )
 
@@ -43,7 +41,7 @@ func On(condition Condition, feature Feature, format string, args ...interface{}
 	}
 
 	if _, ok := global.enabled[feature]; ok && condition() {
-		global.logger.Tracef(fmt.Sprintf("[%s] %s", feature, format), args...)
+		global.logger.WithField("feature", feature).Tracef(format, args...)
 	}
 }
 


### PR DESCRIPTION
Convert logged trace message: field+msg into structured fields `feature` + `msg`.

Current trace format:
```
time="2021-06-29T10:07:21+02:00" level=trace msg="[v3.submission] [{\"EntityID\":40716074594850361,\"IsAgent\":true...
```

New structured format:
```
time="2021-06-29T10:07:21+02:00" level=trace feature="v3.submission" msg="[{\"EntityID\":40716074594850361,\"IsAgent\":true...
```