### PR TITLE
Uppercase all ENV vars and add ENV variables to payload log output

### DIFF
--- a/internal/integrations/v4/integration/definition_test.go
+++ b/internal/integrations/v4/integration/definition_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -362,4 +363,28 @@ func TestDefinition_Hash(t *testing.T) {
 	}
 	assert.NotNil(t, def3)
 	assert.Equal(t, def3.Hash(), def2.Hash())
+}
+
+func TestNewDefinition_LowerCasedEnvGetsUppercased(t *testing.T) {
+	const (
+		envA = "an_env_var"
+		envB = "other_env_var"
+		envC = "ANOTHER_ENV_VAR"
+	)
+
+	def, err := NewDefinition(config.ConfigEntry{
+		InstanceName: "foo",
+		Exec:         testhelp.Command(fixtures.BasicCmd),
+		Env: map[string]string{
+			envA: "random-val",
+			envB: "random-val",
+			envC: "random-val",
+		},
+	}, ErrLookup, nil, nil)
+	require.NoError(t, err)
+
+	for _, v := range []string{strings.ToUpper(envA), strings.ToUpper(envB), strings.ToUpper(envC)} {
+		require.Equal(t, "random-val", def.ExecutorConfig.Environment[v])
+	}
+
 }

--- a/internal/integrations/v4/integration/integration.go
+++ b/internal/integrations/v4/integration/integration.go
@@ -63,6 +63,8 @@ func newDefinitionWithoutLookup(ce config2.ConfigEntry, passthroughEnv []string,
 		return Definition{}, err
 	}
 
+	ce.UppercaseEnvVars()
+
 	interval := getInterval(ce.Interval)
 	// Reading this env the integration can know configured interval.
 	ce.Env[intervalEnvVarName] = fmt.Sprintf("%v", interval)

--- a/pkg/integrations/v4/config/config.go
+++ b/pkg/integrations/v4/config/config.go
@@ -5,6 +5,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/shlex"
@@ -109,4 +110,18 @@ func (cf *ConfigEntry) Sanitize() error {
 		cf.Env = map[string]string{}
 	}
 	return nil
+}
+
+// UppercaseEnvVars transforms all lowercase env vars defined in the config to uppercase
+func (cf *ConfigEntry) UppercaseEnvVars() {
+	if cf.Env == nil {
+		return
+	}
+	for k, e := range cf.Env {
+		upperCasedKey := strings.ToUpper(k)
+		if k != upperCasedKey {
+			delete(cf.Env, k)
+		}
+		cf.Env[upperCasedKey] = e
+	}
 }

--- a/pkg/integrations/v4/config/config_test.go
+++ b/pkg/integrations/v4/config/config_test.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestConfigEntry_UppercaseEnvVars(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    ConfigEntry
+		expected ConfigEntry
+	}{
+		{
+			name:     "Given lowerCased env vars should get upperCased",
+			input:    ConfigEntry{Env: map[string]string{"host": "a-host", "port": ":9999"}},
+			expected: ConfigEntry{Env: map[string]string{"HOST": "a-host", "PORT": ":9999"}},
+		},
+		{
+			name:     "Given lowerCased and upperCased env vars should get upperCased",
+			input:    ConfigEntry{Env: map[string]string{"host": "a-host", "PORT": ":9999"}},
+			expected: ConfigEntry{Env: map[string]string{"HOST": "a-host", "PORT": ":9999"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.input.UppercaseEnvVars()
+			if !reflect.DeepEqual(tt.input.Env, tt.expected.Env) {
+				t.Errorf("Expected: %v, got: %v", tt.expected, tt.input)
+			}
+		})
+	}
+}

--- a/pkg/integrations/v4/emitter/emitter.go
+++ b/pkg/integrations/v4/emitter/emitter.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/newrelic/infrastructure-agent/pkg/helpers"
+
 	"github.com/newrelic/infrastructure-agent/pkg/fwrequest"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/legacy"
 	"github.com/sirupsen/logrus"
@@ -64,7 +66,8 @@ func (e *VersionAwareEmitter) Emit(definition integration.Definition, extraLabel
 		fields["parent_integration_name"] = definition.CfgProtocol.ParentName
 	}
 
-	elog.WithFields(fields).Debug("Received payload.")
+	envVarsForLogEntry := helpers.ObfuscateSensitiveDataFromMap(definition.ExecutorConfig.Environment)
+	elog.WithField("env", envVarsForLogEntry).WithFields(fields).Debug("Received payload.")
 
 	protocolVersion, err := protocol.VersionFromPayload(integrationJSON, e.forceProtocolV2ToV3)
 	if err != nil {


### PR DESCRIPTION
- Uppercase all ENV vars defined on config file
- add ENV variables to payload log output