### PR TITLE
Add additional cloud metadata

### DIFF
--- a/internal/plugins/darwin/hostinfo_test.go
+++ b/internal/plugins/darwin/hostinfo_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/cloud"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"testing"
 )
 
@@ -194,4 +195,158 @@ func TestData(t *testing.T) {
 	assert.Equal(t, expected.AgentMode, data.AgentMode)
 	assert.Equal(t, expected.OperatingSystem, data.OperatingSystem)
 	assert.Equal(t, expected.ProductUuid, data.ProductUuid)
+}
+
+type fakeHarvester struct {
+	mock.Mock
+}
+
+// GetInstanceID will return the id of the cloud instance.
+func (f *fakeHarvester) GetInstanceID() (string, error) {
+	args := f.Called()
+	return args.String(0), args.Error(1)
+}
+
+// GetHostType will return the cloud instance type.
+func (f *fakeHarvester) GetHostType() (string, error) {
+	args := f.Called()
+	return args.String(0), args.Error(1)
+}
+
+// GetCloudType will return the cloud type on which the instance is running.
+func (f *fakeHarvester) GetCloudType() cloud.Type {
+	args := f.Called()
+	return args.Get(0).(cloud.Type)
+}
+
+// Returns a string key which will be used as a HostSource (see host_aliases plugin).
+func (f *fakeHarvester) GetCloudSource() string {
+	args := f.Called()
+	return args.String(0)
+}
+
+// GetRegion returns the cloud region
+func (f *fakeHarvester) GetRegion() (string, error) {
+	args := f.Called()
+	return args.String(0), args.Error(1)
+}
+
+// GetZone returns the cloud zone (availability zone)
+func (f *fakeHarvester) GetZone() (string, error) {
+	args := f.Called()
+	return args.String(0), args.Error(1)
+}
+
+// GetAccount returns the cloud account ID
+func (f *fakeHarvester) GetAccountID() (string, error) {
+	args := f.Called()
+	return args.String(0), args.Error(1)
+}
+
+// GetImageID returns the cloud instance ID
+func (f *fakeHarvester) GetInstanceImageID() (string, error) {
+	args := f.Called()
+	return args.String(0), args.Error(1)
+}
+
+// GetHarvester returns instance of the Harvester detected (or instance of themselves)
+func (f *fakeHarvester) GetHarvester() (cloud.Harvester, error) {
+	return f, nil
+}
+
+func TestHostinfoPluginSetCloudRegion(t *testing.T) {
+	testCases := []struct {
+		name       string
+		assertions func(*HostInfoData)
+		setMock    func(*fakeHarvester)
+	}{
+		{
+			name: "no cloud",
+			assertions: func(d *HostInfoData) {
+				assert.Equal(t, "", d.RegionAWS)
+				assert.Equal(t, "", d.RegionAzure)
+				assert.Equal(t, "", d.RegionGCP)
+				assert.Equal(t, "", d.RegionAlibaba)
+			},
+			setMock: func(h *fakeHarvester) {
+				h.On("GetCloudType").Return(cloud.TypeNoCloud)
+			},
+		},
+		{
+			name: "cloud aws",
+			assertions: func(d *HostInfoData) {
+				assert.Equal(t, "us-east-1", d.RegionAWS)
+				assert.Equal(t, "us-east-1a", d.AWSAvailabilityZone)
+				assert.Equal(t, "ami-12345", d.AWSImageID)
+				assert.Equal(t, "x123", d.AWSAccountID)
+				assert.Equal(t, "", d.RegionAzure)
+				assert.Equal(t, "", d.RegionGCP)
+				assert.Equal(t, "", d.RegionAlibaba)
+			},
+			setMock: func(h *fakeHarvester) {
+				h.On("GetCloudType").Return(cloud.TypeAWS)
+				h.On("GetRegion").Return("us-east-1", nil)
+				h.On("GetZone").Return("us-east-1a", nil)
+				h.On("GetInstanceImageID").Return("ami-12345", nil)
+				h.On("GetAccountID").Return("x123", nil)
+			},
+		},
+		{
+			name: "cloud azure",
+			assertions: func(d *HostInfoData) {
+				assert.Equal(t, "", d.RegionAWS)
+				assert.Equal(t, "us-east-1", d.RegionAzure)
+				assert.Equal(t, "", d.RegionGCP)
+				assert.Equal(t, "", d.RegionAlibaba)
+			},
+			setMock: func(h *fakeHarvester) {
+				h.On("GetCloudType").Return(cloud.TypeAzure)
+				h.On("GetRegion").Return("us-east-1", nil)
+			},
+		},
+		{
+			name: "cloud gcp",
+			assertions: func(d *HostInfoData) {
+				assert.Equal(t, "", d.RegionAWS)
+				assert.Equal(t, "", d.RegionAzure)
+				assert.Equal(t, "us-east-1", d.RegionGCP)
+				assert.Equal(t, "", d.RegionAlibaba)
+			},
+			setMock: func(h *fakeHarvester) {
+				h.On("GetCloudType").Return(cloud.TypeGCP)
+				h.On("GetRegion").Return("us-east-1", nil)
+			},
+		}, {
+			name: "cloud alibaba",
+			assertions: func(d *HostInfoData) {
+				assert.Equal(t, "", d.RegionAWS)
+				assert.Equal(t, "", d.RegionAzure)
+				assert.Equal(t, "", d.RegionGCP)
+				assert.Equal(t, "us-east-1", d.RegionAlibaba)
+			},
+			setMock: func(h *fakeHarvester) {
+				h.On("GetCloudType").Return(cloud.TypeAlibaba)
+				h.On("GetRegion").Return("us-east-1", nil)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			h := new(fakeHarvester)
+			testCase.setMock(h)
+			data := &HostInfoData{}
+			p := &HostinfoPlugin{
+				PluginCommon: agent.PluginCommon{
+					ID:      ids.HostInfo,
+					Context: testing2.NewMockAgent(),
+				},
+				cloudHarvester: h,
+			}
+			_ = p.setCloudRegion(data)
+			_ = p.setCloudMetadata(data)
+			testCase.assertions(data)
+			h.AssertExpectations(t)
+		})
+	}
 }

