### PR TITLE
fix race condition in test (Flaky 2)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -695,7 +695,10 @@ func (a *Agent) Run() (err error) {
 
 	//Remove send timer
 	if !a.shouldSendInventory() {
-		sendInventoryTimer.Stop()
+		//If Stop returns false means that the timer has been already triggered
+		if !sendInventoryTimer.Stop() {
+			<-sendInventoryTimer.C
+		}
 		reapInventoryTimer.Stop()
 		alog.Info("inventory submission disabled")
 	}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -541,22 +541,36 @@ func (p *patchSenderCallRecorder) getCalls() int {
 
 func TestAgent_Run_DontSendInventoryIfFwdOnly(t *testing.T) {
 	tests := []struct {
-		name       string
-		fwdOnly    bool
-		assertFunc func(t assert.TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool
-		expected   int
+		name              string
+		fwdOnly           bool
+		assertFunc        func(t assert.TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool
+		expected          int
+		firstReapInterval time.Duration
+		sendInterval      time.Duration
 	}{
 		{
-			name:       "forward only enabled should not send inventory",
-			fwdOnly:    true,
-			assertFunc: assert.Equal,
-			expected:   0,
+			name:              "forward only enabled should not send inventory",
+			fwdOnly:           true,
+			assertFunc:        assert.Equal,
+			expected:          0,
+			firstReapInterval: time.Second,
+			sendInterval:      time.Microsecond * 5,
 		},
 		{
-			name:       "forward only disabled should send inventory at least once",
-			fwdOnly:    false,
-			assertFunc: assert.GreaterOrEqual,
-			expected:   1,
+			name:              "forward only enabled should not send inventory low values timers",
+			fwdOnly:           true,
+			assertFunc:        assert.Equal,
+			expected:          0,
+			firstReapInterval: time.Nanosecond,
+			sendInterval:      time.Nanosecond,
+		},
+		{
+			name:              "forward only disabled should send inventory at least once",
+			fwdOnly:           false,
+			assertFunc:        assert.GreaterOrEqual,
+			expected:          1,
+			firstReapInterval: time.Second,
+			sendInterval:      time.Microsecond * 5,
 		},
 	}
 
@@ -566,8 +580,8 @@ func TestAgent_Run_DontSendInventoryIfFwdOnly(t *testing.T) {
 			wg.Add(1)
 			cfg := &config.Config{
 				IsForwardOnly:     tt.fwdOnly,
-				FirstReapInterval: time.Second,
-				SendInterval:      time.Microsecond * 5,
+				FirstReapInterval: tt.firstReapInterval,
+				SendInterval:      tt.sendInterval,
 			}
 			a := newTesting(cfg)
 			//Give time to at least send one request


### PR DESCRIPTION
Fix race condition in test when using mock register client:
```
WARNING: DATA RACE
Read at 0x00c000510b28 by goroutine 22:
  github.com/newrelic/infrastructure-agent/pkg/entity/register.(*fakeClient).assertRecordedData()
      /Users/runner/work/infrastructure-agent/infrastructure-agent/pkg/entity/register/worker_test.go:91 +0x1a7
  github.com/newrelic/infrastructure-agent/pkg/entity/register.TestWorker_Run_SendsWhenBatchLimitIsReached.func1()
      /Users/runner/work/infrastructure-agent/infrastructure-agent/pkg/entity/register/worker_test.go:206 +0xb6a
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.16.12/x64/src/testing/testing.go:1193 +0x202

Previous write at 0x00c000510b28 by goroutine 23:
  github.com/newrelic/infrastructure-agent/pkg/entity/register.(*fakeClient).RegisterBatchEntities()
      /Users/runner/work/infrastructure-agent/infrastructure-agent/pkg/entity/register/worker_test.go:72 +0x8fe
  github.com/newrelic/infrastructure-agent/pkg/entity/register.(*worker).registerEntitiesWithRetry()
      /Users/runner/work/infrastructure-agent/infrastructure-agent/pkg/entity/register/worker.go:181 +0x16f
  github.com/newrelic/infrastructure-agent/pkg/entity/register.(*worker).send()
      /Users/runner/work/infrastructure-agent/infrastructure-agent/pkg/entity/register/worker.go:118 +0x308
  github.com/newrelic/infrastructure-agent/pkg/entity/register.(*worker).Run()
      /Users/runner/work/infrastructure-agent/infrastructure-agent/pkg/entity/register/worker.go:103 +0x376
```