### PR TITLE
NR-54822 refactor: exclude rss process error from logs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,7 @@ linters-settings:
   lll:
     # max line length, lines longer will be reported. Default is 120.
     # '\t' is counted as 1 character by default, and can be changed with the tab-width option
-    line-length: 300 # setting high as tests have long payloads currently
+    line-length: 350 # setting high as tests have long payloads currently
   wsl:
     allow-cuddle-declarations: true
     allow-assign-and-anything: true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,6 +36,7 @@ const (
 	TracesFieldName = "traces"
 	SupervisorTrace = "supervisor"
 	FeatureTrace    = "feature"
+	ProcessTrace    = "process"
 
 	// LogFilterWildcard will match everything.
 	LogFilterWildcard = "*"
@@ -1178,7 +1179,7 @@ func (lc *LogConfig) AttachDefaultFilters() {
 	}
 
 	// Exclude by default supervisor and feature traces.
-	lc.ExcludeFilters[TracesFieldName] = append(lc.ExcludeFilters[TracesFieldName], SupervisorTrace, FeatureTrace)
+	lc.ExcludeFilters[TracesFieldName] = append(lc.ExcludeFilters[TracesFieldName], SupervisorTrace, FeatureTrace, ProcessTrace)
 }
 
 // HasIncludeFilter returns true if key-value pair are included in the filtering configuration.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -669,7 +669,7 @@ func Test_ParseLogConfigRule_EnvVar(t *testing.T) {
 		Forward:              nil,
 		SmartLevelEntryLimit: &expectedSmartLevelEntryLimit,
 		IncludeFilters:       map[string][]interface{}{"component": {"ProcessSample", "StorageSample"}},
-		ExcludeFilters:       map[string][]interface{}{TracesFieldName: {SupervisorTrace, FeatureTrace}},
+		ExcludeFilters:       map[string][]interface{}{TracesFieldName: {SupervisorTrace, FeatureTrace, ProcessTrace}},
 	}
 	assert.EqualValues(t, expected, cfg.Log)
 }
