### PR TITLE
add support for RHEL9 (#1171)

### DIFF
--- a/build/goreleaser/linux/rhel_9_amd64.yml
+++ b/build/goreleaser/linux/rhel_9_amd64.yml
@@ -1,0 +1,81 @@
+  # RHEL 9 amd64
+  
+  - id: rhel-9-infrastructure-agent
+    builds:
+      - linux-agent-amd64
+      - linux-ctl-amd64
+      - linux-service-amd64
+    package_name: newrelic-infra
+    file_name_template: "newrelic-infra-{{ .Env.TAG }}-1.el9.{{ .Arch }}"
+    vendor: 'New Relic, Inc.'
+    homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
+    maintainer: 'caos-team@newrelic.com'
+    description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
+    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    formats:
+      - rpm
+    bindir: /usr/bin
+    contents:
+      - src: 'assets/examples/logging/linux/file.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/file.yml.example'
+      - src: 'assets/examples/logging/linux/fluentbit.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/fluentbit.yml.example'
+      - src: 'assets/examples/logging/linux/syslog.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/syslog.yml.example'
+      - src: 'assets/examples/logging/linux/systemd.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/systemd.yml.example'
+      - src: 'assets/examples/logging/linux/tcp.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/tcp.yml.example'
+  
+      - src: 'build/package/systemd/newrelic-infra.service'
+        dst: '/etc/systemd/system/newrelic-infra.service'
+      - src: 'LICENSE'
+        dst: '/var/db/newrelic-infra/LICENSE.txt'
+      - src: 'target/nridocker/amd64/etc/newrelic-infra/integrations.d/docker-config.yml'
+        dst: '/etc/newrelic-infra/integrations.d/docker-config.yml'
+        type: config
+      - src: 'target/nridocker/amd64/var/db/newrelic-infra/newrelic-integrations/bin/nri-docker'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-docker'
+      - src: 'target/nriflex/amd64/nri-flex'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
+      - src: 'target/nriprometheus/amd64/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
+#      - src: 'target/fluent-bit-plugin/amd64/out_newrelic.so'
+#        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
+#      - src: 'assets/examples/logging/parsers.conf'
+#        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
+    empty_folders:
+      - /var/db/newrelic-infra/custom-integrations
+      - /var/db/newrelic-infra/integrations.d
+      - /var/log/newrelic-infra
+      - /var/run/newrelic-infra
+    epoch: 0
+    release: 1.el9
+    replacements:
+      amd64: x86_64
+  
+    # Scripts to execute during the installation of the package.
+    scripts:
+      preinstall: "build/package/before-install.sh"
+      preremove: "build/package/rpm/prerm-systemd.sh"
+  
+    # Packages to replace according to old packaging scripts.
+    replaces:
+      - opspro-agent
+      - opspro-agent-systemd
+    # Section.
+    section: default
+    # Priority.
+    priority: extra
+    rpm:
+      scripts:
+        posttrans: "build/package/rpm/postinst-systemd.sh"
+  
+      summary: "New Relic Infrastructure Agent"
+      group: default
+    # Required packages. rpm version 4.11.3 does not support weak dependencies
+# not supported yet
+#    dependencies:
+#      - td-agent-bit
+  
+  # end RHEL 9 amd64

--- a/build/goreleaser/linux/rhel_9_arm.yml
+++ b/build/goreleaser/linux/rhel_9_arm.yml
@@ -1,0 +1,77 @@
+  # RHEL 9 arm
+  
+  - id: rhel-9-infrastructure-agent-arm
+    builds:
+      - linux-agent-arm
+      - linux-ctl-arm
+      - linux-service-arm
+    package_name: newrelic-infra
+    file_name_template: "newrelic-infra-{{ .Env.TAG }}-1.el9.{{ .Arch }}"
+    vendor: 'New Relic, Inc.'
+    homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
+    maintainer: 'caos-team@newrelic.com'
+    description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
+    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    formats:
+      - rpm
+    bindir: /usr/bin
+    contents:
+      #      - src: 'assets/examples/logging/linux/file.yml.example'
+      #        dst: '/etc/newrelic-infra/logging.d/file.yml.example'
+      #      - src: 'assets/examples/logging/linux/fluentbit.yml.example'
+      #        dst: '/etc/newrelic-infra/logging.d/fluentbit.yml.example'
+      #      - src: 'assets/examples/logging/linux/syslog.yml.example'
+      #        dst: '/etc/newrelic-infra/logging.d/syslog.yml.example'
+      #      - src: 'assets/examples/logging/linux/systemd.yml.example'
+      #        dst: '/etc/newrelic-infra/logging.d/systemd.yml.example'
+      #      - src: 'assets/examples/logging/linux/tcp.yml.example'
+      #        dst: '/etc/newrelic-infra/logging.d/tcp.yml.example'
+  
+      - src: 'build/package/systemd/newrelic-infra.service'
+        dst: '/etc/systemd/system/newrelic-infra.service'
+      - src: 'LICENSE'
+        dst: '/var/db/newrelic-infra/LICENSE.txt'
+      - src: 'target/nridocker/{{ .Arch }}/etc/newrelic-infra/integrations.d/docker-config.yml'
+        dst: '/etc/newrelic-infra/integrations.d/docker-config.yml'
+        type: config
+      - src: 'target/nridocker/{{ .Arch }}/var/db/newrelic-infra/newrelic-integrations/bin/nri-docker'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-docker'
+      - src: 'target/nriflex/{{ .Arch }}/nri-flex'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
+      - src: 'target/nriprometheus/{{ .Arch }}/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
+    #      - src: 'target/fluent-bit-plugin/{{ .Arch }}/out_newrelic.so'
+    #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
+    #      - src: 'assets/examples/logging/parsers.conf'
+    #        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
+    empty_folders:
+      - /var/db/newrelic-infra/custom-integrations
+      - /var/db/newrelic-infra/integrations.d
+      - /var/log/newrelic-infra
+      - /var/run/newrelic-infra
+    epoch: 0
+    release: 1.el9
+  
+    # Scripts to execute during the installation of the package.
+    scripts:
+      preinstall: "build/package/before-install.sh"
+      preremove: "build/package/rpm/prerm-systemd.sh"
+    # Packages to replace according to old packaging scripts.
+    replaces:
+      - opspro-agent
+      - opspro-agent-systemd
+    # Section.
+    section: default
+    # Priority.
+    priority: extra
+    rpm:
+      scripts:
+        posttrans: "build/package/rpm/postinst-systemd.sh"
+  
+      summary: "New Relic Infrastructure Agent"
+      group: default
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+#    recommends:
+#      - td-agent-bit
+  
+  # end RHEL 9 arm

--- a/build/goreleaser/linux/rhel_9_arm64.yml
+++ b/build/goreleaser/linux/rhel_9_arm64.yml
@@ -1,0 +1,78 @@
+  # RHEL 9 arm64
+  
+  - id: rhel-9-infrastructure-agent-arm64
+    builds:
+      - linux-agent-arm64
+      - linux-ctl-arm64
+      - linux-service-arm64
+    package_name: newrelic-infra
+    file_name_template: "newrelic-infra-{{ .Env.TAG }}-1.el9.{{ .Arch }}"
+    vendor: 'New Relic, Inc.'
+    homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
+    maintainer: 'caos-team@newrelic.com'
+    description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
+    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    formats:
+      - rpm
+    bindir: /usr/bin
+    contents:
+      - src: 'assets/examples/logging/linux/file.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/file.yml.example'
+      - src: 'assets/examples/logging/linux/fluentbit.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/fluentbit.yml.example'
+      - src: 'assets/examples/logging/linux/syslog.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/syslog.yml.example'
+      - src: 'assets/examples/logging/linux/systemd.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/systemd.yml.example'
+      - src: 'assets/examples/logging/linux/tcp.yml.example'
+        dst: '/etc/newrelic-infra/logging.d/tcp.yml.example'
+  
+      - src: 'build/package/systemd/newrelic-infra.service'
+        dst: '/etc/systemd/system/newrelic-infra.service'
+      - src: 'LICENSE'
+        dst: '/var/db/newrelic-infra/LICENSE.txt'
+      - src: 'target/nridocker/{{ .Arch }}/etc/newrelic-infra/integrations.d/docker-config.yml'
+        dst: '/etc/newrelic-infra/integrations.d/docker-config.yml'
+        type: config
+      - src: 'target/nridocker/{{ .Arch }}/var/db/newrelic-infra/newrelic-integrations/bin/nri-docker'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-docker'
+      - src: 'target/nriflex/{{ .Arch }}/nri-flex'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-flex'
+      - src: 'target/nriprometheus/{{ .Arch }}/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
+        dst: '/var/db/newrelic-infra/newrelic-integrations/bin/nri-prometheus'
+#      - src: 'target/fluent-bit-plugin/{{ .Arch }}/out_newrelic.so'
+#        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so'
+#      - src: 'assets/examples/logging/parsers.conf'
+#        dst: '/var/db/newrelic-infra/newrelic-integrations/logging/parsers.conf'
+    empty_folders:
+      - /var/db/newrelic-infra/custom-integrations
+      - /var/db/newrelic-infra/integrations.d
+      - /var/log/newrelic-infra
+      - /var/run/newrelic-infra
+    epoch: 0
+    release: 1.el9
+  
+    # Scripts to execute during the installation of the package.
+    scripts:
+      preinstall: "build/package/before-install.sh"
+      preremove: "build/package/rpm/prerm-systemd.sh"
+    # Packages to replace according to old packaging scripts.
+    replaces:
+      - opspro-agent
+      - opspro-agent-systemd
+    # Section.
+    section: default
+    # Priority.
+    priority: extra
+    rpm:
+      scripts:
+        posttrans: "build/package/rpm/postinst-systemd.sh"
+  
+      summary: "New Relic Infrastructure Agent"
+      group: default
+    # Recommended packages. If they fail to install installation of the agent will not be interrupted.
+# not supported yet
+#    dependencies:
+#      - td-agent-bit
+  
+  # end RHEL 9 arm64

--- a/build/release.mk
+++ b/build/release.mk
@@ -177,6 +177,7 @@ generate-goreleaser-amd64:
   		$(CURDIR)/build/goreleaser/linux/centos_6_amd64.yml\
   		$(CURDIR)/build/goreleaser/linux/centos_7_amd64.yml\
   		$(CURDIR)/build/goreleaser/linux/centos_8_amd64.yml\
+  		$(CURDIR)/build/goreleaser/linux/rhel_9_amd64.yml\
   		$(CURDIR)/build/goreleaser/linux/debian_systemd_amd64.yml\
   		$(CURDIR)/build/goreleaser/linux/debian_upstart_amd64.yml\
   		$(CURDIR)/build/goreleaser/linux/sles_114_amd64.yml\
@@ -201,6 +202,7 @@ generate-goreleaser-amd64:
 		$(CURDIR)/build/goreleaser/linux/al2022_arm.yml\
   		$(CURDIR)/build/goreleaser/linux/centos_7_arm.yml\
   		$(CURDIR)/build/goreleaser/linux/centos_8_arm.yml\
+  		$(CURDIR)/build/goreleaser/linux/rhel_9_arm.yml\
   		$(CURDIR)/build/goreleaser/linux/debian_systemd_arm.yml\
   		$(CURDIR)/build/goreleaser/linux/sles_122_arm.yml\
   		$(CURDIR)/build/goreleaser/linux/sles_123_arm.yml\
@@ -222,6 +224,7 @@ generate-goreleaser-arm64:
   		$(CURDIR)/build/goreleaser/linux/al2_arm64.yml\
   		$(CURDIR)/build/goreleaser/linux/centos_7_arm64.yml\
   		$(CURDIR)/build/goreleaser/linux/centos_8_arm64.yml\
+  		$(CURDIR)/build/goreleaser/linux/rhel_9_arm64.yml\
   		$(CURDIR)/build/goreleaser/linux/debian_systemd_arm64.yml\
   		$(CURDIR)/build/goreleaser/linux/sles_122_arm64.yml\
   		$(CURDIR)/build/goreleaser/linux/sles_123_arm64.yml\
@@ -266,6 +269,9 @@ generate-goreleaser-multiarch:
   		$(CURDIR)/build/goreleaser/linux/centos_8_amd64.yml\
   		$(CURDIR)/build/goreleaser/linux/centos_8_arm.yml\
   		$(CURDIR)/build/goreleaser/linux/centos_8_arm64.yml\
+  		$(CURDIR)/build/goreleaser/linux/rhel_9_amd64.yml\
+  		$(CURDIR)/build/goreleaser/linux/rhel_9_arm.yml\
+  		$(CURDIR)/build/goreleaser/linux/rhel_9_arm64.yml\
   		$(CURDIR)/build/goreleaser/linux/debian_systemd_amd64.yml\
   		$(CURDIR)/build/goreleaser/linux/debian_systemd_arm.yml\
   		$(CURDIR)/build/goreleaser/linux/debian_systemd_arm64.yml\

--- a/build/upload-schema-linux-rpm.yml
+++ b/build/upload-schema-linux-rpm.yml
@@ -9,6 +9,7 @@
         - 6
         - 7
         - 8
+        - 9
 
 - src: "newrelic-infra-{version}-1.el{os_version}.{arch}.rpm"
   arch:
@@ -20,6 +21,7 @@
       os_version:
         - 7
         - 8
+        - 9
 
 - src: "newrelic-infra-{version}-1.sles{os_version}.{arch}.rpm"
   arch:

--- a/test/automated/ansible/group_vars/localhost/main.yml
+++ b/test/automated/ansible/group_vars/localhost/main.yml
@@ -2,6 +2,7 @@
 
 #Ubuntu AMI: https://cloud-images.ubuntu.com/locator/ec2/
 #CentOS AMI: https://www.centos.org/download/aws-images/
+#RHEL AMI: https://access.redhat.com/solutions/15356
 #SLES:
 
 #https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/connection-prereqs.html
@@ -218,12 +219,26 @@ instances:
     platform: "linux"
     python_interpreter: "/usr/bin/python3"
     launch_template: "LaunchTemplateId=lt-0b00afb3f5110a0e6,Version=3"
+  - ami: "ami-078cbc4c2d057c244"
+    type: "t2.small"
+    name: "amd64:redhat-9.0"
+    username: "ec2-user"
+    platform: "linux"
+    python_interpreter: "/usr/bin/python"
+    launch_template: "LaunchTemplateId=lt-0b00afb3f5110a0e6,Version=3"
   ############################
   # redhat arm64
   ############################
   - ami: "ami-0302c1ecc74930ba5"
     type: "t4g.small"
     name: "arm64:redhat-7.6"
+    username: "ec2-user"
+    platform: "linux"
+    python_interpreter: "/usr/bin/python"
+    launch_template: "LaunchTemplateId=lt-0b00afb3f5110a0e6,Version=3"
+  - ami: "ami-01089181b0aa3be51"
+    type: "t4g.small"
+    name: "arm64:redhat-9.0"
     username: "ec2-user"
     platform: "linux"
     python_interpreter: "/usr/bin/python"

--- a/test/automated/ansible/roles/logrotate/templates/syslog-RH9.j2
+++ b/test/automated/ansible/roles/logrotate/templates/syslog-RH9.j2
@@ -1,0 +1,16 @@
+#created with ansible
+/var/log/cron
+/var/log/maillog
+/var/log/messages
+/var/log/secure
+/var/log/spooler
+{
+    missingok
+    compress
+    dateext
+    daily
+    sharedscripts
+    postrotate
+        /usr/bin/systemctl kill -s HUP rsyslog.service >/dev/null 2>&1 || true
+    endscript
+}

--- a/test/fixture/inventory/expect.go
+++ b/test/fixture/inventory/expect.go
@@ -64,11 +64,7 @@ var (
 					"id":           ".kernel.panic",
 					"sysctl_value": AnyValue,
 				},
-				".kernel.printk": AnyValue,
-				".vm.block_dump": map[string]interface{}{
-					"id":           ".vm.block_dump",
-					"sysctl_value": AnyValue,
-				},
+				".kernel.printk":             AnyValue,
 				".vm.dirty_background_ratio": AnyValue,
 			},
 		},

