### PR TITLE
Missing CI checkout previous to purge CDN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,7 @@ jobs:
     needs: [ publishing-to-s3-windows, publishing-to-s3-linux, publishing-to-s3-macos ]
     runs-on: ubuntu-20.04
     steps:
+      - uses: actions/checkout@v2
       - name: Fasty purge
         env:
           FASTLY_KEY: ${{secrets.FASTLY_KEY }}

--- a/.github/workflows/release_staged.yml
+++ b/.github/workflows/release_staged.yml
@@ -174,6 +174,7 @@ jobs:
     needs: [ publishing-to-s3-windows, publishing-to-s3-linux, publishing-to-s3-macos ]
     runs-on: ubuntu-20.04
     steps:
+      - uses: actions/checkout@v2
       - name: Fasty purge
         env:
           FASTLY_KEY: ${{secrets.FASTLY_KEY }}


### PR DESCRIPTION
Fixes missing checkout previous to run purge CDN script.
See: https://github.com/newrelic/infrastructure-agent/runs/3019770823?check_suite_focus=true