### PR TITLE
Cciutea/log rotation config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1144,6 +1144,8 @@ type LogConfig struct {
 
 	IncludeFilters LogFilters `yaml:"include_filters" envconfig:"include_filters"`
 	ExcludeFilters LogFilters `yaml:"exclude_filters" envconfig:"exclude_filters"`
+
+	Rotate LogRotateConfig `yaml:"rotate" envconfig:"rotate"`
 }
 
 func (lc *LogConfig) AttachDefaultFilters() {
@@ -1172,6 +1174,19 @@ func (lc *LogConfig) HasIncludeFilter(key, value string) bool {
 		}
 	}
 	return false
+}
+
+// LogRotateConfig map all log rotator configuration options
+type LogRotateConfig struct {
+	MaxSizeMb          int    `yaml:"max_size_mb" envconfig:"max_size_mb"`
+	MaxFiles           int    `yaml:"max_files" envconfig:"max_files"`
+	CompressionEnabled bool   `yaml:"compression_enabled" envconfig:"compression_enabled"`
+	FilePattern        string `yaml:"file_pattern" envconfig:"file_pattern"`
+}
+
+// IsEnabled checks if log rotation is enabled.
+func (l *LogRotateConfig) IsEnabled() bool {
+	return l.MaxSizeMb > 0
 }
 
 func coalesce(values ...string) string {

--- a/pkg/log/exported.go
+++ b/pkg/log/exported.go
@@ -37,10 +37,14 @@ type log struct {
 }
 
 // usual singleton access used on the codebase
-var w = wrap{
-	l:       logrus.StandardLogger(),
-	mu:      &sync.Mutex{},
-	measure: func(instrumentation.MetricType, instrumentation.MetricName, int64) {},
+var w = newWrappedLogger()
+
+func newWrappedLogger() wrap {
+	return wrap{
+		l:       logrus.StandardLogger(),
+		mu:      &sync.Mutex{},
+		measure: func(instrumentation.MetricType, instrumentation.MetricName, int64) {},
+	}
 }
 
 func (w *wrap) smartVerboseEnabled() bool {

--- a/pkg/log/stdout_tee.go
+++ b/pkg/log/stdout_tee.go
@@ -1,0 +1,29 @@
+package log
+
+import (
+	"io"
+	"os"
+)
+
+// stdoutTeeLogger is a simple logging wrapper which copies all output to both stdout and a log file to make it easier to find.
+// This is nice for Windows, since there's nothing built-in to capture all stdout from a program into some
+// kind of syslog, and we don't want to flood the system event log with uninteresting messages.
+type stdoutTeeLogger struct {
+	writer io.Writer
+	stdout bool
+}
+
+// NewStdoutTeeLogger return an io.Writer that can redirect to stdout if needed.
+func NewStdoutTeeLogger(writer io.Writer, stdout bool) io.Writer {
+	return &stdoutTeeLogger{
+		writer: writer,
+		stdout: stdout,
+	}
+}
+
+func (s *stdoutTeeLogger) Write(b []byte) (n int, err error) {
+	if s.stdout {
+		_, _ = os.Stdout.Write(b)
+	}
+	return s.writer.Write(b)
+}


### PR DESCRIPTION
This PR adds configuration structure for built-in log rotation:

e.g.: 
```
log:
  level: info
  file: /var/log/newrelic-infra/newrelic-infra.log
  rotate:
      #Required to enable the feature
      max_size_mb: 1000

      #Optional
      max_files: 5

      #Optional
      compression_enabled: true

      #Optional
      file_pattern: rotated.YYYY-MM-DD_hh-mm-ss.log
```