### PR TITLE
feat: added check if license key changed to reset inventory

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -482,7 +482,8 @@ func (a *Agent) registerEntityInventory(entity entity.Entity) error {
 		fileName := entity.Key.String()
 		lastSubmission := delta.NewLastSubmissionStore(a.store.DataDir, fileName)
 		lastEntityID := delta.NewEntityIDFilePersist(a.store.DataDir, fileName)
-		inv.sender, err = newPatchSender(entity, a.Context, a.store, lastSubmission, lastEntityID, a.userAgent, a.Context.Identity, a.httpClient)
+		lastLicense := delta.NewLastSubmissionLicenseFileStore(a.store.DataDir, fileName)
+		inv.sender, err = newPatchSender(entity, a.Context, a.store, lastSubmission, lastEntityID, lastLicense, a.userAgent, a.Context.Identity, a.httpClient)
 	}
 	if err != nil {
 		return err
@@ -763,12 +764,12 @@ func (a *Agent) Run() (err error) {
 					_ = a.updateIDLookupTable(data.Data)
 				}
 
-				entityKey := data.Entity.Key.String()
-				if _, ok := a.inventories[entityKey]; !ok {
-					_ = a.registerEntityInventory(data.Entity)
-				}
-
 				if !data.NotApplicable {
+					entityKey := data.Entity.Key.String()
+
+					if _, ok := a.inventories[entityKey]; !ok {
+						_ = a.registerEntityInventory(data.Entity)
+					}
 					if err := a.storePluginOutput(data); err != nil {
 						alog.WithError(err).Error("problem storing plugin output")
 					}

--- a/internal/agent/delta/last_license_hash.go
+++ b/internal/agent/delta/last_license_hash.go
@@ -40,6 +40,18 @@ func NewLastSubmissionLicenseFileStore(dataDir, fileName string) LastSubmissionL
 	}
 }
 
+// NewLastSubmissionLicenseInMemory will store the license hash only in memory.
+func NewLastSubmissionLicenseInMemory() LastSubmissionLicense {
+	return &LastSubmissionLicenseFileStore{
+		readFile: func(path string) (string, error) {
+			return "", nil
+		},
+		writeFile: func(content string, path string) error {
+			return nil
+		},
+	}
+}
+
 // load will get the license hash from the disk.
 func (l *LastSubmissionLicenseFileStore) load() error {
 	var err error

--- a/internal/agent/delta/last_license_hash.go
+++ b/internal/agent/delta/last_license_hash.go
@@ -1,0 +1,109 @@
+package delta
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"github.com/newrelic/infrastructure-agent/pkg/helpers"
+	"github.com/newrelic/infrastructure-agent/pkg/log"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+var (
+	md5Validator = regexp.MustCompile("(?i)^[a-f0-9]{32}$")
+)
+
+// LastSubmissionLicense retrieves and stores last inventory successful submission license key hash.
+type LastSubmissionLicense interface {
+	HasChanged(string) (bool, error)
+	Update(string) error
+}
+
+// LastSubmissionLicenseFileStore persists last successful submission license key hash.
+type LastSubmissionLicenseFileStore struct {
+	readFile  func(path string) (string, error)
+	writeFile func(content string, path string) error
+	// file holds the file path storing the data
+	filePath   string
+	licenseMD5 string
+}
+
+// NewLastSubmissionLicenseFileStore creates a new LastSubmissionLicenseFileStore storing data in file.
+func NewLastSubmissionLicenseFileStore(dataDir, fileName string) LastSubmissionLicense {
+	return &LastSubmissionLicenseFileStore{
+		readFile:  readLicenseHashFromFileFn,
+		writeFile: writeLicenseHashToFileFn,
+		filePath:  filepath.Join(dataDir, lastLicenseHashFolder, helpers.SanitizeFileName(fileName)),
+	}
+}
+
+// load will get the license hash from the disk.
+func (l *LastSubmissionLicenseFileStore) load() error {
+	var err error
+	if l.licenseMD5 == "" {
+		l.licenseMD5, err = l.readFile(l.filePath)
+	}
+
+	return err
+}
+
+var pslog = log.WithComponent("PatchSender")
+
+// UpdateEntityID will store the entityID on memory and disk.
+func (l *LastSubmissionLicenseFileStore) Update(license string) error {
+	l.licenseMD5 = l.md5(license)
+	return l.writeFile(l.licenseMD5, l.filePath)
+}
+
+// HasChanged returns whether the License had been changed.
+func (l *LastSubmissionLicenseFileStore) HasChanged(license string) (bool, error) {
+	err := l.load()
+	// If license file not found.
+	if err == nil && l.licenseMD5 == "" {
+		err = l.Update(license)
+		return false, err
+	}
+
+	return l.licenseMD5 != l.md5(license), err
+}
+
+func (l *LastSubmissionLicenseFileStore) md5(license string) string {
+	hash := md5.New()
+	hash.Write([]byte(license))
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func readLicenseHashFromFileFn(filePath string) (string, error) {
+	// Check if there is an already stored value on disk.
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return "", nil
+	}
+
+	buf, err := ioutil.ReadFile(filePath)
+
+	if err != nil {
+		return "", fmt.Errorf("cannot read file persisted license hash, file: '%s', error: %v", filePath, err)
+	}
+
+	match := md5Validator.Match(buf)
+	if !match {
+		return "", fmt.Errorf("expected licence has to be an MD5 format, content: %s", buf)
+	}
+	return string(buf), nil
+}
+
+func writeLicenseHashToFileFn(content string, filePath string) error {
+	dir := filepath.Dir(filePath)
+
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		if mkDirErr := os.MkdirAll(dir, DATA_DIR_MODE); mkDirErr != nil {
+			return fmt.Errorf("cannot persist license hash, agent data directory: '%s' does not exist and cannot be created: %v",
+				dir, mkDirErr)
+		}
+	}
+
+	return ioutil.WriteFile(filePath, []byte(content), DATA_FILE_MODE)
+}

