### PR TITLE
Added checksums for tar.gz, zip and msi packages

### DIFF
--- a/.github/actions/generate-checksums/action.yml
+++ b/.github/actions/generate-checksums/action.yml
@@ -1,0 +1,43 @@
+name: 'Generate Checksums'
+description: 'Generate checksums for artifacts'
+inputs:
+  checksums_file_name:
+    description: 'file name of the resulting file containing all the generated checksums'
+  checksums_dir:
+    description: "directory where the files will be stored in the workflow"
+    default: "checksums"
+  files_regex:
+    description: 'regex for matching files that we want to generate checksums for'
+  files_path:
+    description: 'directory containing the files that we want to generate checksums for'
+  merge:
+    description: 'generate new checksums or merge existing ones'
+    type: "boolean"
+    default: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Generate checksums file
+      run: ${GITHUB_ACTION_PATH}/generate_checksums.sh -p '${{ inputs.files_path }}' -o '${{ inputs.checksums_file_name }}' -r '${{ inputs.files_regex }}'
+      shell: bash
+      if: ${{ inputs.merge == 'false' }}
+
+    - name: Upload checksums file to workflow artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.checksums_dir }}
+        path: ${{ inputs.checksums_file_name }}
+      if: ${{ inputs.merge == 'false' }}
+
+    - name: Download checksums file from workflow artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ inputs.checksums_dir }}
+        path: ${{ inputs.checksums_dir }}
+      if: ${{ inputs.merge == 'true' }}
+
+    - name: Merge checksum files
+      shell: bash
+      run: ${GITHUB_ACTION_PATH}/merge_files.sh -p ${{ inputs.checksums_dir }} -o ${{ inputs.checksums_file_name }}
+      if: ${{ inputs.merge == 'true' }}

--- a/.github/actions/generate-checksums/generate_checksums.sh
+++ b/.github/actions/generate-checksums/generate_checksums.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+print_usage() {
+  printf -- "Usage: %s\n" "$(basename ${0})"
+  printf -- "-o: Output file for generated checksums\n"
+  printf -- "-p: Path to look for the files to generate checksums for\n"
+  printf -- "-r: Regex to find files to generate checksum for.  e.g. -f '.*tar.gz\|.*msi'\n"
+}
+
+OUTPUT_FILE='checksums.txt'
+SEARCH_PATH='./'
+FIND_REGEX='.*'
+
+while getopts 'o:p:r:' flag
+do
+    case "${flag}" in
+        h)
+          print_usage
+          exit 0
+        ;;
+        o)
+          OUTPUT_FILE="${OPTARG}"
+          continue
+        ;;
+        r)
+          FIND_REGEX="${OPTARG}"
+          continue
+        ;;
+        p)
+         SEARCH_PATH="${OPTARG}"
+         continue
+        ;;
+        *)
+          print_usage
+          exit 1
+        ;;
+    esac
+done
+
+echo -n > "${OUTPUT_FILE}"
+for filename in $(eval find "${SEARCH_PATH}" -maxdepth 1 -regex "'${FIND_REGEX}'");do
+   if [ "${filename}" == "${OUTPUT_FILE}" ]; then
+     continue
+   fi
+   echo "Processing file: ${filename}"
+   sha256sum "${filename}" | awk -F ' ' '{gsub(".*/", "", $2); print $1 "  " $2}' >> "${OUTPUT_FILE}"
+done

