### PR TITLE
fix: decorate events with custom_attributes

### DIFF
--- a/internal/agent/status/status_test.go
+++ b/internal/agent/status/status_test.go
@@ -25,6 +25,13 @@ func TestNewReporter_Report(t *testing.T) {
 	}))
 	defer serverTimeout.Close()
 
+	assert.Eventually(t,
+		func() bool {
+			res, err := serverOk.Client().Get(serverOk.URL)
+			return err == nil && res.StatusCode == 200
+		},
+		time.Second, 10*time.Millisecond)
+
 	endpointsOk := []string{serverOk.URL}
 	endpointsTimeout := []string{serverTimeout.URL}
 	endpointsMixed := []string{serverOk.URL, serverTimeout.URL}

--- a/pkg/integrations/legacy/runner.go
+++ b/pkg/integrations/legacy/runner.go
@@ -788,7 +788,7 @@ func EmitDataSet(
 	}
 
 	for _, event := range dataSet.Events {
-		normalizedEvent := NormalizeEvent(elog, event, labels, integrationUser, entityKey.String())
+		normalizedEvent := NormalizeEvent(elog, event, labels, extraAnnotations, integrationUser, entityKey.String())
 
 		if normalizedEvent != nil {
 			emitter.EmitEvent(normalizedEvent, entityKey)

--- a/pkg/integrations/legacy/runner_test.go
+++ b/pkg/integrations/legacy/runner_test.go
@@ -728,7 +728,7 @@ func (rs *RunnerSuite) TestPluginHandleOutputEventsV1(c *C) {
 	c.Assert(event["label.expected"], Equals, "extra label")
 	c.Assert(event["label.important"], Equals, "true")
 
-	c.Assert(event["special.annotation"], Equals, nil)
+	c.Assert(event["special.annotation"], Equals, "not a label but a fact")
 
 	c.Assert(event["attrKey"], Equals, "attrValue")
 	// To avoid collisions repeated attributes are namespaced

--- a/pkg/integrations/legacy/utils.go
+++ b/pkg/integrations/legacy/utils.go
@@ -54,6 +54,7 @@ func NormalizeEvent(
 	entryLog log.Entry,
 	event protocol.EventData,
 	labels map[string]string,
+	extraAnnotations map[string]string,
 	integrationUser string,
 	entityKey string) protocol.EventData {
 	_, ok := event[V1_REQUIRED_EVENT_FIELD]
@@ -76,6 +77,12 @@ func NormalizeEvent(
 	}
 	for key, value := range labels {
 		normalizedEvent[fmt.Sprintf("label.%s", key)] = value
+	}
+	for key, value := range extraAnnotations {
+		// Extra annotations can't override current events
+		if _, ok = event[key]; !ok {
+			normalizedEvent[key] = value
+		}
 	}
 	if integrationUser != "" {
 		normalizedEvent["integrationUser"] = integrationUser

--- a/pkg/integrations/v4/dm/emitter_no_register.go
+++ b/pkg/integrations/v4/dm/emitter_no_register.go
@@ -83,7 +83,7 @@ func (e *nonRegisterEmitter) Send(dto fwrequest.FwRequest) {
 		}
 
 		for _, event := range dataSet.Events {
-			normalizedEvent := legacy.NormalizeEvent(elog, event, labels, integrationUser, dataSet.Entity.Name)
+			normalizedEvent := legacy.NormalizeEvent(elog, event, labels, extraAnnotations, integrationUser, dataSet.Entity.Name)
 
 			if normalizedEvent != nil {
 				emitter.EmitEvent(normalizedEvent, entity.Key(dataSet.Entity.Name))


### PR DESCRIPTION
Decorate events with [custom_attributes](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/#custom-attributes) as it is done with metrics.

@kang-makes can you confirm the structure below is what you would expect?

<img width="854" alt="Screenshot 2022-01-26 at 10 06 30" src="https://user-images.githubusercontent.com/3380451/151134345-d48dafea-b62b-4656-98b8-72b9f055ddeb.png">