--- a/internal/agent/delta/last_license_hash_test.go
+++ b/internal/agent/delta/last_license_hash_test.go
@@ -1,0 +1,236 @@
+package delta
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLicenseHashFilePersist_RetrieveStoredValue(t *testing.T) {
+	expected := "718779752b851ac0dc6281a8c8d77e7e"
+
+	l := &LastSubmissionLicenseFileStore{
+		readFile: func(path string) (string, error) {
+			return expected, nil
+		},
+	}
+
+	err := l.load()
+
+	assert.Equal(t, expected, l.licenseMD5)
+	assert.NoError(t, err)
+}
+
+func TestLicenseHashFilePersist_RetrieveInMemoryValue(t *testing.T) {
+	expected := "718779752b851ac0dc6281a8c8d77e7e"
+
+	l := &LastSubmissionLicenseFileStore{
+		readFile: func(path string) (string, error) {
+			return "", fmt.Errorf("should not read from file")
+		},
+		licenseMD5: expected,
+	}
+
+	err := l.load()
+
+	assert.Equal(t, expected, l.licenseMD5)
+	require.NoError(t, err)
+}
+
+func TestLicenseHashFilePersist_ErrWhenReadingFile(t *testing.T) {
+	expectedMessage := "failed when reading file"
+
+	l := &LastSubmissionLicenseFileStore{
+		readFile: func(path string) (string, error) {
+			return "", fmt.Errorf(expectedMessage)
+		},
+	}
+
+	err := l.load()
+
+	assert.Equal(t, "", l.licenseMD5)
+	assert.Error(t, err, expectedMessage)
+}
+
+func TestLicenseHashFilePersist_UpdateValue(t *testing.T) {
+	license := "license"
+	expected := "718779752b851ac0dc6281a8c8d77e7e"
+
+	l := &LastSubmissionLicenseFileStore{
+		writeFile: func(content string, filePath string) error {
+			assert.Equal(t, expected, content)
+			return nil
+		},
+	}
+
+	err := l.Update(license)
+	require.NoError(t, err)
+	assert.Equal(t, expected, l.licenseMD5)
+}
+
+func TestLicenseHashFilePersist_ErrWhenWritingFile(t *testing.T) {
+	expectedErrMessage := "file could not be written"
+	expected := "718779752b851ac0dc6281a8c8d77e7e"
+
+	l := &LastSubmissionLicenseFileStore{
+		writeFile: func(content string, filePath string) error {
+			return fmt.Errorf(expectedErrMessage)
+		},
+	}
+
+	err := l.Update("license")
+
+	assert.Errorf(t, err, "Update license should return an error when failed writing file")
+	assert.Equal(t, expectedErrMessage, err.Error())
+	assert.Equal(t, expected, l.licenseMD5)
+}
+
+// Read File IT
+func TestReadLicenseHashFromFileFn_ReturnContent(t *testing.T) {
+	expected := "718779752b851ac0dc6281a8c8d77e7e"
+
+	path, err := TempDeltaStoreDir()
+	require.NoError(t, err)
+	defer cleanFolder(path)
+
+	file := filepath.Join(path, "temporary_file")
+	err = ioutil.WriteFile(file, []byte(expected), 0644)
+	assert.NoError(t, err)
+
+	content, err := readLicenseHashFromFileFn(file)
+
+	assert.Equal(t, expected, content)
+	assert.NoError(t, err)
+}
+
+func TestReadLicenseHashFromFileFn_EmptyFile(t *testing.T) {
+	path, err := TempDeltaStoreDir()
+	require.NoError(t, err)
+	defer cleanFolder(path)
+
+	file := filepath.Join(path, "temporary_file")
+	err = ioutil.WriteFile(file, []byte(""), 0644)
+	assert.NoError(t, err)
+
+	content, err := readLicenseHashFromFileFn(file)
+
+	assert.Equal(t, "", content)
+	require.Error(t, err, "Expected to return an Empty file error")
+}
+
+func TestReadLicenseHashFromFileFn_FileNotFound(t *testing.T) {
+	content, err := readLicenseHashFromFileFn("some_non-existing_file_path")
+
+	assert.Equal(t, "", content)
+	require.NoError(t, err)
+}
+
+func TestReadLicenseHashFromFileFn_NoPermission(t *testing.T) {
+	path, err := TempDeltaStoreDir()
+	require.NoError(t, err)
+	defer cleanFolder(path)
+
+	file := filepath.Join(path, "temporary_file")
+	err = ioutil.WriteFile(file, []byte(""), 0000)
+	assert.NoError(t, err)
+
+	content, err := readLicenseHashFromFileFn(file)
+
+	assert.Equal(t, "", content)
+	require.Error(t, err, "Expected to return an permission error")
+}
+
+func TestReadLicenseHashFromFileFn_ErrParseContent(t *testing.T) {
+	temp, err := TempDeltaStoreDir()
+	require.NoError(t, err)
+	defer cleanFolder(temp)
+
+	filePath := filepath.Join(temp, "temporary_file")
+	err = ioutil.WriteFile(filePath, []byte("wrong_md5"), 0644)
+	require.NoError(t, err)
+
+	emptyID, err := readLicenseHashFromFileFn(filePath)
+	require.Error(t, err)
+	assert.Equal(t, "", emptyID)
+}
+
+// Write File IT
+func TestWriteLicenseHashToFileFn_StoreValue(t *testing.T) {
+
+	//GIVEN a file with a stored license hash
+	oldHash := "1bad9a4c31a1256e9d62feea2dcfd188"
+
+	temp, err := TempDeltaStoreDir()
+	require.NoError(t, err)
+	defer cleanFolder(temp)
+
+	err = os.MkdirAll(filepath.Join(temp, lastLicenseHashFolder), DATA_DIR_MODE)
+	require.NoError(t, err)
+
+	filePath := filepath.Join(temp, lastLicenseHashFolder, "nria_locally")
+	err = ioutil.WriteFile(filePath, []byte(oldHash), DATA_FILE_MODE)
+	require.NoError(t, err, "Should create a last license hash file")
+
+	newLicense := "license"
+	newHash := "718779752b851ac0dc6281a8c8d77e7e"
+	l := NewLastSubmissionLicenseFileStore(temp, "nria_locally")
+
+	//WHEN UpdateEntityID
+	err = l.Update(newLicense)
+	require.NoError(t, err)
+
+	//THEN new content can be retrieved
+	persistedLicesenHash, err := ioutil.ReadFile(filePath)
+	require.NoError(t, err)
+
+	assert.Equal(t, newHash, string(persistedLicesenHash))
+}
+
+func TestWriteLicenseHashToFileFn_FileNotExist(t *testing.T) {
+	expected := "718779752b851ac0dc6281a8c8d77e7e"
+
+	//GIVEN a temporary folder
+	temp, err := TempDeltaStoreDir()
+	require.NoError(t, err, "Should create a temporary file")
+	defer cleanFolder(temp)
+
+	//AND a non existing file to store a value
+	nonExistingFilePath := filepath.Join(temp, "nria_locally")
+
+	//WHEN want to write content on it
+	err = writeLicenseHashToFileFn(expected, nonExistingFilePath)
+	require.NoError(t, err, "Should write the file")
+
+	//THEN file were created
+	_, err = os.Stat(nonExistingFilePath)
+	require.NoError(t, err, "Should create the file if not exist")
+
+	//AND the value can be retrieved
+	actualValue, err := readLicenseHashFromFileFn(nonExistingFilePath)
+	require.NoError(t, err, "Should retrieve value from file")
+	assert.Equal(t, expected, actualValue)
+}
+
+func TestHasChanged(t *testing.T) {
+	oldLicense := "license"
+	oldHash := "718779752b851ac0dc6281a8c8d77e7e"
+
+	l := &LastSubmissionLicenseFileStore{
+		readFile: func(path string) (string, error) {
+			return "", fmt.Errorf("this should not be called")
+		},
+		licenseMD5: oldHash,
+	}
+
+	actual, actualErr := l.HasChanged(oldLicense)
+	assert.False(t, actual)
+	assert.NoError(t, actualErr)
+
+	actual, actualErr = l.HasChanged("license2")
+	assert.True(t, actual)
+	assert.NoError(t, actualErr)
+}

