### PR TITLE
fix: do not read sysctl deprecated item

### DIFF
--- a/internal/plugins/linux/sysctl.go
+++ b/internal/plugins/linux/sysctl.go
@@ -26,6 +26,7 @@ var (
 		`net/core/((bpf_jit_harden)|(bpf_jit_kallsyms))`,
 		`net/ipv4/(tcp_fastopen_key)`,
 		`net/ipv6/conf/(.+)/(stable_secret)`,
+		`net/ipv6/neigh/default/retrans_time$`,
 		`vm/((mmap_rnd_bits)|(mmap_rnd_compat_bits)|(stat_refresh))`,
 	}
 )


### PR DESCRIPTION
dmesg complains about reading deprecated sysctl item:
```
[ 1936.917785] ICMPv6: process `newrelic-infra' is using deprecated sysctl (syscall) net.ipv6.neigh.default.retrans_time - use net.ipv6.neigh.default.retrans_time_ms instead
```