--- a/internal/plugins/linux/hostinfo.go
+++ b/internal/plugins/linux/hostinfo.go
@@ -63,9 +63,9 @@ type HostinfoData struct {
 	RegionAzure         string `json:"region_name,omitempty"`
 	RegionGCP           string `json:"zone,omitempty"`
 	RegionAlibaba       string `json:"region_id,omitempty"`
-	AWSAccountID        string `json:"awsAccountId,omitempty"`
-	AWSAvailabilityZone string `json:"awsAvailabilityZone,omitempty"`
-	AWSImageID          string `json:"awsImageID,omitempty"`
+	AWSAccountID        string `json:"aws_account_id,omitempty"`
+	AWSAvailabilityZone string `json:"aws_availability_zone,omitempty"`
+	AWSImageID          string `json:"aws_image_id,omitempty"`
 }
 
 func (self HostinfoData) SortKey() string {
@@ -275,12 +275,12 @@ func (self *HostinfoPlugin) setCloudMetadata(data *HostinfoData) (err error) {
 		data.AWSImageID = imageID
 		awsAccountID, err := self.cloudHarvester.GetAccountID()
 		if err != nil {
-			return fmt.Errorf("couldn't retrieve cloud region: %v", err)
+			return fmt.Errorf("couldn't retrieve cloud account ID: %v", err)
 		}
 		data.AWSAccountID = awsAccountID
 		availabilityZone, err := self.cloudHarvester.GetZone()
 		if err != nil {
-			return fmt.Errorf("couldn't retrieve cloud region: %v", err)
+			return fmt.Errorf("couldn't retrieve cloud availability zone: %v", err)
 		}
 		data.AWSAvailabilityZone = availabilityZone
 	}

--- a/internal/plugins/linux/hostinfo_test.go
+++ b/internal/plugins/linux/hostinfo_test.go
@@ -213,6 +213,24 @@ func (f *fakeHarvester) GetRegion() (string, error) {
 	return args.String(0), args.Error(1)
 }
 
+// GetZone returns the cloud zone (availability zone)
+func (f *fakeHarvester) GetZone() (string, error) {
+	args := f.Called()
+	return args.String(0), args.Error(1)
+}
+
+// GetAccount returns the cloud account ID
+func (f *fakeHarvester) GetAccountID() (string, error) {
+	args := f.Called()
+	return args.String(0), args.Error(1)
+}
+
+// GetImageID returns the cloud instance ID
+func (f *fakeHarvester) GetInstanceImageID() (string, error) {
+	args := f.Called()
+	return args.String(0), args.Error(1)
+}
+
 // GetHarvester returns instance of the Harvester detected (or instance of themselves)
 func (f *fakeHarvester) GetHarvester() (cloud.Harvester, error) {
 	return f, nil
@@ -240,6 +258,9 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 			name: "cloud aws",
 			assertions: func(d *HostinfoData) {
 				assert.Equal(t, "us-east-1", d.RegionAWS)
+				assert.Equal(t, "us-east-1a", d.AWSAvailabilityZone)
+				assert.Equal(t, "ami-12345", d.AWSImageID)
+				assert.Equal(t, "x123", d.AWSAccountID)
 				assert.Equal(t, "", d.RegionAzure)
 				assert.Equal(t, "", d.RegionGCP)
 				assert.Equal(t, "", d.RegionAlibaba)
@@ -247,6 +268,9 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 			setMock: func(h *fakeHarvester) {
 				h.On("GetCloudType").Return(cloud.TypeAWS)
 				h.On("GetRegion").Return("us-east-1", nil)
+				h.On("GetZone").Return("us-east-1a", nil)
+				h.On("GetInstanceImageID").Return("ami-12345", nil)
+				h.On("GetAccountID").Return("x123", nil)
 			},
 		},
 		{
@@ -302,6 +326,7 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 				cloudHarvester: h,
 			}
 			_ = p.setCloudRegion(data)
+			_ = p.setCloudMetadata(data)
 			testCase.assertions(data)
 			h.AssertExpectations(t)
 		})

