### PR TITLE
chore: bump nri-flex

### DIFF
--- a/build/embed/integrations.version
+++ b/build/embed/integrations.version
@@ -1,5 +1,5 @@
 #ohi-repo-name,version
 nri-docker,1.6.0
-nri-flex,1.4.1
+nri-flex,1.4.2
 nri-winservices,v0.2.0-beta
 nri-prometheus,2.7.0


### PR DESCRIPTION
Bumps nri-flex to [1.4.2](https://github.com/newrelic/nri-flex/releases/tag/v1.4.2) fixing Flex CVE-2020-29652 