### PR TITLE
feat(logging): Set logging_retry_limit config as public

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -797,8 +797,8 @@ type Config struct {
 	// LoggingRetryLimit determines the value of the Retry_Limit for the New Relic fluent-bit output plugin.
 	// https://github.com/newrelic/newrelic-fluent-bit-output/blob/7cbb4393aa36e48bad783231182f707037ebf217/README.md#retry-logic
 	// Default: "5"
-	// Public: No
-	LoggingRetryLimit string `yaml:"logging_retry_limit" envconfig:"logging_retry_limit" public:"false"`
+	// Public: Yes
+	LoggingRetryLimit string `yaml:"logging_retry_limit" envconfig:"logging_retry_limit" public:"true"`
 
 	// FluentBitExePath is the location from where the agent can execute fluent-bit.
 	// Default (Linux): /opt/td-agent-bit/bin/td-agent-bit


### PR DESCRIPTION
Hi!

I'm not sure exactly what that public means, but this configurations should be available for users, so I think it should be public.

Feel free to close if this doesn't provide any value.

Regards!