--- a/internal/plugins/windows/hostinfo.go
+++ b/internal/plugins/windows/hostinfo.go
@@ -42,23 +42,26 @@ type HostinfoPlugin struct {
 }
 
 type HostinfoData struct {
-	System          string `json:"id"`
-	WindowsPlatform string `json:"windows_platform"`
-	WindowsFamily   string `json:"windows_family"`
-	WindowsVersion  string `json:"windows_version"`
-	HostType        string `json:"host_type"`
-	CpuName         string `json:"cpu_name"`
-	CpuNum          string `json:"cpu_num"`
-	TotalCpu        string `json:"total_cpu"`
-	Ram             string `json:"ram"`
-	UpSince         string `json:"boot_timestamp"`
-	AgentVersion    string `json:"agent_version"`
-	AgentName       string `json:"agent_name"`
-	OperatingSystem string `json:"operating_system"`
-	RegionAWS       string `json:"aws_region,omitempty"`
-	RegionAzure     string `json:"region_name,omitempty"`
-	RegionGCP       string `json:"zone,omitempty"`
-	RegionAlibaba   string `json:"region_id,omitempty"`
+	System              string `json:"id"`
+	WindowsPlatform     string `json:"windows_platform"`
+	WindowsFamily       string `json:"windows_family"`
+	WindowsVersion      string `json:"windows_version"`
+	HostType            string `json:"host_type"`
+	CpuName             string `json:"cpu_name"`
+	CpuNum              string `json:"cpu_num"`
+	TotalCpu            string `json:"total_cpu"`
+	Ram                 string `json:"ram"`
+	UpSince             string `json:"boot_timestamp"`
+	AgentVersion        string `json:"agent_version"`
+	AgentName           string `json:"agent_name"`
+	OperatingSystem     string `json:"operating_system"`
+	RegionAWS           string `json:"aws_region,omitempty"`
+	RegionAzure         string `json:"region_name,omitempty"`
+	RegionGCP           string `json:"zone,omitempty"`
+	RegionAlibaba       string `json:"region_id,omitempty"`
+	AWSAccountID        string `json:"aws_account_id,omitempty"`
+	AWSAvailabilityZone string `json:"aws_availability_zone,omitempty"`
+	AWSImageID          string `json:"aws_image_id,omitempty"`
 }
 
 type cpuInfo struct {
@@ -123,6 +126,12 @@ func (self *HostinfoPlugin) gatherHostinfo(context agent.AgentContext, info *hos
 			"cloud region couldn't be set")
 	}
 
+	err = self.setCloudMetadata(data)
+	if err != nil {
+		hlog.WithError(err).WithField("cloudType", self.cloudHarvester.GetCloudType()).Debug(
+			"cloud metadata couldn't be set")
+	}
+
 	helpers.LogStructureDetails(hlog, data, "HostInfoData", "raw", nil)
 
 	return data
