### PR TITLE
fix indentation to 2 spaces

### DIFF
--- a/assets/examples/logging/windows/winlog.yml.example
+++ b/assets/examples/logging/windows/winlog.yml.example
@@ -1,48 +1,49 @@
 ###############################################################################
 # Log forwarder configuration winlog example                                  #
-# Source: windows event log                                                   #
+# Source: Windows event log                                                   #
 ###############################################################################
 logs:
- # Winlog log ingestion with eventId filters.
+  # Winlog log ingestion with eventId filters.
   - name: windows-security
     winlog:
-       channel: Security
-       collect-eventids:
+      channel: Security
+      collect-eventids:
         - 4624
         - 4265
         - 4700-4800
-       exclude-eventids:
+      exclude-eventids:
         - 4735
- 
- # entries for the application, system, powershell, and SCOM channels
-  - name: windows-application
-    winlog: 
-       channel: Application
-  - name: windows-system
-    winlog: 
-       channel: System
-  - name: windows-pshell
-    winlog: 
-       channel: Windows Powershell
-  - name: scom
-    winlog: 
-       channel: Operations Manager
 
- # Entry for Windows Defender Logs
+  # entries for the application, system, powershell, and SCOM channels
+  - name: windows-application
+    winlog:
+      channel: Application
+  - name: windows-system
+    winlog:
+      channel: System
+  - name: windows-pshell
+    winlog:
+      channel: Windows Powershell
+  - name: scom
+    winlog:
+      channel: Operations Manager
+
+  # Entry for Windows Defender Logs
   - name: windows-defender
     winlog:
-       channel: Microsoft-Windows-Windows Defender/Operational
- 
- # Entry for Windows Clustering Logs
+      channel: Microsoft-Windows-Windows Defender/Operational
+
+  # Entry for Windows Clustering Logs
   - name: windows-clustering
     winlog:
-       channel: Microsoft-Windows-FailoverClustering/Operational
- 
- # Entry for IIS logs with logtype attribute for automatic parsing
+      channel: Microsoft-Windows-FailoverClustering/Operational
+
+  # Entry for IIS logs with logtype attribute for automatic parsing
   - name: iis-log
     file: C:\inetpub\logs\LogFiles\w3svc.log
     attributes:
       logtype: iis_w3c
 
-# Add event IDs or ranges to collect-eventids or exclude-eventids to forward
-# or drop specific events. exclude-eventids takes precedence over collect-eventids
+# Add event IDs or ranges to collect-eventids or exclude-eventids to
+# forward or drop specific events. exclude-eventids takes precedence
+# over collect-eventids


### PR DESCRIPTION
Clean pull request, thanks for your patience @rogercoll.

This standardizes indentation to 2 spaces in this file. Some indentation was at 3 and some at 1 space previously, this was confusing and seems to have led to some issues with YAML parsing as users self-corrected the indentation to the wrong levels.