### PR TITLE
Build al2022

### DIFF
--- a/build/goreleaser/linux/al2022_amd64.yml
+++ b/build/goreleaser/linux/al2022_amd64.yml
@@ -1,0 +1,80 @@
+  # AL2022 adm64
+  
+  - id: amazonlinux-2022-infrastructure-agent
+    builds:
+      - linux-agent-amd64
+      - linux-ctl-amd64
+      - linux-service-amd64
+    package_name: newrelic-infra
+    file_name_template: "newrelic-infra-{{ .Env.TAG }}-1.amazonlinux-2022.{{ .Arch }}"
+    vendor: 'New Relic, Inc.'
+    homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
+    maintainer: 'caos-team@newrelic.com'
+    description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
+    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    formats:
+      - rpm
+    bindir: /usr/bin
+    contents:
+      - src: 'assets/examples/logging/linux/file.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/file.yml.example'
+      - src: 'assets/examples/logging/linux/fluentbit.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/fluentbit.yml.example'
+      - src: 'assets/examples/logging/linux/syslog.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/syslog.yml.example'
+      - src: 'assets/examples/logging/linux/systemd.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/systemd.yml.example'
+      - src: 'assets/examples/logging/linux/tcp.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/tcp.yml.example'
+  
+      - src: 'build/package/systemd/newrelic-infra.service'
+        dst: '/etc/systemd/system/newrelic-infra.service'
+      - src: 'LICENSE'
+        dst: '/var/db/newrelic-infra/LICENSE.txt'
+      - src: 'target/nridocker/amd64/etc/newrelic-infra/integrations.d/docker-config.yml'
+        dst: '/etc/newrelic-infra/integrations.d/docker-config.yml'
+        type: config
+      - src: 'target/nridocker/amd64/var/db/newrelic-infra/newrelic-integrations/bin/nri-docker'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-docker'
+      - src: 'target/nriflex/amd64/nri-flex'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
+      - src: 'target/nriprometheus/amd64/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
+      - src: 'target/fluent-bit-plugin/amd64/out_newrelic.so'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
+      - src: 'assets/examples/logging/parsers.conf'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
+    empty_folders:
+      - /var/db/newrelic-infra/custom-integrations
+      - /var/db/newrelic-infra/integrations.d
+      - /var/log/newrelic-infra
+      - /var/run/newrelic-infra
+    epoch: 0
+    release: 1.amazonlinux-2022
+    replacements:
+      amd64: x86_64
+  
+    # Scripts to execute during the installation of the package.
+    scripts:
+      preinstall: "build/package/before-install.sh"
+      preremove: "build/package/rpm/prerm-systemd.sh"
+  
+    # Packages to replace according to old packaging scripts.
+    replaces:
+      - opspro-agent
+      - opspro-agent-systemd
+    # Section.
+    section: default
+    # Priority.
+    priority: extra
+    rpm:
+      scripts:
+        posttrans: "build/package/rpm/postinst-systemd.sh"
+  
+      summary: "New Relic Infrastructure Agent"
+      group: default
+    # Required packages. rpm version 4.11.3 does not support weak dependencies
+    recommends:
+      - td-agent-bit
+  
+  # end AL2022 adm64

