### PR TITLE
CI infra: replace gpgv with gnupg2

### DIFF
--- a/test/automated/ansible/install-requirements.yml
+++ b/test/automated/ansible/install-requirements.yml
@@ -2,7 +2,6 @@
 
 - hosts: testing_hosts
   become: true
-  gather_facts: no
 
   tasks:
     - name: Remove EOL repository sources

--- a/test/automated/ansible/roles/install-gpg/tasks/main.yml
+++ b/test/automated/ansible/roles/install-gpg/tasks/main.yml
@@ -5,6 +5,7 @@
     name: gnupg2
     state: present
     update_cache: yes
-  when: "inventory_hostname in instances_without_gpg"
+  when: inventory_hostname in instances_without_gpg and
+        (ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu')
 
 ...

--- a/test/automated/ansible/roles/install-gpg/tasks/main.yml
+++ b/test/automated/ansible/roles/install-gpg/tasks/main.yml
@@ -1,9 +1,10 @@
 ---
 
 - name: 'install gpg'
-  ansible.builtin.package:
-    name: gpgv
+  apt:
+    name: gnupg2
     state: present
+    update_cache: yes
   when: "inventory_hostname in instances_without_gpg"
 
 ...


### PR DESCRIPTION
Fixed: CI infra replace gpgv with gnupg2 for debian buster

We actually need `gpg` command available in the boxes.
