### PR TITLE
ci: enable logging package for arm64

### DIFF
--- a/build/goreleaser/linux/al2_arm.yml
+++ b/build/goreleaser/linux/al2_arm.yml
@@ -72,7 +72,7 @@
       summary: "New Relic Infrastructure Agent"
       group: default
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
-    recommends:
-      - td-agent-bit
+#    recommends:
+#      - td-agent-bit
   
   # end AL2 arm

--- a/build/goreleaser/linux/al2_arm64.yml
+++ b/build/goreleaser/linux/al2_arm64.yml
@@ -16,16 +16,16 @@
       - rpm
     bindir: /usr/bin
     contents:
-      #      - src: 'assets/examples/logging/linux/file.yml.example'
-      #        dst: '/etc/newrelic-infra/logging.d/file.yml.example'
-      #      - src: 'assets/examples/logging/linux/fluentbit.yml.example'
-      #        dst: '/etc/newrelic-infra/logging.d/fluentbit.yml.example'
-      #      - src: 'assets/examples/logging/linux/syslog.yml.example'
-      #        dst: '/etc/newrelic-infra/logging.d/syslog.yml.example'
-      #      - src: 'assets/examples/logging/linux/systemd.yml.example'
-      #        dst: '/etc/newrelic-infra/logging.d/systemd.yml.example'
-      #      - src: 'assets/examples/logging/linux/tcp.yml.example'
-      #        dst: '/etc/newrelic-infra/logging.d/tcp.yml.example'
+      - src: 'assets/examples/logging/linux/file.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/file.yml.example'
+      - src: 'assets/examples/logging/linux/fluentbit.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/fluentbit.yml.example'
+      - src: 'assets/examples/logging/linux/syslog.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/syslog.yml.example'
+      - src: 'assets/examples/logging/linux/systemd.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/systemd.yml.example'
+      - src: 'assets/examples/logging/linux/tcp.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/tcp.yml.example'
   
       - src: 'build/package/systemd/newrelic-infra.service'
         dst: '/etc/systemd/system/newrelic-infra.service'
@@ -40,10 +40,10 @@
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/{{ .Arch }}/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-    #      - src: 'target/fluent-bit-plugin/{{ .Arch }}/out_newrelic.so'
-    #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
-    #      - src: 'assets/examples/logging/parsers.conf'
-    #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
+      - src: 'target/fluent-bit-plugin/{{ .Arch }}/out_newrelic.so'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
+      - src: 'assets/examples/logging/parsers.conf'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
     empty_folders:
       - /var/db/newrelic-infra/custom-integrations
       - /var/db/newrelic-infra/integrations.d

--- a/build/goreleaser/linux/centos_7_arm64.yml
+++ b/build/goreleaser/linux/centos_7_arm64.yml
@@ -16,16 +16,16 @@
       - rpm
     bindir: /usr/bin
     contents:
-      #      - src: 'assets/examples/logging/linux/file.yml.example'
-      #        dst: '/etc/newrelic-infra/logging.d/file.yml.example'
-      #      - src: 'assets/examples/logging/linux/fluentbit.yml.example'
-      #        dst: '/etc/newrelic-infra/logging.d/fluentbit.yml.example'
-      #      - src: 'assets/examples/logging/linux/syslog.yml.example'
-      #        dst: '/etc/newrelic-infra/logging.d/syslog.yml.example'
-      #      - src: 'assets/examples/logging/linux/systemd.yml.example'
-      #        dst: '/etc/newrelic-infra/logging.d/systemd.yml.example'
-      #      - src: 'assets/examples/logging/linux/tcp.yml.example'
-      #        dst: '/etc/newrelic-infra/logging.d/tcp.yml.example'
+      - src: 'assets/examples/logging/linux/file.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/file.yml.example'
+      - src: 'assets/examples/logging/linux/fluentbit.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/fluentbit.yml.example'
+      - src: 'assets/examples/logging/linux/syslog.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/syslog.yml.example'
+      - src: 'assets/examples/logging/linux/systemd.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/systemd.yml.example'
+      - src: 'assets/examples/logging/linux/tcp.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/tcp.yml.example'
       - src: 'build/package/systemd/newrelic-infra.service'
         dst: '/etc/systemd/system/newrelic-infra.service'
       - src: 'LICENSE'
