### PR TITLE
Bump the embedded nri-prometheus to the last version with ignore_entity

### DIFF
--- a/build/embed/integrations.version
+++ b/build/embed/integrations.version
@@ -2,4 +2,4 @@
 nri-docker,1.6.0
 nri-flex,1.4.4
 nri-winservices,v0.5.0-beta
-nri-prometheus,2.8.0
+nri-prometheus,2.14.0


### PR DESCRIPTION
- The the embedded nri-prometheus now is not using entity synthesis, and retrieves the payload with ignore_entity flag