@@ -149,6 +158,33 @@ func (self *HostinfoPlugin) setCloudRegion(data *HostinfoData) (err error) {
 	case cloud.TypeAlibaba:
 		data.RegionAlibaba = region
 	default:
+	}
+	return
+}
+
+// Only for AWS cloud instances
+func (self *HostinfoPlugin) setCloudMetadata(data *HostinfoData) (err error) {
+	if self.Context.Config().DisableCloudMetadata ||
+		self.cloudHarvester.GetCloudType() == cloud.TypeNoCloud {
+		return
+	}
+
+	if self.cloudHarvester.GetCloudType() == cloud.TypeAWS {
+		imageID, err := self.cloudHarvester.GetInstanceImageID()
+		if err != nil {
+			return fmt.Errorf("couldn't retrieve cloud image ID: %v", err)
+		}
+		data.AWSImageID = imageID
+		awsAccountID, err := self.cloudHarvester.GetAccountID()
+		if err != nil {
+			return fmt.Errorf("couldn't retrieve cloud account ID: %v", err)
+		}
+		data.AWSAccountID = awsAccountID
+		availabilityZone, err := self.cloudHarvester.GetZone()
+		if err != nil {
+			return fmt.Errorf("couldn't retrieve cloud availability zone: %v", err)
+		}
+		data.AWSAvailabilityZone = availabilityZone
 	}
 	return
 }

--- a/internal/plugins/windows/hostinfo_test.go
+++ b/internal/plugins/windows/hostinfo_test.go
@@ -112,6 +112,24 @@ func (f *fakeHarvester) GetHarvester() (cloud.Harvester, error) {
 	return f, nil
 }
 
+// GetZone returns the cloud zone (availability zone)
+func (f *fakeHarvester) GetZone() (string, error) {
+	args := f.Called()
+	return args.String(0), args.Error(1)
+}
+
+// GetAccount returns the cloud account ID
+func (f *fakeHarvester) GetAccountID() (string, error) {
+	args := f.Called()
+	return args.String(0), args.Error(1)
+}
+
+// GetImageID returns the cloud instance ID
+func (f *fakeHarvester) GetInstanceImageID() (string, error) {
+	args := f.Called()
+	return args.String(0), args.Error(1)
+}
+
 func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 	testCases := []struct {
 		name       string
@@ -134,6 +152,9 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 			name: "cloud aws",
 			assertions: func(d *HostinfoData) {
 				assert.Equal(t, "us-east-1", d.RegionAWS)
+				assert.Equal(t, "us-east-1a", d.AWSAvailabilityZone)
+				assert.Equal(t, "ami-12345", d.AWSImageID)
+				assert.Equal(t, "x123", d.AWSAccountID)
 				assert.Equal(t, "", d.RegionAzure)
 				assert.Equal(t, "", d.RegionGCP)
 				assert.Equal(t, "", d.RegionAlibaba)
@@ -141,6 +162,9 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 			setMock: func(h *fakeHarvester) {
 				h.On("GetCloudType").Return(cloud.TypeAWS)
 				h.On("GetRegion").Return("us-east-1", nil)
+				h.On("GetZone").Return("us-east-1a", nil)
+				h.On("GetInstanceImageID").Return("ami-12345", nil)
+				h.On("GetAccountID").Return("x123", nil)
 			},
 		},
 		{
@@ -196,6 +220,7 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 				cloudHarvester: h,
 			}
 			p.setCloudRegion(data)
+			p.setCloudMetadata(data)
 			testCase.assertions(data)
 			h.AssertExpectations(t)
 		})

--- a/pkg/helpers/fingerprint/fingerprint_test.go
+++ b/pkg/helpers/fingerprint/fingerprint_test.go
@@ -56,6 +56,18 @@ func (a *MockCloudHarvester) GetRegion() (string, error) {
 	return "", nil
 }
 
+func (a *MockCloudHarvester) GetAccountID() (string, error) {
+	return "", nil
+}
+
+func (a *MockCloudHarvester) GetInstanceImageID() (string, error) {
+	return "", nil
+}
+
+func (a *MockCloudHarvester) GetZone() (string, error) {
+	return "", nil
+}
+
 func (a *MockCloudHarvester) GetHarvester() (cloud.Harvester, error) {
 	return nil, nil
 }