--- a/internal/agent/delta/store.go
+++ b/internal/agent/delta/store.go
@@ -40,6 +40,7 @@ const (
 	DisableInventorySplit       = 0
 	lastSuccessSubmissionFolder = "last_success"
 	lastEntityIDFolder          = "last_entityID"
+	lastLicenseHashFolder       = "last_license_md5"
 )
 
 var EMPTY_DELTA = []byte{'{', '}'}

--- a/internal/agent/patch_sender.go
+++ b/internal/agent/patch_sender.go
@@ -265,7 +265,7 @@ func (p *patchSenderIngest) agentEntityIDChanged() bool {
 	if entityKey != p.context.EntityKey() {
 		return false
 	}
-	
+
 	lastEntityID, err := p.lastEntityID.GetEntityID()
 	if err != nil {
 		pslog.WithField("entityKey", entityKey).

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1741,7 +1741,7 @@ func NormalizeConfig(cfg *Config, cfgMetadata config_loader.YAMLMetadata) (err e
 	if cfg.MetricsProcessSampleRate < FREQ_INTERVAL_FLOOR_PROCESS_METRICS && cfg.MetricsProcessSampleRate > FREQ_DISABLE_SAMPLING {
 		cfg.MetricsProcessSampleRate = FREQ_INTERVAL_FLOOR_PROCESS_METRICS
 	}
-	nlog.WithField("MetricsNetworkSampleRate", cfg.MetricsProcessSampleRate).Debug("Metrics Process Sample Rate.")
+	nlog.WithField("MetricsProcessSampleRate", cfg.MetricsProcessSampleRate).Debug("Metrics Process Sample Rate.")
 
 	nlog.WithField("FilesConfigOn", cfg.FilesConfigOn).Debug("Configuration file monitoring.")
 


### PR DESCRIPTION
This PR checks whether the license key has changed. This check is required because we cache the inventory that has been already sent. If the agent will report to a new account without this check the inventory will not be submitted which will cause host metadata and entity to not appear in the web interface