### PR TITLE
feat: lazy loaded DM harvester

### DIFF
--- a/pkg/integrations/v4/dm/lazy_harvester.go
+++ b/pkg/integrations/v4/dm/lazy_harvester.go
@@ -1,0 +1,57 @@
+// Copyright 2021 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dm
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/newrelic/infrastructure-agent/internal/agent/id"
+	telemetry "github.com/newrelic/infrastructure-agent/pkg/backend/telemetryapi"
+)
+
+func NewLazyLoadedHarvester(config MetricsSenderConfig, transport http.RoundTripper, idProvide id.Provide) metricHarvester {
+	return &lazyLoadHarvester{
+		config:    config,
+		transport: transport,
+		idProvide: idProvide,
+	}
+}
+
+type lazyLoadHarvester struct {
+	harvester metricHarvester
+	once      sync.Once
+	config    MetricsSenderConfig
+	transport http.RoundTripper
+	idProvide id.Provide
+}
+
+func (l *lazyLoadHarvester) load() (err error) {
+	l.once.Do(func() {
+		l.harvester, err = newTelemetryHarverster(l.config, l.transport, l.idProvide)
+	})
+	return
+}
+
+func (l *lazyLoadHarvester) RecordMetric(m telemetry.Metric) {
+	if l.harvester == nil {
+		if err := l.load(); err != nil {
+			logger.WithError(err).Error("cannot load telemetry harvester, dimensional metrics will be lost")
+			return
+		}
+	}
+
+	l.harvester.RecordMetric(m)
+}
+
+func (l *lazyLoadHarvester) RecordInfraMetrics(commonAttribute telemetry.Attributes, metrics []telemetry.Metric) error {
+	if l.harvester == nil {
+		if err := l.load(); err != nil {
+			return fmt.Errorf("cannot load telemetry harvester: %v", err)
+		}
+	}
+
+	return l.harvester.RecordInfraMetrics(commonAttribute, metrics)
+}

--- a/pkg/integrations/v4/dm/lazy_harvester_test.go
+++ b/pkg/integrations/v4/dm/lazy_harvester_test.go
@@ -1,0 +1,62 @@
+// Copyright 2021 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dm
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/newrelic/infrastructure-agent/pkg/backend/telemetryapi"
+	"github.com/newrelic/infrastructure-agent/pkg/entity"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_lazyLoadHarvester_RecordMetric(t *testing.T) {
+	conf := NewConfig("", false, "", time.Second, 1, 1)
+	emptyIDProvide := func() entity.Identity {
+		return entity.EmptyIdentity
+	}
+
+	l := NewLazyLoadedHarvester(conf, http.DefaultTransport, emptyIDProvide)
+
+	ll, ok := l.(*lazyLoadHarvester)
+	require.True(t, ok)
+
+	require.IsType(t, nil, ll.harvester)
+	l.RecordMetric(telemetryapi.Count{
+		Name:           "myCount",
+		AttributesJSON: json.RawMessage(`{"foo":"bar"}`),
+		Value:          123,
+		Timestamp:      time.Now(),
+		Interval:       1 * time.Second,
+	})
+	require.IsType(t, &telemetryapi.Harvester{}, ll.harvester)
+}
+func Test_lazyLoadHarvester_RecordInfraMetrics(t *testing.T) {
+	conf := NewConfig("", false, "", time.Second, 1, 1)
+	emptyIDProvide := func() entity.Identity {
+		return entity.EmptyIdentity
+	}
+
+	l := NewLazyLoadedHarvester(conf, http.DefaultTransport, emptyIDProvide)
+
+	ll, ok := l.(*lazyLoadHarvester)
+	require.True(t, ok)
+
+	require.IsType(t, nil, ll.harvester)
+	ats := telemetryapi.Attributes(map[string]interface{}{
+		"foo": "bar",
+	})
+	myCount := telemetryapi.Count{
+		Name:           "myCount",
+		AttributesJSON: json.RawMessage(`{"foo":"bar"}`),
+		Value:          123,
+		Timestamp:      time.Now(),
+		Interval:       1 * time.Second,
+	}
+	l.RecordInfraMetrics(ats, []telemetryapi.Metric{myCount})
+	require.IsType(t, &telemetryapi.Harvester{}, ll.harvester)
+}

--- a/pkg/integrations/v4/dm/sender.go
+++ b/pkg/integrations/v4/dm/sender.go
@@ -44,9 +44,8 @@ func NewConfig(url string, fedramp bool, licenseKey string, submissionPeriod tim
 
 // NewDMSender creates a Dimensional Metrics sender.
 func NewDMSender(config MetricsSenderConfig, transport http.RoundTripper, idProvide id.Provide) (s MetricsSender, err error) {
-	harvester, err := newTelemetryHarverster(config, transport, idProvide)
 	s = &sender{
-		harvester: harvester,
+		harvester: NewLazyLoadedHarvester(config, transport, idProvide),
 		calculator: Calculator{
 			rate:  rate.NewCalculator(),
 			delta: cumulative.NewDeltaCalculator(),


### PR DESCRIPTION
This avoids loading the telemetry-api (dimensional metrics) harvester right away. It'll be lazy loaded on its first usage instead.