--- a/build/goreleaser/linux/al2022_arm.yml
+++ b/build/goreleaser/linux/al2022_arm.yml
@@ -1,0 +1,78 @@
+  # AL2022 arm
+  
+  - id: amazonlinux-2022-infrastructure-agent-arm
+    builds:
+      - linux-agent-arm
+      - linux-ctl-arm
+      - linux-service-arm
+    package_name: newrelic-infra
+    file_name_template: "newrelic-infra-{{ .Env.TAG }}-1.amazonlinux-2022.{{ .Arch }}"
+    vendor: 'New Relic, Inc.'
+    homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
+    maintainer: 'caos-team@newrelic.com'
+    description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
+    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    formats:
+      - rpm
+    bindir: /usr/bin
+    contents:
+      #      - src: 'assets/examples/logging/linux/file.yml.example'
+      #        dst: '/etc/newrelic-infra/logging.d/file.yml.example'
+      #      - src: 'assets/examples/logging/linux/fluentbit.yml.example'
+      #        dst: '/etc/newrelic-infra/logging.d/fluentbit.yml.example'
+      #      - src: 'assets/examples/logging/linux/syslog.yml.example'
+      #        dst: '/etc/newrelic-infra/logging.d/syslog.yml.example'
+      #      - src: 'assets/examples/logging/linux/systemd.yml.example'
+      #        dst: '/etc/newrelic-infra/logging.d/systemd.yml.example'
+      #      - src: 'assets/examples/logging/linux/tcp.yml.example'
+      #        dst: '/etc/newrelic-infra/logging.d/tcp.yml.example'
+  
+      - src: 'build/package/systemd/newrelic-infra.service'
+        dst: '/etc/systemd/system/newrelic-infra.service'
+      - src: 'LICENSE'
+        dst: '/var/db/newrelic-infra/LICENSE.txt'
+      - src: 'target/nridocker/{{ .Arch }}/etc/newrelic-infra/integrations.d/docker-config.yml'
+        dst: '/etc/newrelic-infra/integrations.d/docker-config.yml'
+        type: config
+  
+      - src: 'target/nridocker/{{ .Arch }}/var/db/newrelic-infra/newrelic-integrations/bin/nri-docker'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-docker'
+      - src: 'target/nriflex/{{ .Arch }}/nri-flex'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
+      - src: 'target/nriprometheus/{{ .Arch }}/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
+    #      - src: 'target/fluent-bit-plugin/{{ .Arch }}/out_newrelic.so'
+    #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
+    #      - src: 'assets/examples/logging/parsers.conf'
+    #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
+    empty_folders:
+      - /var/db/newrelic-infra/custom-integrations
+      - /var/db/newrelic-infra/integrations.d
+      - /var/log/newrelic-infra
+      - /var/run/newrelic-infra
+    epoch: 0
+    release: 1.amazonlinux-2022
+  
+    # Scripts to execute during the installation of the package.
+    scripts:
+      preinstall: "build/package/before-install.sh"
+      preremove: "build/package/rpm/prerm-systemd.sh"
+    # Packages to replace according to old packaging scripts.
+    replaces:
+      - opspro-agent
+      - opspro-agent-systemd
+    # Section.
+    section: default
+    # Priority.
+    priority: extra
+    rpm:
+      scripts:
+        posttrans: "build/package/rpm/postinst-systemd.sh"
+  
+      summary: "New Relic Infrastructure Agent"
+      group: default
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+#    recommends:
+#      - td-agent-bit
+  
+  # end AL2022 arm