@@ -40,10 +40,10 @@
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/{{ .Arch }}/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-    #      - src: 'target/fluent-bit-plugin/{{ .Arch }}/out_newrelic.so'
-    #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
-    #      - src: 'assets/examples/logging/parsers.conf'
-    #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
+      - src: 'target/fluent-bit-plugin/{{ .Arch }}/out_newrelic.so'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
+      - src: 'assets/examples/logging/parsers.conf'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
     empty_folders:
       - /var/db/newrelic-infra/custom-integrations
       - /var/db/newrelic-infra/integrations.d
@@ -72,7 +72,7 @@
       group: default
     # Required packages. rpm version 4.11.3 does not support weak dependencies
     # disabled until logging packaging is properly handled for arm
-  #    dependencies:
-  #      - td-agent-bit
+    dependencies:
+      - td-agent-bit
   
   # end CentOS 7 arm64

--- a/build/goreleaser/linux/centos_8_arm.yml
+++ b/build/goreleaser/linux/centos_8_arm.yml
@@ -71,7 +71,7 @@
       summary: "New Relic Infrastructure Agent"
       group: default
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
-    recommends:
-      - td-agent-bit
+#    recommends:
+#      - td-agent-bit
   
   # end CentOS 8 arm

--- a/build/goreleaser/linux/centos_8_arm64.yml
+++ b/build/goreleaser/linux/centos_8_arm64.yml
@@ -16,16 +16,16 @@
       - rpm
     bindir: /usr/bin
     contents:
-      #      - src: 'assets/examples/logging/linux/file.yml.example'
-      #        dst: '/etc/newrelic-infra/logging.d/file.yml.example'
-      #      - src: 'assets/examples/logging/linux/fluentbit.yml.example'
-      #        dst: '/etc/newrelic-infra/logging.d/fluentbit.yml.example'
-      #      - src: 'assets/examples/logging/linux/syslog.yml.example'
-      #        dst: '/etc/newrelic-infra/logging.d/syslog.yml.example'
-      #      - src: 'assets/examples/logging/linux/systemd.yml.example'
-      #        dst: '/etc/newrelic-infra/logging.d/systemd.yml.example'
-      #      - src: 'assets/examples/logging/linux/tcp.yml.example'
-      #        dst: '/etc/newrelic-infra/logging.d/tcp.yml.example'
+      - src: 'assets/examples/logging/linux/file.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/file.yml.example'
+      - src: 'assets/examples/logging/linux/fluentbit.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/fluentbit.yml.example'
+      - src: 'assets/examples/logging/linux/syslog.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/syslog.yml.example'
+      - src: 'assets/examples/logging/linux/systemd.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/systemd.yml.example'
+      - src: 'assets/examples/logging/linux/tcp.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/tcp.yml.example'
   
       - src: 'build/package/systemd/newrelic-infra.service'
         dst: '/etc/systemd/system/newrelic-infra.service'
@@ -40,10 +40,10 @@
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/{{ .Arch }}/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-    #      - src: 'target/fluent-bit-plugin/{{ .Arch }}/out_newrelic.so'
-    #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
-    #      - src: 'assets/examples/logging/parsers.conf'
-    #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
+      - src: 'target/fluent-bit-plugin/{{ .Arch }}/out_newrelic.so'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
+      - src: 'assets/examples/logging/parsers.conf'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
     empty_folders:
       - /var/db/newrelic-infra/custom-integrations
       - /var/db/newrelic-infra/integrations.d

