### PR TITLE
test: fix ec2 spinner interactive mode

### DIFF
--- a/test/automated/ansible/roles/provision-ec2/tasks/main.yml
+++ b/test/automated/ansible/roles/provision-ec2/tasks/main.yml
@@ -9,7 +9,7 @@
   shell: "aws ec2 run-instances --launch-template {{ item.launch_template }} --image-id {{ item.ami }} --instance-type {{ item.type }}  --subnet-id {{ subnet }} --tag-specifications 'ResourceType=instance,Tags=[{Key=Name,Value={{ provision_host_prefix }}:{{ item.name }}},{Key=owning_team,Value=CAOS}]'"
   with_items: "{{ instances | list }}"
   when:
-    - item.platform == "{{ platform }}"
+    - item.platform == "{{ platform }}" or "{{ platform }}" == "all"
   register: run_instances
   tags:
     - print_action

--- a/tools/spin-ec2/main.go
+++ b/tools/spin-ec2/main.go
@@ -124,6 +124,7 @@ func interactiveMode() {
 			"-f", strconv.Itoa(defaultAnsibleForks),
 			"--extra-vars", "@"+path.Join(curPath, inventoryForCreation),
 			"-e", "instance_prefix="+provisionHostPrefix+":",
+			"-e", "platform=all",
 			path.Join(curPath, "test/automated/ansible/provision.yml"))
 
 		execNameArgs("ansible-playbook",


### PR DESCRIPTION
Interactive `ec-spinner` was broken after make `platform` parameter mandatory. This PR fixes it.