--- a/build/goreleaser/linux/al2022_arm64.yml
+++ b/build/goreleaser/linux/al2022_arm64.yml
@@ -1,0 +1,77 @@
+  # AL2022 arm64
+  
+  - id: amazonlinux-2022-infrastructure-agent-arm64
+    builds:
+      - linux-agent-arm64
+      - linux-ctl-arm64
+      - linux-service-arm64
+    package_name: newrelic-infra
+    file_name_template: "newrelic-infra-{{ .Env.TAG }}-1.amazonlinux-2022.{{ .Arch }}"
+    vendor: 'New Relic, Inc.'
+    homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
+    maintainer: 'caos-team@newrelic.com'
+    description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
+    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    formats:
+      - rpm
+    bindir: /usr/bin
+    contents:
+      - src: 'assets/examples/logging/linux/file.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/file.yml.example'
+      - src: 'assets/examples/logging/linux/fluentbit.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/fluentbit.yml.example'
+      - src: 'assets/examples/logging/linux/syslog.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/syslog.yml.example'
+      - src: 'assets/examples/logging/linux/systemd.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/systemd.yml.example'
+      - src: 'assets/examples/logging/linux/tcp.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/tcp.yml.example'
+  
+      - src: 'build/package/systemd/newrelic-infra.service'
+        dst: '/etc/systemd/system/newrelic-infra.service'
+      - src: 'LICENSE'
+        dst: '/var/db/newrelic-infra/LICENSE.txt'
+      - src: 'target/nridocker/{{ .Arch }}/etc/newrelic-infra/integrations.d/docker-config.yml'
+        dst: '/etc/newrelic-infra/integrations.d/docker-config.yml'
+        type: config
+      - src: 'target/nridocker/{{ .Arch }}/var/db/newrelic-infra/newrelic-integrations/bin/nri-docker'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-docker'
+      - src: 'target/nriflex/{{ .Arch }}/nri-flex'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
+      - src: 'target/nriprometheus/{{ .Arch }}/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
+      - src: 'target/fluent-bit-plugin/{{ .Arch }}/out_newrelic.so'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
+      - src: 'assets/examples/logging/parsers.conf'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
+    empty_folders:
+      - /var/db/newrelic-infra/custom-integrations
+      - /var/db/newrelic-infra/integrations.d
+      - /var/log/newrelic-infra
+      - /var/run/newrelic-infra
+    epoch: 0
+    release: 1.amazonlinux-2022
+  
+    # Scripts to execute during the installation of the package.
+    scripts:
+      preinstall: "build/package/before-install.sh"
+      preremove: "build/package/rpm/prerm-systemd.sh"
+    # Packages to replace according to old packaging scripts.
+    replaces:
+      - opspro-agent
+      - opspro-agent-systemd
+    # Section.
+    section: default
+    # Priority.
+    priority: extra
+    rpm:
+      scripts:
+        posttrans: "build/package/rpm/postinst-systemd.sh"
+  
+      summary: "New Relic Infrastructure Agent"
+      group: default
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+    recommends:
+      - td-agent-bit
+  
+  # end AL2022 arm64

--- a/build/release.mk
+++ b/build/release.mk
@@ -167,6 +167,7 @@ generate-goreleaser-amd64:
 		$(CURDIR)/build/goreleaser/linux/archives_header.yml\
 		$(CURDIR)/build/goreleaser/linux/archives_amd64.yml\
 		$(CURDIR)/build/goreleaser/linux/nfpms_header.yml\
+		$(CURDIR)/build/goreleaser/linux/al2022_amd64.yml\
   		$(CURDIR)/build/goreleaser/linux/al2_amd64.yml\
   		$(CURDIR)/build/goreleaser/linux/centos_6_amd64.yml\
   		$(CURDIR)/build/goreleaser/linux/centos_7_amd64.yml\
@@ -191,7 +192,8 @@ generate-goreleaser-amd64:
 		$(CURDIR)/build/goreleaser/linux/archives_header.yml\
 		$(CURDIR)/build/goreleaser/linux/archives_arm.yml\
 		$(CURDIR)/build/goreleaser/linux/nfpms_header.yml\
-  		$(CURDIR)/build/goreleaser/linux/al2_arm.yml\
+		$(CURDIR)/build/goreleaser/linux/al2_arm.yml\
+		$(CURDIR)/build/goreleaser/linux/al2022_arm.yml\
   		$(CURDIR)/build/goreleaser/linux/centos_7_arm.yml\
   		$(CURDIR)/build/goreleaser/linux/centos_8_arm.yml\
   		$(CURDIR)/build/goreleaser/linux/debian_systemd_arm.yml\
@@ -211,6 +213,7 @@ generate-goreleaser-arm64:
 		$(CURDIR)/build/goreleaser/linux/archives_header.yml\
 		$(CURDIR)/build/goreleaser/linux/archives_arm64.yml\
 		$(CURDIR)/build/goreleaser/linux/nfpms_header.yml\
