### PR TITLE
fix: run macos pre-release in macos runner

### DIFF
--- a/.github/workflows/prerelease_macos.yml
+++ b/.github/workflows/prerelease_macos.yml
@@ -75,17 +75,20 @@ jobs:
 
   packaging-macos:
     name: Build and upload all artifacts into GH Release assets
-    runs-on: ubuntu-20.04
+    runs-on: macos-11
     needs: [unit-test-macos]
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+      - name: Install Go
+        uses: actions/setup-go@v2
         with:
-          username: ${{ env.DOCKER_HUB_ID }}
-          password: ${{ env.DOCKER_HUB_PASSWORD }}
+          go-version: ${{env.GO_VERSION}}
+
+      - name: Install macos build dependencies
+        shell: bash
+        run: build/install_macos_dependencies.sh
 
       - name: Releasing macos packages
         run: make ci/prerelease/macos

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -50,7 +50,14 @@ ci/prerelease/linux:
 
 .PHONY : ci/prerelease/macos
 ci/prerelease/macos:
-	TARGET_OS=macos $(MAKE) ci/prerelease
+ifdef TAG
+	PRERELEASE=true \
+	SNAPSHOT=false \
+		$(MAKE) release-macos
+else
+	@echo "===> infrastructure-agent ===  [ci/prerelease/macos] TAG env variable expected to be set"
+	exit 1
+endif
 
 .PHONY : ci/prerelease
 ci/prerelease: ci/deps

--- a/build/install_macos_dependencies.sh
+++ b/build/install_macos_dependencies.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Install goreleaser
+export BINDIR=/usr/local/bin
+curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh

--- a/build/upload_artifacts_gh.sh
+++ b/build/upload_artifacts_gh.sh
@@ -6,7 +6,7 @@ set -e
 #
 #
 cd dist
-for filename in $(find  -regex ".*\.\(msi\|rpm\|deb\|zip\|tar.gz\)");do
+for filename in $(find . -name "*.msi" -o -name "*.rpm" -o -name "*.deb" -o -name "*.zip" -o -name "*.tar.gz");do
   echo "===> Uploading to GH $TAG: ${filename}"
       gh release upload $TAG $filename
 done


### PR DESCRIPTION
Run macos build in macos runner to avoid missing libraries errors when cross compiling for macos with CGO enabled.