### PR TITLE
fix: HTTP APIs enablement flags

### DIFF
--- a/cmd/newrelic-infra/newrelic-infra.go
+++ b/cmd/newrelic-infra/newrelic-infra.go
@@ -344,7 +344,7 @@ func initializeAgentAndRun(c *config.Config, logFwCfg config.LogForward) error {
 			aslog.WithError(err).Error("invalid startup_connection_timeout value, cannot run status server")
 		} else {
 			rep := status.NewReporter(agt.Context.Ctx, rlog, c.StatusEndpoints, timeoutD, transport, agt.Context.AgentIdnOrEmpty, c.License, userAgent)
-			apiCfg := httpapi.NewConfig(c.StatusServerEnabled, c.HTTPServerHost, c.HTTPServerPort, c.HTTPServerEnabled, c.StatusServerPort)
+			apiCfg := httpapi.NewConfig(c.HTTPServerEnabled, c.HTTPServerHost, c.HTTPServerPort, c.StatusServerEnabled, c.StatusServerPort)
 			apiSrv, err := httpapi.NewServer(apiCfg, rep, integrationEmitter)
 			if err != nil {
 				aslog.WithError(err).Error("cannot run api server")


### PR DESCRIPTION
Fixes regression mixing up enablement flags from HTTP APIs: status and data ingest.