### PR TITLE
ci: enable CGO for amd64

### DIFF
--- a/build/.goreleaser_linux.yml
+++ b/build/.goreleaser_linux.yml
@@ -9,7 +9,7 @@ builds:
     main: ./cmd/newrelic-infra
     binary: newrelic-infra
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
     goos:
       - linux
     ldflags:
@@ -22,7 +22,7 @@ builds:
     main: ./cmd/newrelic-infra-ctl
     binary: newrelic-infra-ctl
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
     goos:
       - linux
     ldflags:
@@ -35,7 +35,7 @@ builds:
     main: ./cmd/newrelic-infra-service
     binary: newrelic-infra-service
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
     goos:
       - linux
     ldflags:
@@ -133,7 +133,7 @@ builds:
     main: ./cmd/newrelic-infra
     binary: newrelic-infra
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
     goos:
       - linux
     ldflags:
@@ -141,9 +141,56 @@ builds:
       - -s -w -X main.gitCommit={{.Commit}}
     goarch:
       - amd64
+    gomips:
+      - hardfloat
+
+  - id: linux-newrelic-infra-ctl
+    main: ./cmd/newrelic-infra-ctl
+    binary: newrelic-infra-ctl
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - linux
+    ldflags:
+      - -s -w -X main.buildVersion={{.Version}}
+      - -s -w -X main.gitCommit={{.Commit}}
+    goarch:
+      - amd64
+    gomips:
+      - hardfloat
+
+  - id: linux-newrelic-infra-service
+    main: ./cmd/newrelic-infra-service
+    binary: newrelic-infra-service
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - linux
+    ldflags:
+      - -s -w -X main.buildVersion={{.Version}}
+      - -s -w -X main.gitCommit={{.Commit}}
+    goarch:
+      - amd64
+    gomips:
+      - hardfloat
+
+  ###
+  ###  architectures where CGO is not supported
+  ###
+  - id: linux-newrelic-infra-no-cgo
+    main: ./cmd/newrelic-infra
+    binary: newrelic-infra
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    ldflags:
+      - -s -w -X main.buildVersion={{.Version}}
+      - -s -w -X main.gitCommit={{.Commit}}
+    goarch:
+      - 386
       - arm
       - arm64
-      - 386
       - mips
       - mips64
       - mipsle
@@ -153,7 +200,7 @@ builds:
     gomips:
       - hardfloat
 
-  - id: linux-newrelic-infra-ctl
+  - id: linux-newrelic-infra-ctl-no-cgo
     main: ./cmd/newrelic-infra-ctl
     binary: newrelic-infra-ctl
     env:
@@ -164,10 +211,9 @@ builds:
       - -s -w -X main.buildVersion={{.Version}}
       - -s -w -X main.gitCommit={{.Commit}}
     goarch:
-      - amd64
+      - 386
       - arm
       - arm64
-      - 386
       - mips
       - mips64
       - mipsle
@@ -177,7 +223,7 @@ builds:
     gomips:
       - hardfloat
 
-  - id: linux-newrelic-infra-service
+  - id: linux-newrelic-infra-service-no-cgo
     main: ./cmd/newrelic-infra-service
     binary: newrelic-infra-service
     env:
@@ -188,10 +234,9 @@ builds:
       - -s -w -X main.buildVersion={{.Version}}
       - -s -w -X main.gitCommit={{.Commit}}
     goarch:
-      - amd64
+      - 386
       - arm
       - arm64
-      - 386
       - mips
       - mips64
       - mipsle
@@ -207,6 +252,16 @@ archives:
       - linux-newrelic-infra
       - linux-newrelic-infra-ctl
       - linux-newrelic-infra-service
+    name_template: "newrelic-infra_{{.Os}}_{{ .Env.TAG }}_{{ .Arch }}_dirty"
+    wrap_in_directory: false
+    format: tar.gz
+    files:
+      - none*
+  - id: linux-tarball-infrastructure-agent-no-cgo
+    builds:
+      - linux-newrelic-infra-no-cgo
+      - linux-newrelic-infra-ctl-no-cgo
+      - linux-newrelic-infra-service-no-cgo
     name_template: "newrelic-infra_{{.Os}}_{{ .Env.TAG }}_{{ .Arch }}_dirty"
     wrap_in_directory: false
     format: tar.gz

