### PR TITLE
disable renovate bot dashboard

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,8 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    // Disable the creation of DependencyDashboard issue, we follow pull requests with Zenhub
+    ":disableDependencyDashboard"
   ],
   "enabledManagers": [
     // Enable only the regex manager (for Dockerfile base image bumping).


### PR DESCRIPTION
Renovate dashboard is an issue opened by the Renovate bot which
keeps track of the Pull Requests done by the bot. Currently, we use
Zenhub to view and manage PRs.