### PR TITLE
fix: rename fluent-bit binary name for windows packaging

### DIFF
--- a/build/windows/scripts/embed_ohis.ps1
+++ b/build/windows/scripts/embed_ohis.ps1
@@ -81,7 +81,10 @@ Function EmbedFluentBit {
 
     [string]$nrfbUrl = "https://github.com/newrelic-experimental/fluent-bit-package/releases/download/$nrfbVersion/fb-windows-$arch.zip"
     DownloadAndExtractZip -dest:"$downloadPath\logging\nrfb" -url:"$nrfbUrl"
-    
+
+    # rename fluent-bit binary name to old name
+    Rename-Item -Path "$downloadPath\logging\nrfb\td-agent-bit.exe" -NewName "fluent-bit.exe"
+
     if (-Not $skipSigning) {
         SignExecutable -executable "$downloadPath\logging\nrfb\fluent-bit.exe"
     }


### PR DESCRIPTION
From td-agent-bit.exe to fluent-bit.exe