### PR TITLE
fix: CI infra gpg for debian buster

### DIFF
--- a/test/automated/ansible/roles/install-gpg/tasks/main.yml
+++ b/test/automated/ansible/roles/install-gpg/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: 'install gpg'
   ansible.builtin.package:
-    name: gpg
+    name: gpgv
     state: present
   when: "inventory_hostname in instances_without_gpg"
 


### PR DESCRIPTION
Fixes GPG package name for CI infra Debian Buster boxes throwing error `No package matching 'gpg' is available`.

`gpgv` only supports verifying signatures, but that's enough.