### PR TITLE
chore(nri-prometheus): update version

### DIFF
--- a/build/embed/integrations.version
+++ b/build/embed/integrations.version
@@ -2,4 +2,4 @@
 nri-docker,v1.7.2
 nri-flex,v1.5.0
 nri-winservices,v0.5.0-beta
-nri-prometheus,v2.16.3
+nri-prometheus,v2.16.4


### PR DESCRIPTION
Update the bundled nri-prometheus to leverage https://github.com/newrelic/nri-prometheus/releases/tag/v2.16.4