### PR TITLE
Fix executor.Execute Close and test FD leaks

### DIFF
--- a/internal/integrations/v4/executor/executor.go
+++ b/internal/integrations/v4/executor/executor.go
@@ -46,6 +46,7 @@ func (r *Executor) Execute(ctx context.Context, pidChan, exitCodeCh chan<- int) 
 	commandCtx, cancelCommand := context.WithCancel(ctx)
 
 	go func() {
+		defer out.Close()
 		cmd := r.buildCommand(commandCtx)
 
 		illog.
@@ -114,7 +115,6 @@ func (r *Executor) Execute(ctx context.Context, pidChan, exitCodeCh chan<- int) 
 		}
 
 		allOutputForwarded.Wait() // waiting again to avoid closing output before the data is received during cancellation
-		out.Close()
 	}()
 	return receiver
 }

--- a/internal/integrations/v4/testhelp/channels.go
+++ b/internal/integrations/v4/testhelp/channels.go
@@ -4,6 +4,7 @@ package testhelp
 
 import (
 	"errors"
+	"testing"
 	"time"
 )
 
@@ -20,6 +21,19 @@ func ChannelRead(ch <-chan []byte) string {
 }
 
 var ErrChannelTimeout = errors.New("channel not closed after timeout")
+
+func AssertChanIsClosed(t *testing.T, ch <-chan []byte) {
+	select {
+	case content, more := <-ch:
+		if more {
+			t.Errorf("channel has content: %s", string(content))
+		}
+		return
+
+	case <-time.After(channelTimeout):
+		t.Error(ErrChannelTimeout.Error())
+	}
+}
 
 // if the channel has been closed without an error, it returns nil. An error otherwise
 func ChannelErrClosed(ch <-chan error) error {


### PR DESCRIPTION

After `executor.Execute()` calls `OutputSend.Close()` there are a couple channels that might be handled out of the Execute() context, I noted these down on the test code.
It'd be nice to build a larger scope leak test covering those too.