### PR TITLE
Split tarball staged releases per OS

### DIFF
--- a/.github/workflows/prerelease_staged_publish.yml
+++ b/.github/workflows/prerelease_staged_publish.yml
@@ -30,6 +30,7 @@ jobs:
   publishing-to-s3-linux:
     name: Publish linux artifacts into s3 staging bucket
     runs-on: ubuntu-20.04
+    if: ${{ (github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType) && (github.event.inputs.targzOS == 'all' || github.event.inputs.targzOS == matrix.targzOS) }}
 
     strategy:
       max-parallel: 1
@@ -41,13 +42,11 @@ jobs:
 
     steps:
       - name: Login to DockerHub
-        if: ${{ github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType }}
         uses: docker/login-action@v1
         with:
           username: ${{ env.DOCKER_HUB_ID }}
           password: ${{ env.DOCKER_HUB_PASSWORD }}
       - name: Publish ${{ matrix.assetsType }} to S3 action
-        if: ${{ github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType }}
         uses: newrelic/infrastructure-publish-action@v1.0.14
         env:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
@@ -76,6 +75,7 @@ jobs:
   publishing-to-s3-macos:
     name: Publish macos artifacts into s3 staging bucket
     runs-on: ubuntu-20.04
+    if: ${{ (github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType) && (github.event.inputs.targzOS == 'all' || github.event.inputs.targzOS == matrix.targzOS) }}
 
     strategy:
       max-parallel: 1
@@ -87,13 +87,11 @@ jobs:
 
     steps:
       - name: Login to DockerHub
-        if: ${{ github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType }}
         uses: docker/login-action@v1
         with:
           username: ${{ env.DOCKER_HUB_ID }}
           password: ${{ env.DOCKER_HUB_PASSWORD }}
       - name: Publish ${{ matrix.assetsType }} to S3 action
-        if: ${{ github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType }}
         uses: newrelic/infrastructure-publish-action@v1.0.14
         env:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
@@ -122,6 +120,7 @@ jobs:
   publishing-to-s3-windows:
     name: Publish windows artifacts into s3 staging bucket
     runs-on: ubuntu-20.04
+    if: ${{ (github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType) && (github.event.inputs.targzOS == 'all' || github.event.inputs.targzOS == matrix.targzOS) }}
 
     strategy:
       matrix:
@@ -131,13 +130,11 @@ jobs:
 
     steps:
       - name: Login to DockerHub
-        if: ${{ github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType }}
         uses: docker/login-action@v1
         with:
           username: ${{ env.DOCKER_HUB_ID }}
           password: ${{ env.DOCKER_HUB_PASSWORD }}
       - name: Publish ${{ matrix.assetsType }} to S3 action
-        if: ${{ github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType }}
         uses: newrelic/infrastructure-publish-action@v1.0.14
         env:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/prerelease_staged_publish.yml
+++ b/.github/workflows/prerelease_staged_publish.yml
@@ -120,7 +120,7 @@ jobs:
   publishing-to-s3-windows:
     name: Publish windows artifacts into s3 staging bucket
     runs-on: ubuntu-20.04
-    if: ${{ (github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType) && (github.event.inputs.targzOS == 'all' || github.event.inputs.targzOS == matrix.targzOS) }}
+    if: ${{ github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType }}
 
     strategy:
       matrix:

--- a/.github/workflows/release_staged.yml
+++ b/.github/workflows/release_staged.yml
@@ -127,7 +127,7 @@ jobs:
   publishing-to-s3-windows:
     name: Publish windows artifacts into s3 prod bucket
     runs-on: ubuntu-20.04
-    if: ${{ (github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType) && (github.event.inputs.targzOS == 'all' || github.event.inputs.targzOS == matrix.targzOS) }}
+    if: ${{ github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType }}
 
     strategy:
       matrix:
@@ -167,7 +167,7 @@ jobs:
           aws_region: ${{ env.AWS_REGION }}
 
   publish-docker-images:
