### PR TITLE
NEWRELIC-3109 feat: support homebrew path in arm64

### DIFF
--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -3,8 +3,6 @@
 package config
 
 import (
-	"path/filepath"
-
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -12,16 +10,11 @@ const (
 	defaultConnectEnabled = true
 )
 
-func init() {
-	defaultConfigFiles = []string{
-		"newrelic-infra.yml",
-		filepath.Join("/usr", "local", "etc", "newrelic-infra", "newrelic-infra.yml"),
-	}
-	defaultAgentDir = filepath.Join("/usr", "local", "var", "db", "newrelic-infra")
-
+func init() { //nolint:gochecknoinits
 	// add PATH environment variable to all integrations
 	defaultPassthroughEnvironment = []string{"PATH"}
 }
+
 func runtimeValues() (userMode, agentUser, executablePath string) {
 	return ModeRoot, "", ""
 }

--- a/pkg/config/config_darwin_amd64.go
+++ b/pkg/config/config_darwin_amd64.go
@@ -1,0 +1,15 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+package config
+
+import (
+	"path/filepath"
+)
+
+func init() { //nolint:gochecknoinits
+	defaultConfigFiles = []string{
+		"newrelic-infra.yml",
+		filepath.Join("/usr", "local", "etc", "newrelic-infra", "newrelic-infra.yml"),
+	}
+	defaultAgentDir = filepath.Join("/usr", "local", "var", "db", "newrelic-infra")
+}

--- a/pkg/config/config_darwin_arm64.go
+++ b/pkg/config/config_darwin_arm64.go
@@ -1,0 +1,15 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+package config
+
+import (
+	"path/filepath"
+)
+
+func init() { //nolint:gochecknoinits
+	defaultConfigFiles = []string{
+		"newrelic-infra.yml",
+		filepath.Join("/opt", "homebrew", "etc", "newrelic-infra", "newrelic-infra.yml"),
+	}
+	defaultAgentDir = filepath.Join("/opt", "homebrew", "var", "db", "newrelic-infra")
+}


### PR DESCRIPTION
In arm based macos the homebrew path has been changed:
From [https://docs.brew.sh/Installation](https://docs.brew.sh/Installation)
```
This script installs Homebrew to its preferred prefix (/usr/local for macOS Intel, /opt/homebrew for 
Apple Silicon and /home/linuxbrew/.linuxbrew for Linux) so that you don’t need sudo when you brew install
...
```