--- a/.github/actions/generate-checksums/merge_files.sh
+++ b/.github/actions/generate-checksums/merge_files.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+print_usage() {
+  printf -- "Usage: %s\n" "$(basename ${0})"
+  printf -- "-o: Output file\n"
+  printf -- "-p: Path to look for the files to be merged\n"
+  printf -- "-r: Regex to find files to be merged\n"
+}
+
+OUTPUT_FILE='file.txt'
+SEARCH_PATH='./'
+FIND_REGEX='.*txt'
+
+while getopts 'o:p:r:' flag
+do
+    case "${flag}" in
+        h)
+          print_usage
+          exit 0
+        ;;
+        o)
+          OUTPUT_FILE="${OPTARG}"
+          continue
+        ;;
+        r)
+          FIND_REGEX="${OPTARG}"
+          continue
+        ;;
+        p)
+         SEARCH_PATH="${OPTARG}"
+         continue
+        ;;
+        *)
+          print_usage
+          exit 1
+        ;;
+    esac
+done
+
+echo -n > "${OUTPUT_FILE}"
+for filename in $(eval find "${SEARCH_PATH}" -type f -maxdepth 1 -regex "'${FIND_REGEX}'");do
+   echo "Merging file: ${filename}"
+   cat "${filename}" >> "${OUTPUT_FILE}"
+done

--- a/.github/workflows/component_checksums_upload.yml
+++ b/.github/workflows/component_checksums_upload.yml
@@ -1,0 +1,37 @@
+name: ~ Merge and upload checksums into GH Release assets
+
+on:
+  workflow_call:
+    secrets:
+      GH_TOKEN:
+        required: true
+    inputs:
+      CHECKSUMS_FILE_NAME:
+        required: true
+        type: string
+      TAG:
+        required: true
+        type: string
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+  TAG:  ${{ inputs.TAG }}
+
+jobs:
+  merge-checksums:
+    name: Merge and upload checksums into GH Release assets
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Merge checksums files
+        uses: ./.github/actions/generate-checksums
+        with:
+          merge: true
+          checksums_dir: 'checksums'
+          checksums_file_name: ${{ inputs.CHECKSUMS_FILE_NAME }}
+
+      - name: Upload checksum to GH
+        shell: bash
+        run: build/upload_artifacts_gh.sh -p '.' -n '${{ inputs.CHECKSUMS_FILE_NAME }}'

--- a/.github/workflows/component_linux_packaging.yml
+++ b/.github/workflows/component_linux_packaging.yml
@@ -49,3 +49,10 @@ jobs:
 
       - name: Releasing linux packages
         run: make ci/prerelease/linux-${{ env.ARCH }}
+
+      - name: Generate checksums file
+        uses: ./.github/actions/generate-checksums
+        with:
+          checksums_file_name: "checksums_linux_${{ env.ARCH }}.txt"
+          files_regex: '.*tar\.gz'
+          files_path: 'dist'

--- a/.github/workflows/component_windows_packaging.yml
+++ b/.github/workflows/component_windows_packaging.yml
@@ -78,3 +78,19 @@ jobs:
       - name: Upload MSI to GH
         shell: bash
         run: build/upload_artifacts_gh.sh
+
+      - name: Generate checksums file
+        uses: ./src/github.com/newrelic/infrastructure-agent/.github/actions/generate-checksums
+        with:
+          checksums_file_name: "checksums_windows_${{ matrix.goarch }}.txt"
+          files_regex: '.*zip\|.*msi'
+          files_path: './src/github.com/newrelic/infrastructure-agent/dist'
+
+  merge-checksums:
+    needs: [ packaging ]
+    uses: newrelic/infrastructure-agent/.github/workflows/component_checksums_upload.yml@master
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      TAG: ${{ github.event.release.tag_name }}
+      CHECKSUMS_FILE_NAME: 'checksums_windows.txt'

--- a/.github/workflows/prerelease_linux.yml
+++ b/.github/workflows/prerelease_linux.yml
@@ -78,6 +78,15 @@ jobs:
       TAG:  ${{ github.event.release.tag_name }}
       ARCH: 'legacy'
 