+		$(CURDIR)/build/goreleaser/linux/al2022_arm64.yml\
   		$(CURDIR)/build/goreleaser/linux/al2_arm64.yml\
   		$(CURDIR)/build/goreleaser/linux/centos_7_arm64.yml\
   		$(CURDIR)/build/goreleaser/linux/centos_8_arm64.yml\
@@ -245,6 +248,9 @@ generate-goreleaser-multiarch:
 		$(CURDIR)/build/goreleaser/linux/archives_arm64.yml\
 		$(CURDIR)/build/goreleaser/linux/archives_legacy.yml\
 		$(CURDIR)/build/goreleaser/linux/nfpms_header.yml\
+		$(CURDIR)/build/goreleaser/linux/al2022_amd64.yml\
+		$(CURDIR)/build/goreleaser/linux/al2022_arm.yml\
+		$(CURDIR)/build/goreleaser/linux/al2022_arm64.yml\
   		$(CURDIR)/build/goreleaser/linux/al2_amd64.yml\
   		$(CURDIR)/build/goreleaser/linux/al2_arm.yml\
   		$(CURDIR)/build/goreleaser/linux/al2_arm64.yml\

--- a/build/upload-schema-linux-rpm.yml
+++ b/build/upload-schema-linux-rpm.yml
@@ -64,3 +64,4 @@
       dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"
       os_version:
         - 2
+        - 2022

--- a/test/automated/ansible/group_vars/localhost/main.yml
+++ b/test/automated/ansible/group_vars/localhost/main.yml
@@ -293,7 +293,7 @@ instances:
   ############################
   # amazon linux 2022 amd64
   ############################
-  - ami: "ami-095f7ef665092668f"
+  - ami: "ami-012df31c3005bafaf"
     type: "t3a.small"
     name: "amd64:al-2022"
     username: "ec2-user"
@@ -303,7 +303,7 @@ instances:
   ############################
   # amazon linux 2022 arm64
   ############################
-  - ami: "ami-0a672c79e61374a45"
+  - ami: "ami-03c3e19c26859bb60"
     type: "t4g.small"
     name: "arm64:al-2022"
     username: "ec2-user"

--- a/test/automated/ansible/group_vars/localhost/main.yml
+++ b/test/automated/ansible/group_vars/localhost/main.yml
@@ -291,6 +291,26 @@ instances:
     python_interpreter: "/usr/bin/python"
     launch_template: "LaunchTemplateId=lt-0b00afb3f5110a0e6,Version=3"
   ############################
+  # amazon linux 2022 amd64
+  ############################
+  - ami: "ami-095f7ef665092668f"
+    type: "t3a.small"
+    name: "amd64:al-2022"
+    username: "ec2-user"
+    platform: "linux"
+    python_interpreter: "/usr/bin/python3"
+    launch_template: "LaunchTemplateId=lt-0b00afb3f5110a0e6,Version=3"
+  ############################
+  # amazon linux 2022 arm64
+  ############################
+  - ami: "ami-0a672c79e61374a45"
+    type: "t4g.small"
+    name: "arm64:al-2022"
+    username: "ec2-user"
+    platform: "linux"
+    python_interpreter: "/usr/bin/python3"
+    launch_template: "LaunchTemplateId=lt-0b00afb3f5110a0e6,Version=3"
+  ############################
   # windows amd64
   ############################
   - ami: "ami-0c5d73971003d1ab0"

--- a/test/packaging/ansible/roles/agent-upgrade/tasks/upgrade-RedHat.yaml
+++ b/test/packaging/ansible/roles/agent-upgrade/tasks/upgrade-RedHat.yaml
@@ -8,5 +8,16 @@
     state: "latest"
   retries: 5
   delay: 60