--- a/build/goreleaser/linux/debian_systemd_arm.yml
+++ b/build/goreleaser/linux/debian_systemd_arm.yml
@@ -62,7 +62,7 @@
     # Priority.
     priority: extra
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
-    recommends:
-      - td-agent-bit
+#    recommends:
+#      - td-agent-bit
   
   # end Debian systemd arm

--- a/build/goreleaser/linux/debian_systemd_arm64.yml
+++ b/build/goreleaser/linux/debian_systemd_arm64.yml
@@ -16,16 +16,16 @@
       - deb
     bindir: /usr/bin
     contents:
-      #      - src: 'assets/examples/logging/linux/file.yml.example'
-      #        dst: '/etc/newrelic-infra/logging.d/file.yml.example'
-      #      - src: 'assets/examples/logging/linux/fluentbit.yml.example'
-      #        dst: '/etc/newrelic-infra/logging.d/fluentbit.yml.example'
-      #      - src: 'assets/examples/logging/linux/syslog.yml.example'
-      #        dst: '/etc/newrelic-infra/logging.d/syslog.yml.example'
-      #      - src: 'assets/examples/logging/linux/systemd.yml.example'
-      #        dst: '/etc/newrelic-infra/logging.d/systemd.yml.example'
-      #      - src: 'assets/examples/logging/linux/tcp.yml.example'
-      #        dst: '/etc/newrelic-infra/logging.d/tcp.yml.example'
+      - src: 'assets/examples/logging/linux/file.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/file.yml.example'
+      - src: 'assets/examples/logging/linux/fluentbit.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/fluentbit.yml.example'
+      - src: 'assets/examples/logging/linux/syslog.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/syslog.yml.example'
+      - src: 'assets/examples/logging/linux/systemd.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/systemd.yml.example'
+      - src: 'assets/examples/logging/linux/tcp.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/tcp.yml.example'
       - src: 'build/package/systemd/newrelic-infra.service'
         dst: '/etc/systemd/system/newrelic-infra.service'
       - src: 'LICENSE'
@@ -38,10 +38,10 @@
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
       - src: 'target/nriprometheus/{{ .Arch }}/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
         dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
-    #      - src: 'target/fluent-bit-plugin/{{ .Arch }}/out_newrelic.so'
-    #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
-    #      - src: 'assets/examples/logging/parsers.conf'
-    #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
+      - src: 'target/fluent-bit-plugin/{{ .Arch }}/out_newrelic.so'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
+      - src: 'assets/examples/logging/parsers.conf'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
     empty_folders:
       - /var/db/newrelic-infra/custom-integrations
       - /var/db/newrelic-infra/integrations.d

--- a/build/goreleaser/linux/sles_122_arm.yml
+++ b/build/goreleaser/linux/sles_122_arm.yml
@@ -71,7 +71,7 @@
       summary: "New Relic Infrastructure Agent"
       group: default
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
-    recommends:
-      - td-agent-bit
+#    recommends:
+#      - td-agent-bit
   
   # end SLES 12.2 arm

--- a/build/goreleaser/linux/sles_122_arm64.yml
+++ b/build/goreleaser/linux/sles_122_arm64.yml
@@ -71,7 +71,7 @@
       summary: "New Relic Infrastructure Agent"
       group: default
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
-    recommends:
-      - td-agent-bit
+#    recommends:
+#      - td-agent-bit
   
   # end SLES 12.2 arm64

--- a/build/goreleaser/linux/sles_123_arm.yml
+++ b/build/goreleaser/linux/sles_123_arm.yml
@@ -71,7 +71,7 @@
       summary: "New Relic Infrastructure Agent"
       group: default
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
-    recommends:
-      - td-agent-bit
+#    recommends:
+#      - td-agent-bit
   
   # end SLES 12.3 arm

--- a/build/goreleaser/linux/sles_123_arm64.yml
+++ b/build/goreleaser/linux/sles_123_arm64.yml
@@ -71,7 +71,7 @@
       summary: "New Relic Infrastructure Agent"
       group: default
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
-    recommends:
-      - td-agent-bit
+#    recommends:
+#      - td-agent-bit
   
   # end SLES 12.3 arm64