--- a/test/packaging/ansible/roles/assert-privileged-caps/tasks/check-Linux.yaml
+++ b/test/packaging/ansible/roles/assert-privileged-caps/tasks/check-Linux.yaml
@@ -9,16 +9,9 @@
   debug:
     msg: "{{ getcap.stdout }}"
 
-  # based on libcap version getp output is different (https://git.kernel.org/pub/scm/libs/libcap/libcap.git/commit/?id=177cd418031b1acfcf73fe3b1af9f3279828681c)
-  # for now just affecting to debian 11.
 - name: assert caps are the same as expected
   assert:
-    that: "'{{ getcap.stdout }}' == '/usr/bin/newrelic-infra = cap_dac_read_search,cap_sys_ptrace+ep'"
-  when: ansible_os_family != "Debian" and ansible_distribution_major_version != 11
-
-- name: assert caps are the same as expected
-  assert:
-    that: "'{{ getcap.stdout }}' == '/usr/bin/newrelic-infra cap_dac_read_search,cap_sys_ptrace=ep'"
-  when: ansible_os_family == "Debian" and ansible_distribution_major_version == 11
+    that:
+      - getcap.stdout is search('cap_dac_read_search,cap_sys_ptrace.ep')
 
 ...


### PR DESCRIPTION
* add RHEL9

* fix: .vm.block_dump not available in all kernels

Packaging tests expect the file /proc/sys/vm/block_dump but this file
will only be available if block I/O debugging is enabled in the kernel.

* fix: binary capabilities assertion

* feat: add rhel amis

Co-authored-by: Roger Coll <rogercoll@protonmail.com>