### PR TITLE
feat: update fluent-bit version for windows

### DIFF
--- a/build/embed/fluent-bit.version
+++ b/build/embed/fluent-bit.version
@@ -1,9 +1,9 @@
 ####
 # newrelic_plugin_version - https://github.com/newrelic/newrelic-fluent-bit-output/releases
-# This file declares the different versions of the NR plugin and fluent-bit needed for Windows & Linux. 
-# For Linux is no longer need to specify the fluent-bit version due this dependency is handled at package manager level. 
+# This file declares the different versions of the NR plugin and fluent-bit needed for Windows & Linux.
+# For Linux is no longer need to specify the fluent-bit version due this dependency is handled at package manager level.
 #
-# OS, newrelic_plugin_version, fluent-bit 
+# OS, newrelic_plugin_version, fluent-bit
 
 linux,1.9.2
-windows,1.9.2,1.9.1
+windows,1.9.2,1.9.3

--- a/build/windows/scripts/embed_ohis.ps1
+++ b/build/windows/scripts/embed_ohis.ps1
@@ -58,7 +58,7 @@ Function EmbedPrometheus {
     # download
     [string]$file="nri-prometheus-$arch.${version}.zip"
     $url="https://github.com/newrelic/nri-prometheus/releases/download/v${version}/${file}"
- 
+
     DownloadAndExtractZip -dest:"$downloadPath\nri-prometheus" -url:"$url"
 
     Copy-Item -Path "$downloadPath\nri-prometheus\New Relic\newrelic-infra\newrelic-integrations\bin\nri-prometheus.exe" -Destination "$downloadPath\nri-prometheus\nri-prometheus.exe" -Recurse -Force
@@ -82,9 +82,6 @@ Function EmbedFluentBit {
     [string]$nrfbUrl = "https://github.com/newrelic-experimental/fluent-bit-package/releases/download/$nrfbVersion/fb-windows-$arch.zip"
     DownloadAndExtractZip -dest:"$downloadPath\logging\nrfb" -url:"$nrfbUrl"
 
-    # rename fluent-bit binary name to old name
-    Rename-Item -Path "$downloadPath\logging\nrfb\td-agent-bit.exe" -NewName "fluent-bit.exe"
-
     if (-Not $skipSigning) {
         SignExecutable -executable "$downloadPath\logging\nrfb\fluent-bit.exe"
     }
@@ -100,7 +97,7 @@ Function EmbedWinpkg {
 
     [string]$url = "https://download.newrelic.com/infrastructure_agent/$UrlPath"
     DownloadAndExtractZip -dest:"$downloadPath" -url:"$url"
-    
+
     if (-Not $skipSigning) {
         SignExecutable -executable "$downloadPath\winpkg\nr-winpkg.exe"
     }


### PR DESCRIPTION
Hi!

This PR update the fluent-bit version for windows from 1.9.1 to 1.9.3 that fixes some bugs, especially one with the lua filter we use to filter logs by their event ids.

Also removed a rename that is not necessary anymore (we're doing it on our pipeline) and the binary is fluent-bit.exe and not td-agent-bit.exe anymore.

<img width="358" alt="Screenshot 2022-05-12 at 10 40 48" src="https://user-images.githubusercontent.com/317362/168029498-ca6a19e5-0e02-400b-8ad4-682ae41bffc6.png">


Regards!