### PR TITLE
fix: run proper integration definition

### DIFF
--- a/pkg/integrations/execution/v4/manager.go
+++ b/pkg/integrations/execution/v4/manager.go
@@ -267,10 +267,10 @@ func (mgr *Manager) RunOnce(ctx context.Context) {
 		illog.WithField("file", path).Debug("Running integrations group once.")
 
 		wg.Add(1)
-		go func() {
-			group.runOnce(contextWithVerbose(ctx, mgr.managerConfig.Verbose))
+		go func(g *groupContext) {
+			g.runOnce(contextWithVerbose(ctx, mgr.managerConfig.Verbose))
 			wg.Done()
-		}()
+		}(group)
 	}
 	wg.Wait()
 }

--- a/pkg/integrations/execution/v4/runner/group.go
+++ b/pkg/integrations/execution/v4/runner/group.go
@@ -76,14 +76,14 @@ func (g *Group) Run(ctx context.Context) (hasStartedAnyOHI bool) {
 func (g *Group) RunOnce(ctx context.Context) {
 
 	wg := sync.WaitGroup{}
-	for _, integration := range g.integrations {
-		integration.Interval = 0
+	for _, integrationDef := range g.integrations {
+		integrationDef.Interval = 0
 		wg.Add(1)
-		go func() {
-			r := NewRunner(integration, g.emitter, g.dSources, g.handleErrorsProvide, g.cmdReqHandle, g.configHandle, g.terminateDefinitionQ, g.idLookup)
+		go func(definition integration.Definition) {
+			r := NewRunner(definition, g.emitter, g.dSources, g.handleErrorsProvide, g.cmdReqHandle, g.configHandle, g.terminateDefinitionQ, g.idLookup)
 			r.Run(ctx, nil, nil)
 			wg.Done()
-		}()
+		}(integrationDef)
 	}
 
 	wg.Wait()

--- a/pkg/integrations/execution/v4/runner/runner.go
+++ b/pkg/integrations/execution/v4/runner/runner.go
@@ -118,6 +118,8 @@ func (r *runner) Run(ctx context.Context, pidWCh, exitCodeCh chan<- int) {
 		} else {
 			if when.All(r.definition.WhenConditions...) {
 				r.execute(ctx, values, pidWCh, exitCodeCh)
+			} else {
+				r.log.Debug("Integration conditions where not met, skipping execution")
 			}
 		}
 


### PR DESCRIPTION
If we don't specify which integration to run in the go function,
the loop can create a race condition