### PR TITLE
Fix/discovery template replacements

### DIFF
--- a/internal/integrations/v4/integration/definition_test.go
+++ b/internal/integrations/v4/integration/definition_test.go
@@ -45,7 +45,6 @@ func TestRun(t *testing.T) {
 	assert.Equal(t, "error line", testhelp.ChannelRead(outs[0].Receive.Stderr))
 }
 
-// TestRun_NoDiscovery non-existent discovery entry will be used as it is
 func TestRun_NoDiscovery(t *testing.T) {
 	defer leaktest.Check(t)()
 
@@ -54,7 +53,7 @@ func TestRun_NoDiscovery(t *testing.T) {
 		InstanceName: "foo",
 		Exec:         testhelp.Command(fixtures.BasicCmd),
 		Env: map[string]string{
-			"PREFIX": "${discovery.foo}",
+			"CONFIG": "${discovery.foo}",
 		},
 	}, ErrLookup, nil, nil)
 	require.NoError(t, err)
@@ -64,9 +63,7 @@ func TestRun_NoDiscovery(t *testing.T) {
 	require.NoError(t, err)
 
 	// THEN no tasks are executed
-	assert.Equal(t, "stdout line", testhelp.ChannelRead(outs[0].Receive.Stdout))
-	assert.Equal(t, "error line", testhelp.ChannelRead(outs[0].Receive.Stderr))
-	assert.Equal(t, "${discovery.foo}-", testhelp.ChannelRead(outs[0].Receive.Stdout))
+	assert.Empty(t, outs)
 }
 
 func TestRun_Discovery(t *testing.T) {

--- a/internal/integrations/v4/integration/definition_test.go
+++ b/internal/integrations/v4/integration/definition_test.go
@@ -66,6 +66,32 @@ func TestRun_NoDiscovery(t *testing.T) {
 	assert.Empty(t, outs)
 }
 
+func TestRun_NoDiscoveryButFlexVariables(t *testing.T) {
+	t.Parallel()
+	defer leaktest.Check(t)()
+
+	// GIVEN a definition entry with discovery sources
+	def, err := NewDefinition(config.ConfigEntry{
+		InstanceName: "foo",
+		Exec:         testhelp.Command(fixtures.BasicCmd),
+		Env: map[string]string{
+			"CONFIG": "${flexVariable}",
+		},
+	}, ErrLookup, nil, nil)
+	require.NoError(t, err)
+
+	// WHEN the def is executed with no discovery matches
+	outs, err := def.Run(context.Background(), &databind.Values{}, databind.DiscovererInfo{}, nil, nil)
+	require.NoError(t, err)
+
+	// THEN no tasks are executed
+	// THEN the tasks are executed with the given configuration
+	assert.NoError(t, testhelp.ChannelErrClosed(outs[0].Receive.Errors))
+	assert.Equal(t, "stdout line", testhelp.ChannelRead(outs[0].Receive.Stdout))
+	assert.Equal(t, "error line", testhelp.ChannelRead(outs[0].Receive.Stderr))
+	assert.Equal(t, "-", testhelp.ChannelRead(outs[0].Receive.Stdout))
+}
+
 func TestRun_Discovery(t *testing.T) {
 	defer leaktest.Check(t)()
 
@@ -388,5 +414,4 @@ func TestNewDefinition_LowerCasedEnvGetsUppercased(t *testing.T) {
 	for _, v := range []string{strings.ToUpper(envA), strings.ToUpper(envB), strings.ToUpper(envC)} {
 		require.Equal(t, "random-val", def.ExecutorConfig.Environment[v])
 	}
-
 }

--- a/pkg/databind/pkg/databind/ondemand.go
+++ b/pkg/databind/pkg/databind/ondemand.go
@@ -3,10 +3,10 @@
 
 package databind
 
-// OnDemand can be used during Replace to dynamically get variable values given a variable name (key).
+// OnDemand can be used during Replace and ReplaceBytes to dynamically get variable values given a variable name (key).
 type OnDemand func(key string) (value []byte, found bool)
 
-// Provided configures the Replace function to get variables from the OnDemand function.
+// Provided configures the Replace and ReplaceBytes functions to get variables from the OnDemand function.
 // If a given variable is not found on the variables/discovery replacement, the variable name is first
 // looked up in the OnDemand provider before being replaced or discarded as not found.
 func Provided(od OnDemand) ReplaceOption {

--- a/pkg/databind/pkg/databind/ondemand_test.go
+++ b/pkg/databind/pkg/databind/ondemand_test.go
@@ -21,7 +21,8 @@ func TestReplace_OnDemand_ByteSlice(t *testing.T) {
 		discov: []discovery.Discovery{
 			{Variables: data.Map{"name.yours": "Fred"}},
 			{Variables: data.Map{"name.yours": "Marc"}},
-		}}
+		},
+	}
 	ret, err := ReplaceBytes(ctx, template, Provided(func(name string) (value []byte, found bool) {
 		if name == "name.mine" {
 			return []byte("Anna"), true
@@ -80,17 +81,19 @@ func TestReplace_OnDemand(t *testing.T) {
 func TestFetchReplace_OnDemand_VarNotFound(t *testing.T) {
 	// GIVEN a set of discovery values
 	vals := Values{
-		discov: []discovery.Discovery{{Variables: data.Map{"hello": "world", "bye": "you"}},
-			{Variables: data.Map{"hello": "nen", "bye": "nano"}}},
+		discov: []discovery.Discovery{
+			{Variables: data.Map{"discovery.hello": "world", "discovery.bye": "you"}},
+			{Variables: data.Map{"discovery.hello": "nen", "discovery.bye": "nano"}},
+		},
 	}
 
 	// WHEN they are discovered against a given template with dynamically provided variables
 	// and some of the variables can't be dynamically found
 	template := map[string]string{
-		"hello":    "${hello}",
-		"bye":      "${bye}",
-		"myVar":    "${myVar}",
-		"mySecret": "${varNotFound}",
+		"hello":    "${discovery.hello}",
+		"bye":      "${discovery.bye}",
+		"myVar":    "${discovery.myVar}",
+		"mySecret": "${discovery.varNotFound}",
 	}
 	_, err := Replace(&vals, template, Provided(func(key string) (value []byte, found bool) {
 		if key == "myVar" {

--- a/pkg/databind/pkg/databind/replacer.go
+++ b/pkg/databind/pkg/databind/replacer.go
@@ -5,6 +5,7 @@ package databind
 
 import (
 	"bytes"
+	"errors"
 	"reflect"
 	"regexp"
 	"unsafe"
@@ -37,38 +38,76 @@ func Replace(vals *Values, template interface{}, options ...ReplaceOption) (tran
 	// if neither discovery nor variables, we just return the template as it
 	if len(vals.discov) == 0 {
 		if len(vals.vars) == 0 {
-			//Historycally used to check for variables in template and return error in that case
-			//Now variables in template are allowed as they can be used in flex i.e and rc is meant
-			//to be executed internal/integrations/v4/integration/definition.go
-			//for onDemand = ignoreConfigPathVar(&foundConfigPath)
-			replaceAllSources(template, []discovery.Discovery{{}}, data.Map{}, rc)
-
+			// TRICKY LOGIC HERE
+			// if no discovery nor variables, we use this invocation not to replace anything, but
+			// to check if there are variable placeholders in the template (observe that we are passing
+			// an empty discovery source in the second argument)
+			_, err := replaceAllSources(template, []discovery.Discovery{{}}, data.Map{}, rc)
+			// if the above returned error, it means it has variables. So since discovery returned
+			// no results, we will to return an empty array
+			if err != nil {
+				return transformedData, nil
+			}
 			// otherwise, it means it does not have variables, so we will return the template as it was
 			// since it was not bounded to any discovery process
 			return []data.Transformed{{Variables: template}}, nil
 		}
 		// if no discovery data but variables, we just replace variables as if they were
 		// a discovery source and leave the "common" values as empty
-		return replaceAllSources(template, []discovery.Discovery{{Variables: vals.vars}}, data.Map{}, rc), nil
+		return replaceAllSources(template, []discovery.Discovery{{Variables: vals.vars}}, data.Map{}, rc)
 	}
 
 	discoverySources := vals.discov
 	varSrc := vals.vars
 
-	return replaceAllSources(template, discoverySources, varSrc, rc), nil
+	return replaceAllSources(template, discoverySources, varSrc, rc)
+}
+
+// ReplaceBytes receives a byte array that may  contain ${variable} placeholders,
+// and returns an array of byte arrays replacing the variable placeholders from the respective Values.
+func ReplaceBytes(vals *Values, template []byte, options ...ReplaceOption) ([][]byte, error) {
+	rc := replaceConfig{}
+	for _, option := range options {
+		option(&rc)
+	}
+	if len(vals.discov) == 0 {
+		if len(vals.vars) == 0 {
+			// the same tricky logic as for "Replace" function
+			_, err := replaceAllBytes(template, []discovery.Discovery{{}}, data.Map{}, rc)
+			if err != nil {
+				return [][]byte{}, nil
+			}
+			return [][]byte{template}, nil
+		}
+		// if no discovery data but variables, we just replace variables as if they were
+		// a discovery source and leave the "common" values as empty
+		return replaceAllBytes(template, []discovery.Discovery{{Variables: vals.vars}}, data.Map{}, rc)
+	}
+
+	discoverySources := vals.discov
+	varSrc := vals.vars
+
+	return replaceAllBytes(template, discoverySources, varSrc, rc)
 }
 
 // Replaces all the discovery sources by the values in the "src" array. The common array is shared
 // If src is empty, no change is done even if there is data in the common map.
-func replaceAllSources(tmpl interface{}, src []discovery.Discovery, common data.Map, rc replaceConfig) (transformedData []data.Transformed) {
+func replaceAllSources(tmpl interface{}, src []discovery.Discovery, common data.Map, rc replaceConfig) (transformedData []data.Transformed, err error) {
 	templateVal := reflect.ValueOf(tmpl)
 	for _, discov := range src {
 		matches := 0
-		replaced := replaceFields([]data.Map{discov.Variables, common}, templateVal, rc, &matches)
-		entityRewrites := replaceEntityRewrites([]data.Map{discov.Variables, common}, discov.EntityRewrites, rc)
+		replaced, err := replaceFields([]data.Map{discov.Variables, common}, templateVal, rc, &matches)
+		if err != nil {
+			return transformedData, err
+		}
+
+		entityRewrites, err := replaceEntityRewrites([]data.Map{discov.Variables, common}, discov.EntityRewrites, rc)
+		if err != nil {
+			return transformedData, err
+		}
 
 		if matches == 0 { // the config has no variables. Returning single instance
-			return []data.Transformed{{Variables: tmpl, EntityRewrites: entityRewrites}}
+			return []data.Transformed{{Variables: tmpl, EntityRewrites: entityRewrites}}, nil
 		}
 
 		transformedData = append(transformedData,
@@ -78,10 +117,10 @@ func replaceAllSources(tmpl interface{}, src []discovery.Discovery, common data.
 				EntityRewrites:    entityRewrites,
 			})
 	}
-	return transformedData
+	return transformedData, nil
 }
 
-func replaceEntityRewrites(values []data.Map, entityRewrite []data.EntityRewrite, rc replaceConfig) []data.EntityRewrite {
+func replaceEntityRewrites(values []data.Map, entityRewrite []data.EntityRewrite, rc replaceConfig) ([]data.EntityRewrite, error) {
 
 	for i := range entityRewrite {
 		entityRewrite[i].ReplaceField = naming.AddPrefixToVariable(data.DiscoveryPrefix, entityRewrite[i].ReplaceField)
@@ -92,28 +131,34 @@ func replaceEntityRewrites(values []data.Map, entityRewrite []data.EntityRewrite
 
 	entityRewriteMatches := 0
 
-	entityRewriteReplaced := replaceFields(values, entityRewriteTpl, rc, &entityRewriteMatches)
+	entityRewriteReplaced, err := replaceFields(values, entityRewriteTpl, rc, &entityRewriteMatches)
+	if err != nil {
+		return nil, err
+	}
 
 	if entityRewriteMatches > 0 {
 		entityRewrite = entityRewriteReplaced.Interface().([]data.EntityRewrite)
 	}
-	return entityRewrite
+	return entityRewrite, nil
 }
 
-func replaceAllBytes(template []byte, src []discovery.Discovery, common data.Map, rc replaceConfig) [][]byte {
+func replaceAllBytes(template []byte, src []discovery.Discovery, common data.Map, rc replaceConfig) ([][]byte, error) {
 	var allReplaced [][]byte
 	for _, discov := range src {
 		matches := 0
-		replaced := replaceBytes([]data.Map{discov.Variables, common}, template, rc, &matches)
+		replaced, err := replaceBytes([]data.Map{discov.Variables, common}, template, rc, &matches)
+		if err != nil {
+			return nil, err
+		}
 		if matches == 0 { // the config has no variables. Returning single instance
-			return [][]byte{template}
+			return [][]byte{template}, nil
 		}
 		allReplaced = append(allReplaced, replaced)
 	}
-	return allReplaced
+	return allReplaced, nil
 }
 
-func replaceFields(values []data.Map, val reflect.Value, rc replaceConfig, matches *int) reflect.Value {
+func replaceFields(values []data.Map, val reflect.Value, rc replaceConfig, matches *int) (reflect.Value, error) {
 	switch val.Kind() {
 	case reflect.Slice:
 		// return provided slice if is empty
@@ -123,38 +168,53 @@ func replaceFields(values []data.Map, val reflect.Value, rc replaceConfig, match
 
 		// if it is a byte array, replaces it as if it were a string
 		if val.Type().Elem().Kind() == reflect.Uint8 {
-			replaced := replaceBytes(values, val.Bytes(), rc, matches)
-			return reflect.ValueOf(replaced)
+			replaced, err := replaceBytes(values, val.Bytes(), rc, matches)
+			if err != nil {
+				return reflect.Value{}, err
+			}
+			return reflect.ValueOf(replaced), nil
 		}
 		length := val.Len()
 		newSlice := reflect.MakeSlice(val.Type(), length, length)
 		for i := 0; i < length; i++ {
 			ival := val.Index(i)
-			replaced := replaceFields(values, ival, rc, matches)
+			replaced, err := replaceFields(values, ival, rc, matches)
+			if err != nil {
+				return reflect.Value{}, err
+			}
 			newSlice.Index(i).Set(replaced)
 		}
-		return newSlice
+		return newSlice, nil
 	case reflect.Ptr:
 		if val.IsNil() {
-			return val.Elem()
+			return val.Elem(), nil
 		}
-		vals := replaceFields(values, val.Elem(), rc, matches)
+		vals, err := replaceFields(values, val.Elem(), rc, matches)
+		if err != nil {
+			return reflect.Value{}, err
+		}
 		if vals.Kind() == reflect.Ptr {
-			return reflect.NewAt(val.Type(), unsafe.Pointer(vals.Pointer()))
+			return reflect.NewAt(val.Type(), unsafe.Pointer(vals.Pointer())), nil
 		}
 		if vals.CanAddr() {
-			return vals.Addr()
+			return vals.Addr(), nil
 		}
-		return val.Elem()
+		return val.Elem(), nil
 	case reflect.Interface:
-		vals := replaceFields(values, reflect.ValueOf(val.Interface()), rc, matches)
-		if vals.Kind() == reflect.Ptr {
-			return reflect.NewAt(val.Type(), unsafe.Pointer(vals.Pointer()))
+		vals, err := replaceFields(values, reflect.ValueOf(val.Interface()), rc, matches)
+		if err != nil {
+			return reflect.Value{}, err
 		}
-		return vals
+		if vals.Kind() == reflect.Ptr {
+			return reflect.NewAt(val.Type(), unsafe.Pointer(vals.Pointer())), nil
+		}
+		return vals, nil
 	case reflect.String:
-		nStr := replaceBytes(values, []byte(val.String()), rc, matches)
-		return reflect.ValueOf(string(nStr))
+		nStr, err := replaceBytes(values, []byte(val.String()), rc, matches)
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		return reflect.ValueOf(string(nStr)), nil
 	case reflect.Map:
 		keys := val.MapKeys()
 		if len(keys) == 0 {
@@ -164,64 +224,76 @@ func replaceFields(values []data.Map, val reflect.Value, rc replaceConfig, match
 		newMap := reflect.MakeMap(val.Type())
 		for _, k := range keys {
 			val := val.MapIndex(k)
-			nComps := replaceFields(values, val, rc, matches)
+			nComps, err := replaceFields(values, val, rc, matches)
+			if err != nil {
+				return reflect.Value{}, err
+			}
 			newMap.SetMapIndex(k, nComps)
 		}
-		return newMap
+		return newMap, nil
 	case reflect.Struct:
 		newStruct := reflect.New(val.Type()).Elem()
 		for i := 0; i < val.NumField(); i++ {
-			nComps := replaceFields(values, val.Field(i), rc, matches)
+			nComps, err := replaceFields(values, val.Field(i), rc, matches)
+			if err != nil {
+				return reflect.Value{}, err
+			}
 			field := newStruct.Field(i)
 			if field.CanSet() && nComps.IsValid() {
 				field.Set(nComps)
 			}
 		}
-		return newStruct
+		return newStruct, nil
 	default:
-		return val
+		return val, nil
 	}
 }
 
-func replaceBytes(values []data.Map, template []byte, rc replaceConfig, nMatches *int) []byte {
+func replaceBytes(values []data.Map, template []byte, rc replaceConfig, nMatches *int) ([]byte, error) {
 	matches := regex.FindAllIndex(template, -1)
 	if len(matches) == 0 {
-		return template // zero variables, all have been found and replaced
+		return template, nil // zero variables, all have been found and replaced
 	}
 	replace := make([]byte, 0, len(template))
 	replace = append(replace, template[:matches[0][0]]...)
 	for i := 0; i < len(matches)-1; i++ {
-		value := variable(values, template[matches[i][0]:matches[i][1]], rc)
+		value, err := variable(values, template[matches[i][0]:matches[i][1]], rc)
+		if err != nil {
+			return nil, err
+		}
 		*nMatches++
 		replace = append(replace, value...)
 		replace = append(replace, template[matches[i][1]:matches[i+1][0]]...)
 	}
 	last := len(matches) - 1
-	value := variable(values, template[matches[last][0]:matches[last][1]], rc)
+	value, err := variable(values, template[matches[last][0]:matches[last][1]], rc)
+	if err != nil {
+		return nil, err
+	}
 	*nMatches++
 	replace = append(replace, value...)
 	replace = append(replace, template[matches[last][1]:]...)
-	return replace
+	return replace, err
 }
 
 // replaces a variable mark from its corresponding variable or discovered item.
-func variable(values []data.Map, match []byte, rc replaceConfig) []byte {
+func variable(values []data.Map, match []byte, rc replaceConfig) ([]byte, error) {
 	// removing ${...}
 	varName := string(bytes.Trim(match, "${}\n\r\t "))
 
 	for _, vmap := range values {
 		if value, ok := vmap[varName]; ok {
-			return []byte(value)
+			return []byte(value), nil
 		}
 	}
 
 	// if not found in the discovered/variables static sources, we ask dynamically for it
 	for _, onDemand := range rc.onDemand {
 		if value, ok := onDemand(varName); ok {
-			return value
+			return value, nil
 		}
 	}
 
 	// if the value is not found, returns the match itself
-	return match
+	return match, errors.New("value not found: " + varName)
 }

--- a/pkg/databind/pkg/databind/replacer_test.go
+++ b/pkg/databind/pkg/databind/replacer_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestReplace_NoVars_EmptyContext(t *testing.T) {
+	t.Parallel()
 	// Given a configuration with no discoverable variables
 	exampleConfig := struct {
 		URL  string
@@ -34,13 +35,14 @@ func TestReplace_NoVars_EmptyContext(t *testing.T) {
 }
 
 func TestReplace_Vars_EmptyContext(t *testing.T) {
+	t.Parallel()
 	// Given a configuration with variables placeholder that do not match any discovery data
 	type example struct {
 		URL  string
 		User string
 		Num  int
 	}
-	cfg := example{"${myVar}", "${myOtherVar}", 123}
+	cfg := example{"${discovery.myVar}", "${discovery.myOtherVar}", 123}
 
 	// When it is invoked with an empty context
 	ret, err := Replace(&Values{}, cfg)
@@ -51,6 +53,7 @@ func TestReplace_Vars_EmptyContext(t *testing.T) {
 }
 
 func TestReplace_NoVars_PopulatedContext(t *testing.T) {
+	t.Parallel()
 	// Given a configuration with no discoverable variables
 	exampleConfig := struct {
 		URL  string
@@ -61,7 +64,8 @@ func TestReplace_NoVars_PopulatedContext(t *testing.T) {
 	// When it is invoked with a populated context
 	ret, err := Replace(&Values{discov: []discovery.Discovery{
 		{Variables: data.Map{"hi": "ho"}},
-		{Variables: data.Map{"hi": "ha"}}}}, exampleConfig)
+		{Variables: data.Map{"hi": "ha"}},
+	}}, exampleConfig)
 	require.NoError(t, err)
 
 	// The original configuration is returned, without modifications
@@ -70,6 +74,7 @@ func TestReplace_NoVars_PopulatedContext(t *testing.T) {
 }
 
 func TestReplace_Map(t *testing.T) {
+	t.Parallel()
 	// GIVEN a complex map with variable marks in the inner values
 	type fakeStruct struct {
 		Host string
@@ -118,6 +123,7 @@ func TestReplace_Map(t *testing.T) {
 }
 
 func TestReplace_ByteSlice(t *testing.T) {
+	t.Parallel()
 	// GIVEN a byte array with variable marks in the inner values
 	template := []byte("Hello ${name.yours},\nMy name is ${name.mine}.\nGoodbye!")
 	// WHEN they are replaced by a set of two discovered items
@@ -126,7 +132,8 @@ func TestReplace_ByteSlice(t *testing.T) {
 		discov: []discovery.Discovery{
 			{Variables: data.Map{"name.yours": "Fred"}},
 			{Variables: data.Map{"name.yours": "Marc"}},
-		}}
+		},
+	}
 	ret, err := ReplaceBytes(ctx, template)
 	require.NoError(t, err)
 
@@ -139,6 +146,7 @@ func TestReplace_ByteSlice(t *testing.T) {
 }
 
 func TestReplace_Struct(t *testing.T) {
+	t.Parallel()
 	// GIVEN a complex structure with variable marks in the inner values
 	type CustomMap map[string]interface{}
 	type CustomArray []int
@@ -202,11 +210,13 @@ func TestReplace_Struct(t *testing.T) {
 }
 
 func TestFetchReplace_WithVars(t *testing.T) {
+	t.Parallel()
 	// GIVEN a discovery source that returns 2 matches
 	discoverer := discoverer{fetch: func() ([]discovery.Discovery, error) {
 		return []discovery.Discovery{
 			{Variables: data.Map{"hello": "world", "bye": "you"}},
-			{Variables: data.Map{"hello": "nen", "bye": "nano"}}}, nil
+			{Variables: data.Map{"hello": "nen", "bye": "nano"}},
+		}, nil
 	}}
 	// AND a set of variables defined by the user
 	variable := func(value string) *gatherer {
@@ -257,6 +267,7 @@ func TestFetchReplace_WithVars(t *testing.T) {
 }
 
 func TestFetchReplace_ComplexVars(t *testing.T) {
+	t.Parallel()
 	// GIVEN a variable that returns a complex object
 	omelette := gatherer{fetch: func() (interface{}, error) {
 		return map[string]interface{}{
@@ -311,11 +322,13 @@ func TestFetchReplace_ComplexVars(t *testing.T) {
 }
 
 func TestFetchReplace_VarNotFound(t *testing.T) {
+	t.Parallel()
 	// GIVEN a discovery source that returns 2 matches
 	discoverer := discoverer{fetch: func() ([]discovery.Discovery, error) {
 		return []discovery.Discovery{
-			{Variables: data.Map{"hello": "world", "bye": "you"}},
-			{Variables: data.Map{"hello": "nen", "bye": "nano"}}}, nil
+			{Variables: data.Map{"discovery.hello": "world", "discovery.bye": "you"}},
+			{Variables: data.Map{"discovery.hello": "nen", "discovery.bye": "nano"}},
+		}, nil
 	}}
 	// AND a set of variables defined by the user
 	variable := func(value string) *gatherer {
@@ -327,7 +340,7 @@ func TestFetchReplace_VarNotFound(t *testing.T) {
 		clock:      time.Now,
 		discoverer: &discoverer,
 		variables: map[string]*gatherer{
-			"myVar": variable("myValue"),
+			"discovery.myVar": variable("myValue"),
 		},
 	}
 	vals, err := Fetch(&ctx)
@@ -335,10 +348,10 @@ func TestFetchReplace_VarNotFound(t *testing.T) {
 
 	// WHEN this data is replaced against a given template, where some variables are not found
 	template := map[string]string{
-		"hello":    "${hello}",
-		"bye":      "${bye}",
-		"myVar":    "${myVar}",
-		"mySecret": "${varNotFound}",
+		"hello":    "${discovery.hello}",
+		"bye":      "${discovery.bye}",
+		"myVar":    "${discovery.myVar}",
+		"mySecret": "${discovery.varNotFound}",
 	}
 	_, err = Replace(&vals, template)
 
@@ -347,6 +360,7 @@ func TestFetchReplace_VarNotFound(t *testing.T) {
 }
 
 func TestFetchReplace_NoMatches_WithVars(t *testing.T) {
+	t.Parallel()
 	// GIVEN a discovery source that returns no matches
 	discoverer := discoverer{fetch: func() ([]discovery.Discovery, error) {
 		return []discovery.Discovery{}, nil
@@ -380,11 +394,13 @@ func TestFetchReplace_NoMatches_WithVars(t *testing.T) {
 }
 
 func TestFetchReplace_MultipleMatches_NoVarsPlaceholders(t *testing.T) {
+	t.Parallel()
 	// GIVEN a discovery source that returns multiple matches
 	discoverer := discoverer{fetch: func() ([]discovery.Discovery, error) {
 		return []discovery.Discovery{
-			{Variables: data.Map{"hello": "world", "bye": "you"}},
-			{Variables: data.Map{"hello": "nen", "bye": "nano"}}}, nil
+			{Variables: data.Map{"discovery.hello": "world", "discovery.bye": "you"}},
+			{Variables: data.Map{"discovery.hello": "nen", "discovery.bye": "nano"}},
+		}, nil
 	}}
 	ctx := Sources{
 		clock:      time.Now,
@@ -407,6 +423,7 @@ func TestFetchReplace_MultipleMatches_NoVarsPlaceholders(t *testing.T) {
 }
 
 func TestFetchReplace_NoMatches_NoVarsPlaceholders(t *testing.T) {
+	t.Parallel()
 	// GIVEN a discovery source that returns NO matches
 	discoverer := discoverer{fetch: func() ([]discovery.Discovery, error) {
 		return []discovery.Discovery{}, nil
@@ -431,7 +448,8 @@ func TestFetchReplace_NoMatches_NoVarsPlaceholders(t *testing.T) {
 	assert.Equal(t, "hello", matches[0].Variables.(map[string]string)["variable"])
 }
 
-func TestFetchReplace_NoMatches_VarsPlaceholders(t *testing.T) {
+func TestFetchReplace_NoMatches_DiscoveryPrefixedVarsPlaceholders(t *testing.T) {
+	t.Parallel()
 	// GIVEN a discovery source that returns NO matches
 	discoverer := discoverer{fetch: func() ([]discovery.Discovery, error) {
 		return []discovery.Discovery{}, nil
@@ -446,7 +464,7 @@ func TestFetchReplace_NoMatches_VarsPlaceholders(t *testing.T) {
 
 	// WHEN this data is replaced against a template that uses variables
 	template := map[string]string{
-		"variable": "${something}",
+		"variable": "${discovery.something}",
 	}
 	matches, err := Replace(&vals, template)
 
@@ -456,11 +474,40 @@ func TestFetchReplace_NoMatches_VarsPlaceholders(t *testing.T) {
 	assert.Len(t, matches, 0)
 }
 
+func TestFetchReplace_NoMatches_NonPrefixedVarsPlaceholders(t *testing.T) {
+	t.Parallel()
+	// GIVEN a discovery source that returns NO matches
+	disc := discoverer{fetch: func() ([]discovery.Discovery, error) {
+		return []discovery.Discovery{}, nil
+	}}
+	ctx := Sources{
+		clock:      time.Now,
+		discoverer: &disc,
+		variables:  map[string]*gatherer{},
+	}
+	vals, err := Fetch(&ctx)
+	require.NoError(t, err)
+
+	// WHEN this data is replaced against a template that uses variables
+	template := map[string]string{
+		"variable": "${something}",
+	}
+	matches, err := Replace(&vals, template)
+	require.NoError(t, err)
+
+	// THEN only one match is returned, with the placeholder as it is
+	require.Len(t, matches, 1)
+	assert.Equal(t, "${something}", matches[0].Variables.(map[string]string)["variable"]) // nolint:forcetypeassert
+}
+
 func TestFetchReplaceBytes_VarNotFound(t *testing.T) {
+	t.Parallel()
 	// GIVEN a discovery source that returns 2 matches
 	discoverer := discoverer{fetch: func() ([]discovery.Discovery, error) {
-		return []discovery.Discovery{{Variables: data.Map{"hello": "world", "bye": "you"}},
-			{Variables: data.Map{"hello": "nen", "bye": "nano"}}}, nil
+		return []discovery.Discovery{
+			{Variables: data.Map{"discovery.hello": "world", "discovery.bye": "you"}},
+			{Variables: data.Map{"discovery.hello": "nen", "discovery.bye": "nano"}},
+		}, nil
 	}}
 	// AND a set of variables defined by the user
 	variable := func(value string) *gatherer {
@@ -472,20 +519,21 @@ func TestFetchReplaceBytes_VarNotFound(t *testing.T) {
 		clock:      time.Now,
 		discoverer: &discoverer,
 		variables: map[string]*gatherer{
-			"myVar": variable("myValue"),
+			"discovery.myVar": variable("myValue"),
 		},
 	}
 	vals, err := Fetch(&ctx)
 	require.NoError(t, err)
 
 	// WHEN this data is replaced against a given template, where some variables are not found
-	_, err = ReplaceBytes(&vals, []byte("Hello ${hello} how ${myVar} ${varNotFound}?"))
+	_, err = ReplaceBytes(&vals, []byte("Hello ${discovery.hello} how ${discovery.myVar} ${discovery.varNotFound}?"))
 
 	// THEN an error is returned
 	assert.Error(t, err)
 }
 
 func TestFetchReplaceBytes_NoMatches_WithVars(t *testing.T) {
+	t.Parallel()
 	// GIVEN a discovery source that returns no matches
 	discoverer := discoverer{fetch: func() ([]discovery.Discovery, error) {
 		return []discovery.Discovery{}, nil
@@ -516,11 +564,13 @@ func TestFetchReplaceBytes_NoMatches_WithVars(t *testing.T) {
 }
 
 func TestFetchReplaceBytes_MultipleMatches_NoVarsPlaceholders(t *testing.T) {
+	t.Parallel()
 	// GIVEN a discovery source that returns multiple matches
 	discoverer := discoverer{fetch: func() ([]discovery.Discovery, error) {
 		return []discovery.Discovery{
 			{Variables: data.Map{"hello": "world", "bye": "you"}},
-			{Variables: data.Map{"hello": "nen", "bye": "nano"}}}, nil
+			{Variables: data.Map{"hello": "nen", "bye": "nano"}},
+		}, nil
 	}}
 	ctx := Sources{
 		clock:      time.Now,
@@ -540,6 +590,7 @@ func TestFetchReplaceBytes_MultipleMatches_NoVarsPlaceholders(t *testing.T) {
 }
 
 func TestFetchReplaceBytes_NoMatches_NoVarsPlaceholders(t *testing.T) {
+	t.Parallel()
 	// GIVEN a discovery source that returns NO matches
 	discoverer := discoverer{fetch: func() ([]discovery.Discovery, error) {
 		return []discovery.Discovery{}, nil
@@ -562,6 +613,7 @@ func TestFetchReplaceBytes_NoMatches_NoVarsPlaceholders(t *testing.T) {
 }
 
 func TestFetchReplaceBytes_NoMatches_VarsPlaceholders(t *testing.T) {
+	t.Parallel()
 	// GIVEN a discovery source that returns NO matches
 	discoverer := discoverer{fetch: func() ([]discovery.Discovery, error) {
 		return []discovery.Discovery{}, nil
@@ -575,7 +627,7 @@ func TestFetchReplaceBytes_NoMatches_VarsPlaceholders(t *testing.T) {
 	require.NoError(t, err)
 
 	// WHEN this data is replaced against a template that uses variables
-	matches, err := ReplaceBytes(&vals, []byte("${something}"))
+	matches, err := ReplaceBytes(&vals, []byte("${discovery.something}"))
 
 	// THEN NO errors are returned, but zero matches (as discovery just did not found
 	// any target to apply


### PR DESCRIPTION
This PR 
* reverts https://github.com/newrelic/infrastructure-agent/pull/1132 so discovery will go back to previous behaviour where if one variable is not found it's not returning and error and the integrations is not run. (1c2250a8b271f6c79c4fa3a132c849d248c1dde8)

* Only variables prefixed with `discovery.` will have the behaviour explained above. The rest, if not found they will be rendered as they are as placeholders as they might be used in nri-flex. (c1fd0af0efdc65ee90c4bd410e56e1106ba49683)