### PR TITLE
Bump nri-winservices to v0.6.0-beta

### DIFF
--- a/build/embed/integrations.version
+++ b/build/embed/integrations.version
@@ -1,5 +1,5 @@
 #ohi-repo-name,version
 nri-docker,v1.7.3
 nri-flex,v1.5.1
-nri-winservices,v0.5.0-beta
+nri-winservices,v0.6.0-beta
 nri-prometheus,v2.16.4


### PR DESCRIPTION
- Bump nri-winservices to last version v0.6.0-beta