### PR TITLE
helpers/docker: ignore docker.sock file if it's not a socket

### DIFF
--- a/pkg/helpers/docker_utils.go
+++ b/pkg/helpers/docker_utils.go
@@ -60,8 +60,16 @@ func IsDockerRunning() bool {
 	if runtime.GOOS == "windows" {
 		_, err := os.Stat(windowsDockerSocket)
 		return err == nil
-	} else {
-		_, err := os.Stat(linuxDockerSocket)
-		return err == nil
 	}
+
+	dockerSock, err := os.Stat(linuxDockerSocket)
+	if err != nil {
+		return false
+	}
+
+	if dockerSock.Mode()&os.ModeSocket == 0 {
+		return false
+	}
+
+	return true
 }

--- a/pkg/metrics/docker_sampler.go
+++ b/pkg/metrics/docker_sampler.go
@@ -13,9 +13,10 @@ import (
 	metricTypes "github.com/newrelic/infrastructure-agent/pkg/metrics/types"
 
 	"github.com/docker/docker/api/types"
+	"github.com/sirupsen/logrus"
+
 	"github.com/newrelic/infrastructure-agent/pkg/helpers"
 	"github.com/newrelic/infrastructure-agent/pkg/helpers/lru"
-	"github.com/sirupsen/logrus"
 )
 
 var dslog = log.WithComponent("DockerSampler")


### PR DESCRIPTION
Moreover, DockerSampler will react to this error and don't log anything if that's the case.