### PR TITLE
fix smar hnr flacky tests

### DIFF
--- a/test/packaging/ansible/roles/agent-host-status-event-assert/defaults/main.yml
+++ b/test/packaging/ansible/roles/agent-host-status-event-assert/defaults/main.yml
@@ -1,7 +1,11 @@
 ---
 entity_name: "{{ iid }}:{{ inventory_hostname }}"
 
-seconds_ago: "{{ since_sec_ago if since_sec_ago is defined else 60 }}"
+# Give a small time-tolerance to account for the time when "since seconds ago" is calculated
+# and the time when the query is actually performed, otherwise we could miss the value window.
+tolerance: 5
+
+seconds_ago: "{{ now(True, '%s') | int + tolerance - timestamp_ref | int if timestamp_ref is defined else (since_sec_ago if since_sec_ago is defined else 60) }}"
 
 infrastructure_event_query: >-
   SELECT count(*) FROM InfrastructureEvent WHERE

--- a/test/packaging/ansible/shutdown-and-terminate.yml
+++ b/test/packaging/ansible/shutdown-and-terminate.yml
@@ -102,7 +102,7 @@
       vars:
         host_status: "shutdown"
         expect_event: "{{ host_supports_shutdown_detection }}"
-        since_sec_ago: "{{ now(True, '%s') | int - ec2_stop_time_sec | int }}"
+        timestamp_ref: "{{ ec2_stop_time_sec | int }}"
 
     - name: start instances
       include_role:
@@ -114,7 +114,7 @@
       vars:
         host_status: "running"
         expect_event: "{{ host_supports_shutdown_detection }}"
-        since_sec_ago: "{{ now(True, '%s') | int - ec2_start_time_sec | int }}"
+        timestamp_ref: "{{ ec2_start_time_sec | int }}"
 
     - name: terminate instances
       include_role:
@@ -130,5 +130,5 @@
       vars:
         host_status: "shutdown"
         expect_event: "{{ host_supports_shutdown_detection }}"
-        since_sec_ago: "{{ now(True, '%s') | int - ec2_terminate_time_sec | int }}"
+        timestamp_ref: "{{ ec2_terminate_time_sec | int }}"
 ...

--- a/tools/aws_logs.sh
+++ b/tools/aws_logs.sh
@@ -73,7 +73,7 @@ while : ; do
         break
     fi
 
-    result=$(echo "${result}" | jq -r '.events[] | [.timestamp, .message] | @tsv | .')
+    result=$(echo "${result}" | jq -r '.events[] | [(.timestamp/1000 | 'todate'), .message] | @tsv | .')
 
     if [[ "${tail}" == "true" ]]; then
         # In tail mode we print results to stdout


### PR DESCRIPTION
context:
- for Smart HNR the agent is performing nrqls to check if agent submited a disconnect request
- for this nrql we calculate a `seconds ago` clause based on the timestamp of ansible ec2 shutdown role execution and the current time of executing the nrql.
- however if the query execution takes longer, the test might miss the "window" of the Sample.

in this fix we delay the seconds ago calculation to the last moment before executing the query and also add a 5 seconds tolerance 