### PR TITLE
Update nri-prometheus to 2.8.0

### DIFF
--- a/build/embed/integrations.version
+++ b/build/embed/integrations.version
@@ -2,4 +2,4 @@
 nri-docker,1.6.0
 nri-flex,1.4.2
 nri-winservices,v0.2.0-beta
-nri-prometheus,2.7.0
+nri-prometheus,2.8.0


### PR DESCRIPTION
Updating nri-prometheus to use https://github.com/newrelic/nri-prometheus/releases/tag/v2.8.0