--- a/pkg/sysinfo/cloud/cloud.go
+++ b/pkg/sysinfo/cloud/cloud.go
@@ -41,6 +41,8 @@ var (
 	ErrDetectorNotInitialized = errors.New("cloud detector not initialized yet")
 	// ErrCouldNotDetect is the error returned when the Detector could not be initialized.
 	ErrCouldNotDetect = errors.New("detector is unable to detect the cloud type")
+	// ErrMethodNotImplemented is the error returned when a method is still not implemented by an implementation.
+	ErrMethodNotImplemented = errors.New("cloud harvester does not implement the method")
 )
 
 // Harvester is the interfaces that should be implemented by any cloud harvester.
@@ -55,6 +57,12 @@ type Harvester interface {
 	GetCloudSource() string
 	// GetRegion returns the cloud region
 	GetRegion() (string, error)
+	// GetAccountID returns the cloud account
+	GetAccountID() (string, error)
+	// GetZone returns the cloud instance zone
+	GetZone() (string, error)
+	// GetInstanceImageID returns the cloud instance image ID
+	GetInstanceImageID() (string, error)
 	// GetHarvester returns instance of the Harvester detected (or instance of themselves)
 	GetHarvester() (Harvester, error)
 }
@@ -161,6 +169,33 @@ func (d *Detector) GetCloudType() Type {
 		return TypeNoCloud
 	}
 	return cloudHarvester.GetCloudType()
+}
+
+// GetHostType will return the cloud instance type.
+func (d *Detector) GetAccountID() (string, error) {
+	cloudHarvester, err := d.GetHarvester()
+	if err != nil {
+		return "", err
+	}
+	return cloudHarvester.GetAccountID()
+}
+
+// GetRegion will return the region of cloud instance.
+func (d *Detector) GetInstanceImageID() (string, error) {
+	cloudHarvester, err := d.GetHarvester()
+	if err != nil {
+		return "", err
+	}
+	return cloudHarvester.GetInstanceImageID()
+}
+
+// GetCloudType will return the cloud type on which the instance is running.
+func (d *Detector) GetZone() (string, error) {
+	cloudHarvester, err := d.GetHarvester()
+	if err != nil {
+		return "", err
+	}
+	return cloudHarvester.GetZone()
 }
 
 // GetCloudSource Returns a string key which will be used as a HostSource (see host_aliases plugin).

--- a/pkg/sysinfo/cloud/cloud_alibaba.go
+++ b/pkg/sysinfo/cloud/cloud_alibaba.go
@@ -42,6 +42,9 @@ type AlibabaHarvester struct {
 	instanceID       string // Cache the Alibaba instance ID.
 	hostType         string // Cache the Alibaba instance Type.
 	region           string
+	zone             string // Cache the Alibaba instance Zone.
+	instanceImageID  string // Cache the Alibaba instance Image ID.
+	account          string // Cache the Alibaba account ID.
 }
 
 // AlibabaHarvester returns a new instance of AlibabaHarvester.
@@ -106,11 +109,53 @@ func (a *AlibabaHarvester) GetRegion() (string, error) {
 	return a.region, nil
 }
 
+// GetAccount will return the cloud account.
+func (a *AlibabaHarvester) GetAccountID() (string, error) {
+	if a.region == "" || a.timeout.HasExpired() {
+		AlibabaMetadata, err := GetAlibabaMetadata(a.disableKeepAlive)
+		if err != nil {
+			return "", err
+		}
+		a.account = AlibabaMetadata.AccountID
+	}
+
+	return a.account, nil
+}
+
+// GetAvailability will return the cloud availability zone.
+func (a *AlibabaHarvester) GetZone() (string, error) {
+	if a.region == "" || a.timeout.HasExpired() {
+		AlibabaMetadata, err := GetAlibabaMetadata(a.disableKeepAlive)
+		if err != nil {
+			return "", err
+		}
+		a.zone = AlibabaMetadata.Zone
+	}
+
+	return a.zone, nil
+}
+
+// GetImageID will return the cloud image ID.
+func (a *AlibabaHarvester) GetInstanceImageID() (string, error) {
+	if a.region == "" || a.timeout.HasExpired() {
+		AlibabaMetadata, err := GetAlibabaMetadata(a.disableKeepAlive)
+		if err != nil {
+			return "", err
+		}
+		a.instanceImageID = AlibabaMetadata.InstanceImageID
+	}
+
+	return a.instanceImageID, nil
+}
+
 // Captures the fields we care about from the Alibaba metadata API
 type AlibabaMetadata struct {
-	RegionID     string `json:"region-id"`
-	InstanceID   string `json:"instance-id"`
-	InstanceType string `json:"instance-type"`
+	RegionID        string `json:"region-id"`
+	InstanceID      string `json:"instance-id"`
+	InstanceType    string `json:"instance-type"`
+	InstanceImageID string `json:"image-id"`
+	AccountID       string `json:"owner-account-id"`
+	Zone            string `json:"zone-id"`
 }
 
 // GetAlibabaMetadata is used to request metadata from Alibaba API.

