### PR TITLE
feat: replace Fields by log.Entry in tracer

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -423,7 +423,7 @@ func New(
 	}
 
 	// Create input channel for plugins to feed data back to the agent
-	trace.Inventory(llog.Fields(), "parallelize queue: %v", a.Context.cfg.InventoryQueueLen)
+	trace.Inventory(llog, "parallelize queue: %v", a.Context.cfg.InventoryQueueLen)
 	a.Context.ch = make(chan PluginOutput, a.Context.cfg.InventoryQueueLen)
 	a.Context.activeEntities = make(chan string, activeEntitiesBufferLength)
 

--- a/internal/agent/cmdchannel/fflag/ffhandler.go
+++ b/internal/agent/cmdchannel/fflag/ffhandler.go
@@ -198,7 +198,7 @@ func (h *handler) handleEnableOHI(ctx context.Context, ff string, enable bool) {
 }
 
 func handleParallelizeInventory(ffArgs args, c *config.Config, isInitialFetch bool) {
-	trace.Inventory(ffLogger.Fields(), "parallelize FF handler initialFetch: %v, enable: %v, queue: %v",
+	trace.Inventory(ffLogger, "parallelize FF handler initialFetch: %v, enable: %v, queue: %v",
 		isInitialFetch,
 		ffArgs.Enabled,
 		c.InventoryQueueLen,

--- a/internal/agent/cmdchannel/runintegration/runintegration.go
+++ b/internal/agent/cmdchannel/runintegration/runintegration.go
@@ -44,7 +44,7 @@ func (a *RunIntArgs) Hash() string {
 // NewHandler creates a cmd-channel handler for run-integration requests.
 func NewHandler(definitionQ chan<- integration.Definition, il integration.InstancesLookup, dmEmitter dm.Emitter, logger log.Entry) *cmdchannel.CmdHandler {
 	handleF := func(ctx context.Context, cmd commandapi.Command, initialFetch bool) (err error) {
-		trace.CmdReq(logger.Fields(), "run integration request received")
+		trace.CmdReq(logger, "run integration request received")
 		var args RunIntArgs
 		if err = json.Unmarshal(cmd.Args, &args); err != nil {
 			err = cmdchannel.NewArgsErr(err)

--- a/internal/agent/cmdchannel/service/service.go
+++ b/internal/agent/cmdchannel/service/service.go
@@ -115,12 +115,12 @@ func (s *srv) nextPollInterval() time.Duration {
 
 func (s *srv) handle(ctx context.Context, c commandapi.Command, initialFetch bool, agentID entity.ID) {
 	if s.wasACKed(c, agentID) {
-		trace.CmdReq(ccsLogger.Fields(), "skipping cmd already ACKed: %s, hash: %s, args: %s", c.Name, c.Hash, string(c.Args))
+		trace.CmdReq(ccsLogger, "skipping cmd already ACKed: %s, hash: %s, args: %s", c.Name, c.Hash, string(c.Args))
 		return
 	}
 
 	if s.requiresAck(c, agentID) {
-		trace.CmdReq(ccsLogger.Fields(), "triggering ACK for cmd: %s, hash: %s, args: %s", c.Name, c.Hash, string(c.Args))
+		trace.CmdReq(ccsLogger, "triggering ACK for cmd: %s, hash: %s, args: %s", c.Name, c.Hash, string(c.Args))
 		if err := s.ack(agentID, c); err != nil {
 			ccsLogger.
 				WithField("cmd_hash", c.Hash).

--- a/internal/agent/cmdchannel/stopintegration/stopintegration.go
+++ b/internal/agent/cmdchannel/stopintegration/stopintegration.go
@@ -33,7 +33,7 @@ func NewHandler(tracker *track.Tracker, il integration.InstancesLookup, dmEmitte
 			return cmdchannel.ErrOSNotSupported
 		}
 
-		trace.CmdReq(l.Fields(), "stop integration request received")
+		trace.CmdReq(l, "stop integration request received")
 
 		var args runintegration.RunIntArgs
 		if err = json.Unmarshal(cmd.Args, &args); err != nil {

--- a/internal/agent/connect_service.go
+++ b/internal/agent/connect_service.go
@@ -48,7 +48,7 @@ func (ic *identityConnectService) Connect() entity.Identity {
 			continue
 		}
 
-		trace.Connect(logger.Fields(), "connect request with fingerprint: %+v", f)
+		trace.Connect(logger, "connect request with fingerprint: %+v", f)
 
 		ids, retry, err := ic.client.Connect(f)
 
@@ -108,7 +108,7 @@ func (ic *identityConnectService) ConnectUpdate(agentIdn entity.Identity) (entit
 
 	var retryBO *backoff.Backoff
 	for {
-		trace.Connect(logger.Fields(), "connect update request with fingerprint: %+v", f)
+		trace.Connect(logger, "connect update request with fingerprint: %+v", f)
 		retry, entityIdn, err := ic.client.ConnectUpdate(agentIdn, f)
 		if retry.After > 0 {
 			logger.WithField("retryAfter", retry.After).Debug("Connect update retry requested.")

--- a/internal/agent/delta/store.go
+++ b/internal/agent/delta/store.go
@@ -895,7 +895,7 @@ func (s *Store) updatePluginInventoryCache(pi *PluginInfo, entityKey string) (up
 		return
 	}
 
-	trace.AttrOn(llog.Fields(),
+	trace.AttrOn(llog,
 		func() bool { return ids.CustomAttrsID.String() == pi.ID() },
 		"reap change, item: %+v", *pi,
 	)

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -194,7 +194,7 @@ func TraceSamplerStructureDetails(logEntry log.Entry, sample interface{}, name, 
 		if dErr != nil {
 			logEntry.WithFields(optionalFields).WithError(dErr).Debug("Can't marshal sample.")
 		} else {
-			trace.Sampler(logEntry.WithFields(optionalFields).Fields(), string(buffer))
+			trace.Sampler(logEntry.WithFields(optionalFields), string(buffer))
 		}
 	}
 }

--- a/pkg/integrations/cmdrequest/handler.go
+++ b/pkg/integrations/cmdrequest/handler.go
@@ -21,7 +21,7 @@ type HandleFn func(protocol.CmdRequestV1)
 // Each command is run in parallel and won't depend on the results of the other ones.
 func NewHandleFn(definitionQueue chan<- integration.Definition, il integration.InstancesLookup, logger log.Entry) HandleFn {
 	return func(crBatch protocol.CmdRequestV1) {
-		trace.CmdReq(logger.Fields(), "received payload: %+v", crBatch)
+		trace.CmdReq(logger, "received payload: %+v", crBatch)
 		for _, c := range crBatch.Commands {
 
 			def, err := integration.NewDefinition(newConfigFromCmdReq(c), il, nil, nil)
@@ -37,7 +37,7 @@ func NewHandleFn(definitionQueue chan<- integration.Definition, il integration.I
 				return
 			}
 
-			trace.CmdReq(logger.Fields(), "queued definition: %+v", def)
+			trace.CmdReq(logger, "queued definition: %+v", def)
 			definitionQueue <- def
 		}
 	}

--- a/pkg/integrations/v4/dm/telemetry.go
+++ b/pkg/integrations/v4/dm/telemetry.go
@@ -35,7 +35,7 @@ func (l *telemetryErrLogger) Write(p []byte) (n int, err error) {
 		telemetryLogger.Debug(string(p))
 	case "audit":
 		// payload should be logged only when customer enabled dm.submission feature traces.
-		trace.Telemetry(telemetryLogger.Fields(), string(p))
+		trace.Telemetry(telemetryLogger, string(p))
 	}
 
 	return len(p), nil

--- a/pkg/integrations/v4/supervisor.go
+++ b/pkg/integrations/v4/supervisor.go
@@ -179,7 +179,7 @@ func (s *Supervisor) logLine(out []byte, channel string) {
 	// avoid feedback loops
 	if !strings.Contains(strOut, componentName) {
 		if s.traceOutput {
-			trace.LogFwdOutput(s.log.Fields(), strOut)
+			trace.LogFwdOutput(s.log, strOut)
 			return
 		}
 

--- a/pkg/metrics/process/harvester_linux.go
+++ b/pkg/metrics/process/harvester_linux.go
@@ -176,7 +176,7 @@ func (ps *linuxHarvester) populateIOCounters(sample, lastSample *types.ProcessSa
 		if lastSample != nil && lastSample.LastIOCounters != nil {
 			lastCounters := lastSample.LastIOCounters
 
-			trace.Proc(mplog.Fields(), "ReadCount: %d, WriteCount: %d, ReadBytes: %d, WriteBytes: %d", ioCounters.ReadCount, ioCounters.WriteCount, ioCounters.ReadBytes, ioCounters.WriteBytes)
+			trace.Proc(mplog, "ReadCount: %d, WriteCount: %d, ReadBytes: %d, WriteBytes: %d", ioCounters.ReadCount, ioCounters.WriteCount, ioCounters.ReadBytes, ioCounters.WriteBytes)
 			ioReadCountPerSecond := acquire.CalculateSafeDelta(ioCounters.ReadCount, lastCounters.ReadCount, elapsedSeconds)
 			ioWriteCountPerSecond := acquire.CalculateSafeDelta(ioCounters.WriteCount, lastCounters.WriteCount, elapsedSeconds)
 			ioReadBytesPerSecond := acquire.CalculateSafeDelta(ioCounters.ReadBytes, lastCounters.ReadBytes, elapsedSeconds)

--- a/pkg/metrics/sampler/matcher.go
+++ b/pkg/metrics/sampler/matcher.go
@@ -76,12 +76,12 @@ func (p matcher) Evaluate(event interface{}) bool {
 		return false
 	}
 	isMatch := p.Evaluator(p.ExpectedValue, actualValue)
-	trace.MetricMatch(mlog.Fields(), "'%v' matches expression %v >> '%v': %v", actualValue, p.PropertyName, p.ExpectedValue, isMatch)
+	trace.MetricMatch(mlog, "'%v' matches expression %v >> '%v': %v", actualValue, p.PropertyName, p.ExpectedValue, isMatch)
 	return isMatch
 }
 
 func getMapValue(object map[string]interface{}, fieldNames []string) interface{} {
-	trace.MetricMatch(mlog.Fields(), "Searching map[string]interface{} for fields %v", fieldNames)
+	trace.MetricMatch(mlog, "Searching map[string]interface{} for fields %v", fieldNames)
 	for i := range fieldNames {
 		obj := object[fieldNames[i]]
 		if obj != nil {
@@ -99,7 +99,7 @@ func getFieldValue(object interface{}, fieldNames []string) interface{} {
 
 	// If a struct then try and get it by field
 	if v.Kind() == reflect.Struct {
-		trace.MetricMatch(mlog.Fields(), "Searching Struct for fields %v", fieldNames)
+		trace.MetricMatch(mlog, "Searching Struct for fields %v", fieldNames)
 		for i := range fieldNames {
 			fv := v.FieldByName(fieldNames[i])
 			if fv.IsValid() && fv.CanInterface() {
@@ -114,7 +114,7 @@ func getFieldValue(object interface{}, fieldNames []string) interface{} {
 	case types.FlatProcessSample: // types.FlatProcessSample is a map so check if any of the field names contains a value
 		return getMapValue(v.Interface().(types.FlatProcessSample), fieldNames)
 	default:
-		trace.MetricMatch(mlog.Fields(), "Fields %v does NOT exist in sample.", fieldNames)
+		trace.MetricMatch(mlog, "Fields %v does NOT exist in sample.", fieldNames)
 		return nil
 	}
 }
@@ -267,7 +267,7 @@ func NewSampleMatchFn(enableProcessMetrics *bool, includeMetricsMatchers config.
 		// if config option is not set, check if we have rules defined. those take precedence over the FF
 		ec := NewMatcherChain(includeMetricsMatchers)
 		if ec.Enabled {
-			trace.MetricMatch(mlog.Fields(), "EnableProcessMetrics is EMPTY and rules ARE defined, process metrics will be ENABLED for matching processes")
+			trace.MetricMatch(mlog, "EnableProcessMetrics is EMPTY and rules ARE defined, process metrics will be ENABLED for matching processes")
 			return func(sample interface{}) bool {
 				return ec.Evaluate(sample)
 			}
@@ -289,19 +289,19 @@ func NewSampleMatchFn(enableProcessMetrics *bool, includeMetricsMatchers config.
 	}
 
 	if excludeProcessMetrics(enableProcessMetrics) {
-		trace.MetricMatch(mlog.Fields(), "EnableProcessMetrics is FALSE, process metrics will be DISABLED")
+		trace.MetricMatch(mlog, "EnableProcessMetrics is FALSE, process metrics will be DISABLED")
 		return func(sample interface{}) bool {
 			switch sample.(type) {
 			case *types.ProcessSample:
-				trace.MetricMatch(mlog.Fields(), "Got a sample of type '*types.ProcessSample' so excluding sample.")
+				trace.MetricMatch(mlog, "Got a sample of type '*types.ProcessSample' so excluding sample.")
 				// no process samples are included
 				return false
 			case *types.FlatProcessSample:
-				trace.MetricMatch(mlog.Fields(), "Got a sample of type '*types.FlatProcessSample' so excluding sample.")
+				trace.MetricMatch(mlog, "Got a sample of type '*types.FlatProcessSample' so excluding sample.")
 				// no flat process samples are included
 				return false
 			default:
-				trace.MetricMatch(mlog.Fields(), "Got a sample of type '%s' that should not be excluded.", reflect.TypeOf(sample).String())
+				trace.MetricMatch(mlog, "Got a sample of type '%s' that should not be excluded.", reflect.TypeOf(sample).String())
 				// other samples are included
 				return true
 			}
@@ -310,13 +310,13 @@ func NewSampleMatchFn(enableProcessMetrics *bool, includeMetricsMatchers config.
 
 	ec := NewMatcherChain(includeMetricsMatchers)
 	if ec.Enabled {
-		trace.MetricMatch(mlog.Fields(), "EnableProcessMetrics is TRUE and rules ARE defined, process metrics will be ENABLED for matching processes")
+		trace.MetricMatch(mlog, "EnableProcessMetrics is TRUE and rules ARE defined, process metrics will be ENABLED for matching processes")
 		return func(sample interface{}) bool {
 			return ec.Evaluate(sample)
 		}
 	}
 
-	trace.MetricMatch(mlog.Fields(), "EnableProcessMetrics is TRUE and rules are NOT defined, ALL process metrics will be ENABLED")
+	trace.MetricMatch(mlog, "EnableProcessMetrics is TRUE and rules are NOT defined, ALL process metrics will be ENABLED")
 	return func(sample interface{}) bool {
 		// all process samples are included
 		return true

--- a/pkg/plugins/custom_attrs.go
+++ b/pkg/plugins/custom_attrs.go
@@ -37,7 +37,7 @@ func (self *CustomAttrsPlugin) Run() {
 	data := agent.PluginInventoryDataset{CustomAttrs(self.customAttributes)}
 	entityKey := self.Context.EntityKey()
 
-	trace.Attr(aclog.Fields(), "run, entity: %s, data: %+v", entityKey, self.customAttributes)
+	trace.Attr(aclog, "run, entity: %s, data: %+v", entityKey, self.customAttributes)
 
 	self.EmitInventory(data, entity.NewFromNameWithoutID(entityKey))
 }

--- a/pkg/sysinfo/hostname/hostname.go
+++ b/pkg/sysinfo/hostname/hostname.go
@@ -75,7 +75,7 @@ func CreateResolver(overrideFull, overrideShort string, dnsResolution bool) Reso
 
 	if overrideShort != "" {
 		resolver.short = func() (string, error) {
-			trace.Hostname(logger.Fields(), "using override_hostname_short property '%s'", overrideShort)
+			trace.Hostname(logger, "using override_hostname_short property '%s'", overrideShort)
 			return overrideShort, nil
 		}
 	}
@@ -131,11 +131,11 @@ func (r *fallbackResolver) Query() (string, string, error) {
 	short, err := r.short()
 	var full string
 	if r.overridenFull != "" {
-		trace.Hostname(logger.Fields(), "using override_hostname property '%s'", r.overridenFull)
+		trace.Hostname(logger, "using override_hostname property '%s'", r.overridenFull)
 		full = r.overridenFull
 	} else {
 		if err != nil {
-			trace.Hostname(logger.Fields(), "failed to resolve short hostname: %s", err)
+			trace.Hostname(logger, "failed to resolve short hostname: %s", err)
 		} else {
 			full, err = r.full(short)
 		}
@@ -143,10 +143,10 @@ func (r *fallbackResolver) Query() (string, string, error) {
 		// and just return the full hostname as queried by the kernel (the old behaviour of the agent)
 		if r.lastFull == "" && (full == "" || full == "localhost") {
 			// In this edge case, the hostname could flip under some network name instability circumstances
-			trace.Hostname(logger.Fields(), "using internal hostname")
+			trace.Hostname(logger, "using internal hostname")
 			full, err = r.internal()
 			if err != nil {
-				trace.Hostname(logger.Fields(), "internal hostname resolution failed")
+				trace.Hostname(logger, "internal hostname resolution failed")
 			}
 			if full == "localhost" {
 				full = ""

--- a/pkg/sysinfo/hostname/hostname_darwin.go
+++ b/pkg/sysinfo/hostname/hostname_darwin.go
@@ -53,7 +53,7 @@ func getFqdnHostname(osHost string) (string, error) {
 		if hosts[0] == "localhost" {
 			continue
 		}
-		trace.Hostname(logger.Fields(), "found FQDN hosts: %s", strings.Join(hosts, ", "))
+		trace.Hostname(logger, "found FQDN hosts: %s", strings.Join(hosts, ", "))
 		return strings.TrimSuffix(hosts[0], "."), nil
 	}
 	return "", errors.New("can't lookup FQDN")

--- a/pkg/sysinfo/hostname/hostname_lin_win.go
+++ b/pkg/sysinfo/hostname/hostname_lin_win.go
@@ -26,7 +26,7 @@ func getFqdnHostname(osHost string) (string, error) {
 		if err != nil || len(hosts) == 0 {
 			return "", err
 		}
-		trace.Hostname(logger.Fields(), "found FQDN hosts: %s", strings.Join(hosts, ", "))
+		trace.Hostname(logger, "found FQDN hosts: %s", strings.Join(hosts, ", "))
 		return strings.TrimSuffix(hosts[0], "."), nil
 	}
 	return "", errors.New("can't lookup FQDN")

--- a/pkg/trace/features.go
+++ b/pkg/trace/features.go
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package trace
 
+import "github.com/newrelic/infrastructure-agent/pkg/log"
+
 // Feature feature to be traced.
 type Feature string
 
@@ -29,23 +31,23 @@ const (
 // trace.On(trace.FEATURE, ...)
 
 // Attr always traces custom-attributes feature.
-func Attr(fields map[string]interface{}, format string, args ...interface{}) {
-	On(func() bool { return true }, ATTR, fields, format, args...)
+func Attr(entry log.Entry, format string, args ...interface{}) {
+	On(func() bool { return true }, ATTR, entry, format, args...)
 }
 
 // AttrOn trace custom-attributes feature on given condition.
-func AttrOn(fields map[string]interface{}, cond Condition, format string, args ...interface{}) {
-	On(cond, ATTR, fields, format, args...)
+func AttrOn(entry log.Entry, cond Condition, format string, args ...interface{}) {
+	On(cond, ATTR, entry, format, args...)
 }
 
 // Connect always traces connect feature.
-func Connect(fields map[string]interface{}, format string, args ...interface{}) {
-	On(func() bool { return true }, CONN, fields, format, args...)
+func Connect(entry log.Entry, format string, args ...interface{}) {
+	On(func() bool { return true }, CONN, entry, format, args...)
 }
 
 // Hostname always traces hostname feature.
-func Hostname(fields map[string]interface{}, format string, args ...interface{}) {
-	On(func() bool { return true }, HOSTNAME, fields, format, args...)
+func Hostname(entry log.Entry, format string, args ...interface{}) {
+	On(func() bool { return true }, HOSTNAME, entry, format, args...)
 }
 
 // NonDMSubmission traces NR platform non-dimensional metrics submission payloads.
@@ -54,36 +56,36 @@ func NonDMSubmission(payload []byte) {
 }
 
 // Telemetry traces to "audit" (log payloads) on DM telemetry.
-func Telemetry(fields map[string]interface{}, format string, args ...interface{}) {
-	On(func() bool { return true }, DM_SUBMISSION, fields, format, args...)
+func Telemetry(entry log.Entry, format string, args ...interface{}) {
+	On(func() bool { return true }, DM_SUBMISSION, entry, format, args...)
 }
 
 // MetricMatch traces to "audit" log metric match rule.
-func MetricMatch(fields map[string]interface{}, format string, args ...interface{}) {
-	On(func() bool { return true }, METRIC_MATCHER, fields, format, args...)
+func MetricMatch(entry log.Entry, format string, args ...interface{}) {
+	On(func() bool { return true }, METRIC_MATCHER, entry, format, args...)
 }
 
 // Inventory traces to "audit" inventory.
-func Inventory(fields map[string]interface{}, format string, args ...interface{}) {
-	On(func() bool { return true }, INVENTORY, fields, format, args...)
+func Inventory(entry log.Entry, format string, args ...interface{}) {
+	On(func() bool { return true }, INVENTORY, entry, format, args...)
 }
 
 // LogFwdOutput traces to "audit" log-forwarder output.
-func LogFwdOutput(fields map[string]interface{}, format string, args ...interface{}) {
-	On(func() bool { return true }, LOG_FWD, fields, format, args...)
+func LogFwdOutput(entry log.Entry, format string, args ...interface{}) {
+	On(func() bool { return true }, LOG_FWD, entry, format, args...)
 }
 
 // CmdReq traces to "audit" command request payloads.
-func CmdReq(fields map[string]interface{}, format string, args ...interface{}) {
-	On(func() bool { return true }, CMDREQ, fields, format, args...)
+func CmdReq(entry log.Entry, format string, args ...interface{}) {
+	On(func() bool { return true }, CMDREQ, entry, format, args...)
 }
 
 // Proc traces to "audit" process sampling.
-func Proc(fields map[string]interface{}, format string, args ...interface{}) {
-	On(func() bool { return true }, PROC, fields, format, args...)
+func Proc(entry log.Entry, format string, args ...interface{}) {
+	On(func() bool { return true }, PROC, entry, format, args...)
 }
 
 // Sampler traces to "audit" system samplers (cpu, disk, network, etc) stats.
-func Sampler(fields map[string]interface{}, format string, args ...interface{}) {
-	On(func() bool { return true }, SAMPLER, fields, format, args...)
+func Sampler(entry log.Entry, format string, args ...interface{}) {
+	On(func() bool { return true }, SAMPLER, entry, format, args...)
 }

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -3,6 +3,7 @@
 package trace
 
 import (
+	"github.com/newrelic/infrastructure-agent/pkg/log"
 	"github.com/sirupsen/logrus"
 )
 
@@ -35,14 +36,15 @@ func EnableOn(features []string) {
 }
 
 // On logs data to be shown if trace for a given feature is enabled and condition is met.
-func On(condition Condition, feature Feature, fields map[string]interface{}, format string, args ...interface{}) {
+func On(condition Condition, feature Feature, entry log.Entry, format string, args ...interface{}) {
 	if global.logger == nil {
 		return
 	}
 
 	if _, ok := global.enabled[feature]; ok && condition() {
-		if fields == nil {
-			fields = make(map[string]interface{})
+		fields := make(map[string]interface{})
+		if entry != nil {
+			fields = entry.Fields()
 		}
 		fields["feature"] = feature
 		global.logger.WithFields(fields).Tracef(format, args...)

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -42,9 +42,12 @@ func On(condition Condition, feature Feature, entry log.Entry, format string, ar
 	}
 
 	if _, ok := global.enabled[feature]; ok && condition() {
-		fields := make(map[string]interface{})
+		var fields logrus.Fields
 		if entry != nil {
 			fields = entry.Fields()
+		}
+		if fields == nil {
+			fields = make(logrus.Fields)
 		}
 		fields["feature"] = feature
 		global.logger.WithFields(fields).Tracef(format, args...)

--- a/pkg/trace/trace_test.go
+++ b/pkg/trace/trace_test.go
@@ -53,8 +53,16 @@ func TestLogrusFields(t *testing.T) {
 		"name":      "SystemSampler",
 	}
 
-	On(func() bool { return true }, Feature("feature1"), expectedFields, "")
+	On(func() bool { return true }, Feature("feature1"), func() *logrus.Entry { return &logrus.Entry{Data: expectedFields} }, "")
 
 	assert.Contains(t, buffer.String(), "component=agentTests")
 	assert.Contains(t, buffer.String(), "name=SystemSampler")
+}
+
+func TestLogrusFieldsDisabled(t *testing.T) {
+	On(func() bool { return true }, Feature("DisabledFeature"), func() *logrus.Entry {
+		t.Log("this expensive operation should not be executed")
+		t.Fail()
+		return &logrus.Entry{}
+	}, "")
 }

--- a/pkg/trace/trace_test.go
+++ b/pkg/trace/trace_test.go
@@ -59,6 +59,18 @@ func TestLogrusFields(t *testing.T) {
 	assert.Contains(t, buffer.String(), "name=SystemSampler")
 }
 
+func TestLogrusWithoutFields(t *testing.T) {
+	On(func() bool { return true }, Feature("feature1"), func() *logrus.Entry { return &logrus.Entry{} }, "")
+
+	assert.Contains(t, buffer.String(), "feature=feature1")
+}
+
+func TestLogrusWithoutEntry(t *testing.T) {
+	On(func() bool { return true }, Feature("feature1"), nil, "")
+
+	assert.Contains(t, buffer.String(), "feature=feature1")
+}
+
 func TestLogrusFieldsDisabled(t *testing.T) {
 	On(func() bool { return true }, Feature("DisabledFeature"), func() *logrus.Entry {
 		t.Log("this expensive operation should not be executed")


### PR DESCRIPTION
Adding `log.Entry` to the tracer allows us to leverage the implementation of Fields in Entry