@@ -823,10 +823,10 @@ func TestLoadLogConfig_Populate(t *testing.T) {
 		c                 Config
 		expectedLogConfig LogConfig
 	}{
-		{"Verbose disabled (info level) and custom log file", Config{Verbose: 0, LogFile: "agent.log"}, LogConfig{Level: LogLevelInfo, File: "agent.log", ToStdout: boolPtr(false), Forward: boolPtr(false), ExcludeFilters: LogFilters{"traces": []interface{}{"supervisor", "feature"}}, SmartLevelEntryLimit: intPtr(0)}},
-		{"Smart Verbose enabled with defined limit", Config{Verbose: 2, SmartVerboseModeEntryLimit: 200}, LogConfig{Level: LogLevelSmart, File: "", ToStdout: boolPtr(false), Forward: boolPtr(false), ExcludeFilters: LogFilters{"traces": []interface{}{"supervisor", "feature"}}, SmartLevelEntryLimit: intPtr(200)}},
-		{"Forward Verbose enabled and stdout", Config{Verbose: 3, LogToStdout: true}, LogConfig{Level: LogLevelDebug, File: "", ToStdout: boolPtr(true), Forward: boolPtr(true), ExcludeFilters: LogFilters{"traces": []interface{}{"supervisor", "feature"}}, SmartLevelEntryLimit: intPtr(0)}},
-		{"Trace Verbose enabled and file", Config{Verbose: 4, LogFile: "agent.log"}, LogConfig{Level: LogLevelTrace, File: "agent.log", ToStdout: boolPtr(false), Forward: boolPtr(false), ExcludeFilters: LogFilters{"traces": []interface{}{"supervisor", "feature"}}, SmartLevelEntryLimit: intPtr(0)}},
+		{"Verbose disabled (info level) and custom log file", Config{Verbose: 0, LogFile: "agent.log"}, LogConfig{Level: LogLevelInfo, File: "agent.log", ToStdout: boolPtr(false), Forward: boolPtr(false), ExcludeFilters: LogFilters{"traces": []interface{}{"supervisor", "feature", "process"}}, SmartLevelEntryLimit: intPtr(0)}},
+		{"Smart Verbose enabled with defined limit", Config{Verbose: 2, SmartVerboseModeEntryLimit: 200}, LogConfig{Level: LogLevelSmart, File: "", ToStdout: boolPtr(false), Forward: boolPtr(false), ExcludeFilters: LogFilters{"traces": []interface{}{"supervisor", "feature", "process"}}, SmartLevelEntryLimit: intPtr(200)}},
+		{"Forward Verbose enabled and stdout", Config{Verbose: 3, LogToStdout: true}, LogConfig{Level: LogLevelDebug, File: "", ToStdout: boolPtr(true), Forward: boolPtr(true), ExcludeFilters: LogFilters{"traces": []interface{}{"supervisor", "feature", "process"}}, SmartLevelEntryLimit: intPtr(0)}},
+		{"Trace Verbose enabled and file", Config{Verbose: 4, LogFile: "agent.log"}, LogConfig{Level: LogLevelTrace, File: "agent.log", ToStdout: boolPtr(false), Forward: boolPtr(false), ExcludeFilters: LogFilters{"traces": []interface{}{"supervisor", "feature", "process"}}, SmartLevelEntryLimit: intPtr(0)}},
 	}
 
 	for _, tt := range configs {

--- a/pkg/metrics/process/harvester_darwin.go
+++ b/pkg/metrics/process/harvester_darwin.go
@@ -72,7 +72,7 @@ func (dh *darwinHarvester) Do(pid int32, elapsedSeconds float64) (*types.Process
 
 	// We don't need to report processes which are not using memory. This filters out certain kernel processes.
 	if !dh.disableZeroRSSFilter && procSnapshot.VmRSS() == 0 {
-		return nil, errors.New("process with zero rss")
+		return nil, errProcessWithoutRSS
 	}
 
 	// Creates a fresh process sample and populates it with the metrics data

--- a/pkg/metrics/process/harvester_linux.go
+++ b/pkg/metrics/process/harvester_linux.go
@@ -69,7 +69,7 @@ func (ps *linuxHarvester) Do(pid int32, elapsedSeconds float64) (*types.ProcessS
 
 	// We don't need to report processes which are not using memory. This filters out certain kernel processes.
 	if !ps.disableZeroRSSFilter && cached.process.VmRSS() == 0 {
-		return nil, errors.New("process with zero rss")
+		return nil, errProcessWithoutRSS
 	}
 
 	// Creates a fresh process sample and populates it with the metrics data

--- a/pkg/metrics/process/harvester_unix.go
+++ b/pkg/metrics/process/harvester_unix.go
@@ -11,11 +11,15 @@
 package process
 
 import (
+	"fmt"
+
 	"github.com/newrelic/infrastructure-agent/pkg/log"
 	"github.com/newrelic/infrastructure-agent/pkg/metrics/types"
 )
 
 var mplog = log.WithComponent("ProcessSampler")
+
+var errProcessWithoutRSS = fmt.Errorf("process with zero rss")
 
 // Harvester manages sampling for individual processes. It is used by the Process Sampler to get information about the
 // existing processes.

--- a/pkg/metrics/process/sampler_darwin.go
+++ b/pkg/metrics/process/sampler_darwin.go
@@ -116,6 +116,7 @@ func (ps *processSampler) Sample() (results sample.EventBatch, err error) {
 			}
 
 			procLog.WithField("pid", pid).Debug("Skipping process.")
+			continue
 		}
 
 		if dockerDecorator != nil {


### PR DESCRIPTION
In an arbitrary Amazon Linux 2 with a very low load all the following PIDs got the "process with zero rss" error:
 pids="[2 3 4 5 7 10 11 12 13 14 15 16 17 18 19 21 24 25 26 28 29 30 31 32 33 88 89 90 91 92 93 94 95 138 140 141 144 186 188 190 197 223 241 251 252 303 748 749 750 751 752 753 754 755 1247 1257 1409 1410 8980 9086 9112 9551 9778 9784 10580 10790 11040 11238]"

For each scrape, a log line for each pid is displayed (debug mode):
```time="2022-09-23T09:50:29Z" level=debug msg="Skipped processes." component=ProcessSampler error="process with zero rss"```

This generates a lot of noise in the logs and most probably the processes without rss memory are internal kernel processes that we do not instrument.
