### PR TITLE
[POC] Execute selfInstrumentation in the integrations when flag is defined

### DIFF
--- a/cmd/newrelic-infra/newrelic-infra.go
+++ b/cmd/newrelic-infra/newrelic-infra.go
@@ -8,11 +8,6 @@ import (
 	context2 "context"
 	"flag"
 	"fmt"
-	v3 "github.com/newrelic/infrastructure-agent/pkg/integrations/execution/v3"
-	v3config "github.com/newrelic/infrastructure-agent/pkg/integrations/execution/v3/config"
-	"github.com/newrelic/infrastructure-agent/pkg/integrations/execution/v4/logs"
-	dm2 "github.com/newrelic/infrastructure-agent/pkg/integrations/outputhandler/v4/dm"
-	"github.com/newrelic/infrastructure-agent/pkg/integrations/outputhandler/v4/emitter"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
@@ -24,6 +19,12 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	v3 "github.com/newrelic/infrastructure-agent/pkg/integrations/execution/v3"
+	v3config "github.com/newrelic/infrastructure-agent/pkg/integrations/execution/v3/config"
+	"github.com/newrelic/infrastructure-agent/pkg/integrations/execution/v4/logs"
+	dm2 "github.com/newrelic/infrastructure-agent/pkg/integrations/outputhandler/v4/dm"
+	"github.com/newrelic/infrastructure-agent/pkg/integrations/outputhandler/v4/emitter"
 
 	selfInstrumentation "github.com/newrelic/infrastructure-agent/internal/agent/instrumentation"
 	"github.com/newrelic/infrastructure-agent/pkg/config/migrate"
@@ -379,6 +380,7 @@ func initializeAgentAndRun(c *config.Config, logFwCfg config.LogForward) error {
 		tracker,
 		agt.Context.IDLookup(),
 		pluginRegistry,
+		c.License,
 	)
 
 	// Command channel handlers

--- a/internal/agent/instrumentation/agent_instrumentation_apm.go
+++ b/internal/agent/instrumentation/agent_instrumentation_apm.go
@@ -17,7 +17,7 @@ const transactionInContextKey = iota
 
 const (
 	appName                = "New Relic Infrastructure Agent"
-	apmInstrumentationName = "newrelic"
+	APMInstrumentationName = "newrelic"
 )
 
 type agentInstrumentationApm struct {
@@ -63,8 +63,16 @@ func (a *agentInstrumentationApm) addHostName(metric metric) metric {
 	return metric
 }
 
+func (a *agentInstrumentationApm) GetType() string {
+	return APMInstrumentationName
+}
+
 type TransactionApm struct {
 	nrTxn *newrelic.Transaction
+}
+
+func (t *TransactionApm) InsertDistributedTraceHeaders(hdrs http.Header) {
+	t.nrTxn.InsertDistributedTraceHeaders(hdrs)
 }
 
 func (t *TransactionApm) AddAttribute(key string, value interface{}) {

--- a/internal/agent/instrumentation/agent_instrumentation_factory.go
+++ b/internal/agent/instrumentation/agent_instrumentation_factory.go
@@ -1,13 +1,14 @@
 package instrumentation
 
 import (
+	"strings"
+
 	"github.com/newrelic/infrastructure-agent/pkg/config"
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/hostname"
-	"strings"
 )
 
 func InitSelfInstrumentation(c *config.Config, resolver hostname.Resolver) {
-	if strings.ToLower(c.SelfInstrumentation) == apmInstrumentationName {
+	if strings.ToLower(c.SelfInstrumentation) == APMInstrumentationName {
 		apmSelfInstrumentation, err := NewAgentInstrumentationApm(
 			c.License,
 			c.SelfInstrumentationApmHost,

--- a/pkg/integrations/execution/v4/config/config.go
+++ b/pkg/integrations/execution/v4/config/config.go
@@ -34,6 +34,8 @@ type ConfigEntry struct {
 	Config interface{} `yaml:"config,omitempty" json:"config"`
 	// TemplatePath specifies the path of an external configuration file. It can't coexist with Config
 	TemplatePath string `yaml:"config_template_path,omitempty" json:"config_template_path"`
+
+	License string
 }
 
 // EnableConditions condition the execution of an integration to the trueness of ALL the conditions

--- a/pkg/integrations/execution/v4/integration/integration.go
+++ b/pkg/integrations/execution/v4/integration/integration.go
@@ -5,12 +5,13 @@ package integration
 import (
 	"errors"
 	"fmt"
-	config2 "github.com/newrelic/infrastructure-agent/pkg/integrations/execution/v4/config"
 	"io/ioutil"
 	"time"
 
+	"github.com/newrelic/infrastructure-agent/internal/agent/instrumentation"
 	"github.com/newrelic/infrastructure-agent/pkg/config"
 	"github.com/newrelic/infrastructure-agent/pkg/databind/pkg/data"
+	config2 "github.com/newrelic/infrastructure-agent/pkg/integrations/execution/v4/config"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/execution/v4/executor"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/execution/v4/when"
 	"github.com/newrelic/infrastructure-agent/pkg/log"
@@ -212,6 +213,17 @@ func (d *Definition) fromName(te config2.ConfigEntry, lookup InstancesLookup) er
 	// folders as different arguments
 	te.Exec = append([]string{path}, te.CLIArgs...)
 	d.runnable, err = newExecutor(&d.ExecutorConfig, te.Exec)
+
+	if instrumentation.SelfInstrumentation.GetType() == instrumentation.APMInstrumentationName {
+		d.runnable.Cfg.Environment["SELF_INSTRUMENTATION"] = "newrelic"
+		// I'm not sure which is the best way to send the LICENSE KEY to the integration
+		// so it's got in this ugly way
+		d.runnable.Cfg.Environment["NRIA_LICENSE_KEY"] = te.License
+		//d.runnable.Cfg.Environment["SELF_INSTRUMENTATION_APM_HOST"] = ""
+		//d.runnable.Cfg.Environment["SELF_INSTRUMENTATION_TELEMETRY_ENDPOINT"] = ""
+
+	}
+
 	return err
 }
 

--- a/pkg/integrations/execution/v4/runner/group_load.go
+++ b/pkg/integrations/execution/v4/runner/group_load.go
@@ -16,7 +16,7 @@ type LoadFn func(dr integration.InstancesLookup, passthroughEnv []string, cfgPat
 // NewLoadFn returns a function that provides partial Group holding provided configuration and
 // features cache. Optionally agent and integration "features" can be provided to be able to load
 // disabled integrations.
-func NewLoadFn(cfg config2.YAML, agentAndCCFeatures *Features) LoadFn {
+func NewLoadFn(cfg config2.YAML, license string, agentAndCCFeatures *Features) LoadFn {
 	return func(il integration.InstancesLookup, passthroughEnv []string, cfgPath string, cmdReqHandle cmdrequest.HandleFn, configHandle configrequest.HandleFn, terminateDefinitionQ chan string) (g Group, c FeaturesCache, err error) {
 		dSources, err := cfg.Databind.DataSources()
 		if err != nil {
@@ -37,6 +37,9 @@ func NewLoadFn(cfg config2.YAML, agentAndCCFeatures *Features) LoadFn {
 			if err != nil {
 				return
 			}
+
+			cfgEntry.License = license
+
 			var i integration.Definition
 			i, err = integration.NewDefinition(cfgEntry, il, passthroughEnv, template)
 			if err != nil {


### PR DESCRIPTION
- If self instrumentation flag is set, create a distributed trace and pass the required parameters to the integration.
- This is a POC and how the license is passed or other decisions are subject to change.