+  merge-checksums:
+    needs: [ packaging-amd64, packaging-arm, packaging-arm64, packaging-legacy ]
+    uses: newrelic/infrastructure-agent/.github/workflows/component_checksums_upload.yml@master
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      TAG: ${{ github.event.release.tag_name }}
+      CHECKSUMS_FILE_NAME: 'checksums_linux.txt'
+
   packaging-docker:
     needs: [unit-test, harvest-test, proxy-tests]
     uses: newrelic/infrastructure-agent/.github/workflows/component_docker_packaging.yml@master

--- a/.github/workflows/prerelease_linux_on_demand.yml
+++ b/.github/workflows/prerelease_linux_on_demand.yml
@@ -52,6 +52,13 @@ jobs:
       - name: Releasing all linux packages
         run: make ci/prerelease/linux
 
+      - name: Generate checksums file
+        uses: ./.github/actions/generate-checksums
+        with:
+          checksums_file_name: "checksums_linux.txt"
+          files_regex: '.*tar\.gz'
+          files_path: 'dist'
+
       - name: Publish deb to S3 action
         uses: newrelic/infrastructure-publish-action@v1.2.3
         with:
@@ -124,3 +131,13 @@ jobs:
           disable_lock: ${{ env.DISABLE_LOCK }}
           dest_prefix: ${{ env.DEST_PREFIX }}
           local_packages_path:  "/srv/dist/"
+
+  merge-checksums:
+    needs: [ packaging ]
+    uses: newrelic/infrastructure-agent/.github/workflows/component_checksums_upload.yml@master
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      TAG: ${{ github.event.release.tag_name }}
+      CHECKSUMS_FILE_NAME: 'checksums_linux.txt'
+

--- a/.github/workflows/prerelease_windows.yml
+++ b/.github/workflows/prerelease_windows.yml
@@ -76,6 +76,22 @@ jobs:
         shell: bash
         run: build/upload_artifacts_gh.sh
 
+      - name: Generate checksums file
+        uses: ./src/github.com/newrelic/infrastructure-agent/.github/actions/generate-checksums
+        with:
+          checksums_file_name: "checksums_windows_${{ matrix.goarch }}.txt"
+          files_regex: '.*zip\|.*msi'
+          files_path: './src/github.com/newrelic/infrastructure-agent/dist'
+
+  merge-checksums:
+    needs: [ packaging ]
+    uses: newrelic/infrastructure-agent/.github/workflows/component_checksums_upload.yml@master
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      TAG: ${{ github.event.release.tag_name }}
+      CHECKSUMS_FILE_NAME: 'checksums_windows.txt'
+
   publishing-to-s3:
     name: Publish windows artifacts into s3 staging bucket
     uses: newrelic/infrastructure-agent/.github/workflows/component_windows_publish.yml@master

--- a/.github/workflows/prerelease_windows_on_demand.yml
+++ b/.github/workflows/prerelease_windows_on_demand.yml
@@ -75,6 +75,22 @@ jobs:
           name: windows-assets
           path: dist
 
+      - name: Generate checksums file
+        uses: ./src/github.com/newrelic/infrastructure-agent/.github/actions/generate-checksums
+        with:
+          checksums_file_name: "checksums_windows_${{ matrix.goarch }}.txt"
+          files_regex: '.*zip\|.*msi'
+          files_path: './src/github.com/newrelic/infrastructure-agent/dist'
+
+  merge-checksums:
+    needs: [ packaging ]
+    uses: newrelic/infrastructure-agent/.github/workflows/component_checksums_upload.yml@master
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      TAG: ${{ github.event.release.tag_name }}
+      CHECKSUMS_FILE_NAME: 'checksums_windows.txt'
+
   publish:
     name: Build and upload artifacts into GH Release assets
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This PR adds in the pre-release pipeline action to generate checksums for tar.gz, zip and msi packages.

- each job generates it's own checksums.txt file and store it into workflow artifacts
- at the end, a final step will be run to merge the checksum files and push the result to release assests
- each workflow (Windows/Linux) will generate it's own checksum file, the result will be checksums_linux.txt and checksums_windows.txt