-    if: ${{ (github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == 'docker') && (github.event.inputs.targzOS == 'all' || github.event.inputs.targzOS == matrix.targzOS) }}
+    if: ${{ github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == 'docker' }}
     name: Create versioned and latest images from RC
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/release_staged.yml
+++ b/.github/workflows/release_staged.yml
@@ -10,6 +10,10 @@ on:
         description: 'Assets type to release: all, docker, targz, zip, msi, deb, rpm'
         required: true
         default: 'all'
+      targzOS:
+        description: 'OS for which tarballs will be released: all, linux, macos'
+        required: true
+        default: 'all'
 
 env:
   GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
@@ -30,6 +34,7 @@ jobs:
   publishing-to-s3-linux:
     name: Publish linux artifacts into s3 prod bucket
     runs-on: ubuntu-20.04
+    if: ${{ (github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType) && (github.event.inputs.targzOS == 'all' || github.event.inputs.targzOS == matrix.targzOS) }}
 
     strategy:
       max-parallel: 1
@@ -38,16 +43,16 @@ jobs:
           - "targz"
           - "deb"
           - "rpm"
+        targzOS:
+          - "linux"
 
     steps:
       - name: Login to DockerHub
-        if: ${{ github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType }}
         uses: docker/login-action@v1
         with:
           username: ${{ env.DOCKER_HUB_ID }}
           password: ${{ env.DOCKER_HUB_PASSWORD }}
       - name: Publish ${{ matrix.assetsType }} to S3 action
-        if: ${{ github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType }}
         uses: newrelic/infrastructure-publish-action@v1.0.14
         env:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
@@ -76,22 +81,23 @@ jobs:
   publishing-to-s3-macos:
     name: Publish macos artifacts into s3 prod bucket
     runs-on: ubuntu-20.04
+    if: ${{ (github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType) && (github.event.inputs.targzOS == 'all' || github.event.inputs.targzOS == matrix.targzOS) }}
 
     strategy:
       max-parallel: 1
       matrix:
         assetsType:
           - "targz"
+        targzOS:
+          - "macos"
 
     steps:
       - name: Login to DockerHub
-        if: ${{ github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType }}
         uses: docker/login-action@v1
         with:
           username: ${{ env.DOCKER_HUB_ID }}
           password: ${{ env.DOCKER_HUB_PASSWORD }}
       - name: Publish ${{ matrix.assetsType }} to S3 action
-        if: ${{ github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType }}
         uses: newrelic/infrastructure-publish-action@v1.0.14
         env:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
@@ -121,6 +127,7 @@ jobs:
   publishing-to-s3-windows:
     name: Publish windows artifacts into s3 prod bucket
     runs-on: ubuntu-20.04
+    if: ${{ (github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType) && (github.event.inputs.targzOS == 'all' || github.event.inputs.targzOS == matrix.targzOS) }}
 
     strategy:
       matrix:
@@ -130,13 +137,11 @@ jobs:
 
     steps:
       - name: Login to DockerHub
-        if: ${{ github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType }}
         uses: docker/login-action@v1
         with:
           username: ${{ env.DOCKER_HUB_ID }}
           password: ${{ env.DOCKER_HUB_PASSWORD }}
       - name: Publish ${{ matrix.assetsType }} to S3 action
-        if: ${{ github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == matrix.assetsType }}
         uses: newrelic/infrastructure-publish-action@v1.0.14
         env:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
@@ -162,7 +167,7 @@ jobs:
           aws_region: ${{ env.AWS_REGION }}
 
   publish-docker-images:
-    if: ${{ github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == 'docker' }}
+    if: ${{ (github.event.inputs.assetsType == 'all' || github.event.inputs.assetsType == 'docker') && (github.event.inputs.targzOS == 'all' || github.event.inputs.targzOS == matrix.targzOS) }}
     name: Create versioned and latest images from RC
     runs-on: ubuntu-20.04
 


### PR DESCRIPTION
Be able to release (staged version) tarballs `targz` per OS: either `linux`, `macos` or `all` (both).