--- a/build/container/Makefile
+++ b/build/container/Makefile
@@ -18,9 +18,16 @@ USE_BUILDX			?= false
 DOCKER_PUBLISH		?= false
 
 AGENT_ARCH ?= $(DOCKER_ARCH)
+CGO_ENABLED := "-no-cgo"
+
+ifeq ($(AGENT_ARCH), amd64)
+	CGO_ENABLED := ""
+
+endif
 
 ifeq ($(AGENT_ARCH), arm)
 	AGENT_ARCH := $(AGENT_ARCH)_6
+
 endif
 
 ifeq ($(DOCKER_PUBLISH), true)
@@ -125,9 +132,9 @@ base/get-integrations : embed-integrations
 .PHONY : base/get-infra-agent
 base/get-infra-agent : workspace
 base/get-infra-agent:
-	@(cp $(AGENT_BUILD_TARGET_DIR)/$(GOOS)-newrelic-infra-ctl_$(GOOS)_$(AGENT_ARCH)/* $(PROJECT_WORKSPACE)/)
-	@(cp $(AGENT_BUILD_TARGET_DIR)/$(GOOS)-newrelic-infra-service_$(GOOS)_$(AGENT_ARCH)/* $(PROJECT_WORKSPACE)/)
-	@(cp $(AGENT_BUILD_TARGET_DIR)/$(GOOS)-newrelic-infra_$(GOOS)_$(AGENT_ARCH)/* $(PROJECT_WORKSPACE)/)
+	@(cp $(AGENT_BUILD_TARGET_DIR)/$(GOOS)-newrelic-infra-ctl$(CGO_ENABLED)_$(GOOS)_$(AGENT_ARCH)/* $(PROJECT_WORKSPACE)/)
+	@(cp $(AGENT_BUILD_TARGET_DIR)/$(GOOS)-newrelic-infra-service$(CGO_ENABLED)_$(GOOS)_$(AGENT_ARCH)/* $(PROJECT_WORKSPACE)/)
+	@(cp $(AGENT_BUILD_TARGET_DIR)/$(GOOS)-newrelic-infra$(CGO_ENABLED)_$(GOOS)_$(AGENT_ARCH)/* $(PROJECT_WORKSPACE)/)
 
 .PHONY : build/base
 build/base : workspace/assets

--- a/internal/integrations/v4/runner/runner_test.go
+++ b/internal/integrations/v4/runner/runner_test.go
@@ -52,7 +52,7 @@ func Test_runner_Run(t *testing.T) {
 	e := &testemit.RecordEmitter{}
 	r := NewRunner(def, e, nil, nil, cmdrequest.NoopHandleFn, configrequest.NoopHandleFn, nil)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
 	r.Run(ctx, nil, nil)

--- a/pkg/helpers/contexts/heartbeat.go
+++ b/pkg/helpers/contexts/heartbeat.go
@@ -5,6 +5,8 @@ package contexts
 
 import (
 	"context"
+	"fmt"
+	"github.com/newrelic/infrastructure-agent/pkg/log"
 	"sync"
 	"time"
 )
@@ -32,7 +34,10 @@ func WithHeartBeat(parent context.Context, lifeTime time.Duration) (context.Cont
 	ctx := heartBeatCtx{lifeTime: lifeTime}
 	actuator := Actuator{HeartBeat: ctx.heartBeat}
 	ctx.Context, actuator.Cancel = context.WithCancel(parent)
-	ctx.timer = time.AfterFunc(lifeTime, actuator.Cancel)
+	ctx.timer = time.AfterFunc(lifeTime, func() {
+		log.Debug(fmt.Sprintf("HeartBeat timeout exceeded after %d", lifeTime))
+		actuator.Cancel()
+	})
 	return &ctx, actuator
 }
 

--- a/pkg/helpers/contexts/heartbeat_test.go
+++ b/pkg/helpers/contexts/heartbeat_test.go
@@ -35,7 +35,7 @@ func TestContexHolder_Timeout(t *testing.T) {
 }
 
 func TestContextHolder_Heartbeat(t *testing.T) {
-	const lifeTime = 50 * time.Millisecond
+	const lifeTime = 100 * time.Millisecond
 	const extendUntil = 200 * time.Millisecond
 	start := time.Now()
 


### PR DESCRIPTION
Enable CGO for amd64 assets, to restore missing features. Arm/arm64 CGO required more research as there are some missing libraries and cgo files.

Also in this PR we fix some flaky test.