--- a/pkg/sysinfo/cloud/cloud_alibaba.go
+++ b/pkg/sysinfo/cloud/cloud_alibaba.go
@@ -111,7 +111,7 @@ func (a *AlibabaHarvester) GetRegion() (string, error) {
 
 // GetAccount will return the cloud account.
 func (a *AlibabaHarvester) GetAccountID() (string, error) {
-	if a.region == "" || a.timeout.HasExpired() {
+	if a.account == "" || a.timeout.HasExpired() {
 		AlibabaMetadata, err := GetAlibabaMetadata(a.disableKeepAlive)
 		if err != nil {
 			return "", err
@@ -124,7 +124,7 @@ func (a *AlibabaHarvester) GetAccountID() (string, error) {
 
 // GetAvailability will return the cloud availability zone.
 func (a *AlibabaHarvester) GetZone() (string, error) {
-	if a.region == "" || a.timeout.HasExpired() {
+	if a.zone == "" || a.timeout.HasExpired() {
 		AlibabaMetadata, err := GetAlibabaMetadata(a.disableKeepAlive)
 		if err != nil {
 			return "", err
@@ -137,7 +137,7 @@ func (a *AlibabaHarvester) GetZone() (string, error) {
 
 // GetImageID will return the cloud image ID.
 func (a *AlibabaHarvester) GetInstanceImageID() (string, error) {
-	if a.region == "" || a.timeout.HasExpired() {
+	if a.instanceImageID == "" || a.timeout.HasExpired() {
 		AlibabaMetadata, err := GetAlibabaMetadata(a.disableKeepAlive)
 		if err != nil {
 			return "", err

--- a/pkg/sysinfo/cloud/cloud_aws.go
+++ b/pkg/sysinfo/cloud/cloud_aws.go
@@ -50,9 +50,12 @@ type AWSHarvester struct {
 }
 
 type instanceIdentity struct {
-	Region       string `json:"region"`
-	InstanceType string `json:"instanceType"`
-	InstanceID   string `json:"instanceId"`
+	AccountID        string `json:"accountId"`
+	AvailabilityZone string `json:"availabilityZone"`
+	ImageID          string `json:"imageID"`
+	Region           string `json:"region"`
+	InstanceType     string `json:"instanceType"`
+	InstanceID       string `json:"instanceId"`
 }
 
 // NewAWSHarvester returns a new instance of AWSHarvester.
@@ -108,6 +111,33 @@ func (a *AWSHarvester) GetRegion() (string, error) {
 		return "", err
 	}
 	return icc.Region, nil
+}
+
+// GetAccount will return the cloud account.
+func (a *AWSHarvester) GetAccountID() (string, error) {
+	icc, err := a.loadInstanceData()
+	if err != nil {
+		return "", err
+	}
+	return icc.AccountID, nil
+}
+
+// GetAvailability will return the cloud availability zone.
+func (a *AWSHarvester) GetZone() (string, error) {
+	icc, err := a.loadInstanceData()
+	if err != nil {
+		return "", err
+	}
+	return icc.AvailabilityZone, nil
+}
+
+// GetImageID will return the cloud image ID.
+func (a *AWSHarvester) GetInstanceImageID() (string, error) {
+	icc, err := a.loadInstanceData()
+	if err != nil {
+		return "", err
+	}
+	return icc.ImageID, nil
 }
 
 // GetCloudType returns the type of the cloud.

--- a/pkg/sysinfo/cloud/cloud_aws_test.go
+++ b/pkg/sysinfo/cloud/cloud_aws_test.go
@@ -98,6 +98,45 @@ func TestAWSHarvester_GetInstanceID(t *testing.T) {
 	assert.Equal(t, "i-1234567890abcdef0", instanceID)
 }
 
+func TestAWSHarvester_GetAccountID(t *testing.T) {
+	t.Parallel()
+	ts := setupDefaultTestServer(t)
+	defer ts.Close()
+
+	h := NewAWSHarvester(true)
+	h.awsEC2MetadataHostname = ts.URL
+
+	instanceID, err := h.GetAccountID()
+	assert.NoError(t, err)
+	assert.Equal(t, "123456789012", instanceID)
+}
+
+func TestAWSHarvester_GetZone(t *testing.T) {
+	t.Parallel()
+	ts := setupDefaultTestServer(t)
+	defer ts.Close()
+
+	h := NewAWSHarvester(true)
+	h.awsEC2MetadataHostname = ts.URL
+
+	instanceID, err := h.GetZone()
+	assert.NoError(t, err)
+	assert.Equal(t, "us-west-2b", instanceID)
+}
+
+func TestAWSHarvester_GetInstanceImageID(t *testing.T) {
+	t.Parallel()
+	ts := setupDefaultTestServer(t)
+	defer ts.Close()
+
+	h := NewAWSHarvester(true)
+	h.awsEC2MetadataHostname = ts.URL
+
+	instanceID, err := h.GetInstanceImageID()
+	assert.NoError(t, err)
+	assert.Equal(t, "ami-5fb8c835", instanceID)
+}
+
 func TestAWSHarvester_cache(t *testing.T) {
 	t.Parallel()
 	var tokenCounter int32

--- a/pkg/sysinfo/cloud/cloud_azure.go
+++ b/pkg/sysinfo/cloud/cloud_azure.go
@@ -86,6 +86,21 @@ func (a *AzureHarvester) GetRegion() (string, error) {
 	return a.region, nil
 }
 
+// GetAccountID returns the cloud account
+func (a *AzureHarvester) GetAccountID() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetZone returns the cloud instance zone
+func (a *AzureHarvester) GetZone() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetInstanceImageID returns the cloud instance image ID
+func (a *AzureHarvester) GetInstanceImageID() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
 // Captures the fields we care about from the Azure metadata API
 type azureMetadata struct {
 	Compute struct {

--- a/pkg/sysinfo/cloud/cloud_gcp.go
+++ b/pkg/sysinfo/cloud/cloud_gcp.go
@@ -64,6 +64,21 @@ func (gcp *GCPHarvester) GetHostType() (string, error) {
 	return gcp.hostType, nil
 }
 
+// GetAccountID returns the cloud account
+func (gcp *GCPHarvester) GetAccountID() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetZone returns the cloud instance zone
+func (gcp *GCPHarvester) GetZone() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetInstanceImageID returns the cloud instance image ID
+func (gcp *GCPHarvester) GetInstanceImageID() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
 // GetCloudType returns the type of the cloud.
 func (gcp *GCPHarvester) GetCloudType() Type {
 	return TypeGCP

--- a/pkg/sysinfo/cloud/cloud_test.go
+++ b/pkg/sysinfo/cloud/cloud_test.go
@@ -282,6 +282,21 @@ func (m *MockHarvester) GetRegion() (string, error) {
 	return "myRegion", nil
 }
 
+// GetAccountID returns the cloud account where the instance is running.
+func (a *MockHarvester) GetAccountID() (string, error) {
+	return "", nil
+}
+
+// GetInstanceImageID returns the instance image ID.
+func (a *MockHarvester) GetInstanceImageID() (string, error) {
+	return "", nil
+}
+
+// GetZone returns the instance cloud zone.
+func (a *MockHarvester) GetZone() (string, error) {
+	return "", nil
+}
+
 // GetHarvester returns the MockHarvester
 func (m *MockHarvester) GetHarvester() (Harvester, error) {
 	return m, nil


### PR DESCRIPTION
The goal of this PR is to add `aws_account_id, aws_image_id and aws_availability_zone` in the host plugin. The cloud harvester provides and interface for any of the supported clouds, in order to retrieve the previous values new methods were added.

The PR implements the methods for AWS, Azure and Alibaba