### PR TITLE
Update fluentbit windows package version to 1.9.1

### DIFF
--- a/build/embed/fluent-bit.version
+++ b/build/embed/fluent-bit.version
@@ -6,4 +6,4 @@
 # OS, newrelic_plugin_version, fluent-bit 
 
 linux,1.9.2
-windows,1.9.2,1.8.6
+windows,1.9.2,1.9.1


### PR DESCRIPTION
Fluentbit window package for 1.9.1 is now available in https://github.com/newrelic/fluent-bit-package/releases/tag/1.9.1