### PR TITLE
feat: use vault repository for Centos8 canaries

### DIFF
--- a/test/automated/ansible/roles/remove-eol-sources/tasks/main.yml
+++ b/test/automated/ansible/roles/remove-eol-sources/tasks/main.yml
@@ -1,10 +1,16 @@
 ---
 
+- name: 'Configure vault repository for Centos8 EOL'
+  raw: 'sudo sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-* \
+    && sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*'
+  when: inventory_hostname is search(item) and "centos8" in inventory_hostname
+  loop: "{{ instances_with_eol_repos }}"
+
 - name: 'Remove jessie-backports deb'
   ansible.builtin.file:
     name: /etc/apt/sources.list.d/backports.list
     state: absent
-  when: inventory_hostname is search(item)
+  when: inventory_hostname is search(item) and "debian" in inventory_hostname
   loop: "{{ instances_with_eol_repos }}"
 
 ...

--- a/test/automated/ansible/roles/remove-eol-sources/vars/main.yml
+++ b/test/automated/ansible/roles/remove-eol-sources/vars/main.yml
@@ -1,2 +1,4 @@
 instances_with_eol_repos:
   - "amd64:debian-jessie"
+  - "amd64:centos8"
+  - "arm64:centos8"


### PR DESCRIPTION
Ansible tasks to change the repositories cannot use ansible builtin
modules as Python3 is not installed by default in Centos8 and we need
to change the repositories url to install it.