### PR TITLE
feat: bump nri-docker to v1.7.0

### DIFF
--- a/build/embed/integrations.version
+++ b/build/embed/integrations.version
@@ -1,5 +1,5 @@
 #ohi-repo-name,version
-nri-docker,1.6.0
+nri-docker,1.7.0
 nri-flex,1.4.4
 nri-winservices,v0.5.0-beta
 nri-prometheus,2.14.0


### PR DESCRIPTION
Bump `nri-docker` integration to v1.7.0

For further details, you can take a look at the [release notes](https://github.com/newrelic/nri-docker/releases/tag/v1.7.0).

## Considerations

There's a NR docs draft PR opened https://github.com/newrelic/docs-website/pull/7628 to update it with the proper infrastructure agent release version.
