### PR TITLE
integrations: bump nri-winservices to v0.5.0-beta

### DIFF
--- a/build/embed/integrations.version
+++ b/build/embed/integrations.version
@@ -1,5 +1,5 @@
 #ohi-repo-name,version
 nri-docker,1.6.0
 nri-flex,1.4.3
-nri-winservices,v0.4.0-beta
+nri-winservices,v0.5.0-beta
 nri-prometheus,2.8.0


### PR DESCRIPTION
This new version of the integration contains the process priority set to the spawned process (the exporter) to the same as the integration itself that should be set once #720 is done. 