+  when: not "python3" in ansible_python_interpreter
+
+- name: dnf install infra-agent
+  environment: "{{ env_vars }}"
+  dnf:
+    name: "newrelic-infra"
+    update_cache: yes
+    state: "latest"
+  retries: 5
+  delay: 60
+  when: "'python3' in ansible_python_interpreter"
 
 ...

--- a/test/packaging/ansible/roles/cleanup/tasks/package-RedHat.yaml
+++ b/test/packaging/ansible/roles/cleanup/tasks/package-RedHat.yaml
@@ -5,5 +5,13 @@
     name: newrelic-infra
     state: absent
   ignore_errors: true
+  when: not "python3" in ansible_python_interpreter
+
+- name: dnf remove newrelic-infra package
+  dnf:
+    name: newrelic-infra
+    state: absent
+  ignore_errors: true
+  when: "'python3' in ansible_python_interpreter"
 
 ...

--- a/test/packaging/ansible/roles/package-install-pinned/tasks/package-RedHat.yaml
+++ b/test/packaging/ansible/roles/package-install-pinned/tasks/package-RedHat.yaml
@@ -7,5 +7,15 @@
     update_cache: yes
   retries: 5
   delay: 60
+  when: not "python3" in ansible_python_interpreter
+
+- name: Install infra-agent dnf
+  environment: "{{ env_vars }}"
+  dnf:
+    name: "newrelic-infra-{{ target_agent_version }}"
+    update_cache: yes
+  retries: 5
+  delay: 60
+  when: "'python3' in ansible_python_interpreter"
 
 ...

--- a/test/packaging/ansible/roles/package-install/tasks/package-RedHat.yaml
+++ b/test/packaging/ansible/roles/package-install/tasks/package-RedHat.yaml
@@ -1,11 +1,21 @@
 ---
 
-- name: yum install infra-agent
+- name: Install infra-agent yum
   environment: "{{ env_vars }}"
   yum:
     name: "newrelic-infra"
     update_cache: yes
   retries: 5
   delay: 60
+  when: not "python3" in ansible_python_interpreter
+
+- name: Install infra-agent dnf
+  environment: "{{ env_vars }}"
+  dnf:
+    name: "newrelic-infra"
+    update_cache: yes
+  retries: 5
+  delay: 60
+  when: "'python3' in ansible_python_interpreter"
 
 ...

--- a/test/packaging/ansible/roles/package-uninstall/tasks/package-RedHat.yaml
+++ b/test/packaging/ansible/roles/package-uninstall/tasks/package-RedHat.yaml
@@ -4,10 +4,17 @@
   yum:
     name: newrelic-infra
     state: absent
-  when: ansible_distribution_major_version != '5'
+  when: ansible_distribution_major_version != '5' and not "python3" in ansible_python_interpreter
+
+- name: dnf remove newrelic-infra package
+  yum:
+    name: newrelic-infra
+    state: absent
+  when: ansible_distribution_major_version != '5' and "'python3' in ansible_python_interpreter"
 
 - name: yum remove newrelic-infra package (rhel5)
   shell: yum -y remove newrelic-infra
   when: ansible_distribution_major_version == '5'
+
 
 ...

--- a/test/packaging/ansible/roles/repo-setup/tasks/repo-Amazon.yaml
+++ b/test/packaging/ansible/roles/repo-setup/tasks/repo-Amazon.yaml
@@ -9,7 +9,7 @@
   yum_repository:
     name: newrelic-infra
     description: New Relic Infrastructure Agent
-    baseurl: "{{ repo_endpoint }}/linux/yum/amazonlinux/2/$basearch"
+    baseurl: "{{ repo_endpoint }}/linux/yum/amazonlinux/{{ ansible_distribution_major_version }}/$basearch"
     gpgkey: http://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg
     gpgcheck: no
     repo_gpgcheck: no


### PR DESCRIPTION
Files to build Amazon Linux 2022. Unlike AL2, we still don't have available the `td-agent-bit` package, thus is not mandatory yet. 