--- a/build/goreleaser/linux/sles_124_arm.yml
+++ b/build/goreleaser/linux/sles_124_arm.yml
@@ -71,7 +71,7 @@
       summary: "New Relic Infrastructure Agent"
       group: default
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
-    recommends:
-      - td-agent-bit
+#    recommends:
+#      - td-agent-bit
   
   # end SLES 12.4 arm

--- a/build/goreleaser/linux/sles_124_arm64.yml
+++ b/build/goreleaser/linux/sles_124_arm64.yml
@@ -71,7 +71,7 @@
       summary: "New Relic Infrastructure Agent"
       group: default
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
-    recommends:
-      - td-agent-bit
+#    recommends:
+#      - td-agent-bit
   
   # end SLES 12.4 arm64

--- a/build/goreleaser/linux/sles_125_arm64.yml
+++ b/build/goreleaser/linux/sles_125_arm64.yml
@@ -72,7 +72,7 @@
       summary: "New Relic Infrastructure Agent"
       group: default
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
-    recommends:
-      - td-agent-bit
+#    recommends:
+#      - td-agent-bit
   
   # end SLES 12.5 arm64

--- a/build/goreleaser/linux/sles_151_arm64.yml
+++ b/build/goreleaser/linux/sles_151_arm64.yml
@@ -72,7 +72,7 @@
       summary: "New Relic Infrastructure Agent"
       group: default
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
-    recommends:
-      - td-agent-bit
+#    recommends:
+#      - td-agent-bit
   
   # end SLES 15.1 arm64

--- a/build/goreleaser/linux/sles_152_arm64.yml
+++ b/build/goreleaser/linux/sles_152_arm64.yml
@@ -72,7 +72,7 @@
       summary: "New Relic Infrastructure Agent"
       group: default
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
-    recommends:
-      - td-agent-bit
+#    recommends:
+#      - td-agent-bit
   
   # end SLES 15.2 arm64

--- a/build/goreleaser/linux/sles_153_arm64.yml
+++ b/build/goreleaser/linux/sles_153_arm64.yml
@@ -72,7 +72,7 @@
       summary: "New Relic Infrastructure Agent"
       group: default
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
-    recommends:
-      - td-agent-bit
+#    recommends:
+#      - td-agent-bit
   
   # end SLES 15.3 arm64

--- a/build/release.mk
+++ b/build/release.mk
@@ -65,7 +65,7 @@ release/pkg-linux: release/get-integrations-arm64
 release/pkg-linux: release/get-integrations-arm
 release/pkg-linux: release/get-fluentbit-linux-amd64
 #release/pkg-linux: release/get-fluentbit-linux-arm
-#release/pkg-linux: release/get-fluentbit-linux-arm64
+release/pkg-linux: release/get-fluentbit-linux-arm64
 	@echo "=== [release/pkg-linux] PRE-RELEASE compiling all binaries, creating packages, archives"
 	$(GORELEASER_BIN) release --config $(GORELEASER_CONFIG_LINUX) $(PKG_FLAGS)
 
@@ -80,7 +80,7 @@ release/pkg-linux-amd64: release/get-fluentbit-linux-amd64
 .PHONY : release/pkg-linux-arm
 release/pkg-linux-arm: release/deps release/clean generate-goreleaser-arm
 release/pkg-linux-arm: release/get-integrations-arm
-release/pkg-linux-arm: release/get-fluentbit-linux-arm
+#release/pkg-linux-arm: release/get-fluentbit-linux-arm
 	@echo "=== [release/pkg-linux-arm] PRE-RELEASE compiling all binaries, creating packages, archives"
 	$(GORELEASER_BIN) release --config $(GORELEASER_CONFIG_LINUX) $(PKG_FLAGS)
 


### PR DESCRIPTION
Enabling log-forwarder dependency for arm64 and disabling every where where we don't support it.