### PR TITLE
NEWRELIC-3023: Add azure metadata

### DIFF
--- a/internal/plugins/common/cloud.go
+++ b/internal/plugins/common/cloud.go
@@ -23,10 +23,10 @@ type AwsCloudData struct {
 }
 
 type AzureCloudData struct {
-	RegionAzure         string `json:"region_name,omitempty"`
-	AzureImageID        string `json:"azure_image_id,omitempty"`
-	AzureSubscriptionID string `json:"azure_subscription_id,omitempty"`
-	AzureLocation       string `json:"azure_location,omitempty"`
+	RegionAzure           string `json:"region_name,omitempty"`
+	AzureImageID          string `json:"azure_image_id,omitempty"`
+	AzureSubscriptionID   string `json:"azure_subscription_id,omitempty"`
+	AzureAvailabilityZone string `json:"azure_availability_zone,omitempty"`
 }
 
 type GoogleCloudData struct {
@@ -77,7 +77,7 @@ func GetCloudData(cloudHarvester cloud.Harvester) (CloudData, error) {
 		cloudData.RegionAzure = region
 		cloudData.AzureImageID = imageID
 		cloudData.AzureSubscriptionID = accountID
-		cloudData.AzureLocation = availabilityZone
+		cloudData.AzureAvailabilityZone = availabilityZone
 	case cloud.TypeGCP:
 		cloudData.RegionGCP = region
 	case cloud.TypeAlibaba:

--- a/internal/plugins/common/cloud.go
+++ b/internal/plugins/common/cloud.go
@@ -81,8 +81,8 @@ func getAzureCloudData(cloudHarvester cloud.Harvester) (azureData AzureCloudData
 	return
 }
 
-// GetCloudData will populate a CloudData structure depending on the cloud type.
-func GetCloudData(cloudHarvester cloud.Harvester) (cloudData CloudData, err error) {
+// getCloudData will populate a CloudData structure depending on the cloud type.
+func getCloudData(cloudHarvester cloud.Harvester) (cloudData CloudData, err error) {
 	switch cloudHarvester.GetCloudType() {
 	case cloud.TypeAWS:
 		cloudData.AwsCloudData, err = getAWSCloudData(cloudHarvester)

--- a/internal/plugins/common/cloud.go
+++ b/internal/plugins/common/cloud.go
@@ -1,0 +1,23 @@
+// Copyright New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+type AwsCloudData struct {
+	RegionAWS           string `json:"aws_region,omitempty"`
+	AWSAccountID        string `json:"aws_account_id,omitempty"`
+	AWSAvailabilityZone string `json:"aws_availability_zone,omitempty"`
+	AWSImageID          string `json:"aws_image_id,omitempty"`
+}
+
+type AzureCloudData struct {
+	RegionAzure string `json:"region_name,omitempty"`
+}
+
+type GoogleCloudData struct {
+	RegionGCP string `json:"zone,omitempty"`
+}
+
+type AlibabaCloudData struct {
+	RegionAlibaba string `json:"region_id,omitempty"`
+}

--- a/internal/plugins/common/cloud_test.go
+++ b/internal/plugins/common/cloud_test.go
@@ -1,0 +1,166 @@
+// Copyright New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/cloud"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+type fakeHarvester struct {
+	mock.Mock
+}
+
+// GetInstanceID will return the id of the cloud instance.
+func (f *fakeHarvester) GetInstanceID() (string, error) {
+	args := f.Called()
+	return args.String(0), args.Error(1)
+}
+
+// GetHostType will return the cloud instance type.
+func (f *fakeHarvester) GetHostType() (string, error) {
+	args := f.Called()
+	return args.String(0), args.Error(1)
+}
+
+// GetCloudType will return the cloud type on which the instance is running.
+func (f *fakeHarvester) GetCloudType() cloud.Type {
+	args := f.Called()
+	return args.Get(0).(cloud.Type)
+}
+
+// Returns a string key which will be used as a HostSource (see host_aliases plugin).
+func (f *fakeHarvester) GetCloudSource() string {
+	args := f.Called()
+	return args.String(0)
+}
+
+// GetRegion returns the cloud region
+func (f *fakeHarvester) GetRegion() (string, error) {
+	args := f.Called()
+	return args.String(0), args.Error(1)
+}
+
+// GetZone returns the cloud zone (availability zone)
+func (f *fakeHarvester) GetZone() (string, error) {
+	args := f.Called()
+	return args.String(0), args.Error(1)
+}
+
+// GetAccount returns the cloud account ID
+func (f *fakeHarvester) GetAccountID() (string, error) {
+	args := f.Called()
+	return args.String(0), args.Error(1)
+}
+
+// GetImageID returns the cloud instance ID
+func (f *fakeHarvester) GetInstanceImageID() (string, error) {
+	args := f.Called()
+	return args.String(0), args.Error(1)
+}
+
+// GetHarvester returns instance of the Harvester detected (or instance of themselves)
+func (f *fakeHarvester) GetHarvester() (cloud.Harvester, error) {
+	return f, nil
+}
+
+func TestGetCloudData(t *testing.T) {
+	testCases := []struct {
+		name       string
+		assertions func(data *HostInfoData)
+		setMock    func(*fakeHarvester)
+	}{
+		{
+			name: "no cloud",
+			assertions: func(d *HostInfoData) {
+				assert.Equal(t, "", d.RegionAWS)
+				assert.Equal(t, "", d.RegionAzure)
+				assert.Equal(t, "", d.RegionGCP)
+				assert.Equal(t, "", d.RegionAlibaba)
+			},
+			setMock: func(h *fakeHarvester) {
+				h.On("GetCloudType").Return(cloud.TypeNoCloud)
+			},
+		},
+		{
+			name: "cloud aws",
+			assertions: func(d *HostInfoData) {
+				assert.Equal(t, "us-east-1", d.RegionAWS)
+				assert.Equal(t, "us-east-1a", d.AWSAvailabilityZone)
+				assert.Equal(t, "ami-12345", d.AWSImageID)
+				assert.Equal(t, "x123", d.AWSAccountID)
+				assert.Equal(t, "", d.RegionAzure)
+				assert.Equal(t, "", d.RegionGCP)
+				assert.Equal(t, "", d.RegionAlibaba)
+			},
+			setMock: func(h *fakeHarvester) {
+				h.On("GetCloudType").Return(cloud.TypeAWS)
+				h.On("GetRegion").Return("us-east-1", nil)
+				h.On("GetZone").Return("us-east-1a", nil)
+				h.On("GetInstanceImageID").Return("ami-12345", nil)
+				h.On("GetAccountID").Return("x123", nil)
+			},
+		},
+		{
+			name: "cloud azure",
+			assertions: func(d *HostInfoData) {
+				assert.Equal(t, "", d.RegionAWS)
+				assert.Equal(t, "northeurope", d.RegionAzure)
+				assert.Equal(t, "", d.RegionGCP)
+				assert.Equal(t, "", d.RegionAlibaba)
+				assert.Equal(t, "12345", d.AzureImageID)
+				assert.Equal(t, "1", d.AzureAvailabilityZone)
+				assert.Equal(t, "x123", d.AzureSubscriptionID)
+			},
+			setMock: func(h *fakeHarvester) {
+				h.On("GetAccountID").Return("x123", nil)
+				h.On("GetCloudType").Return(cloud.TypeAzure)
+				h.On("GetRegion").Return("northeurope", nil)
+				h.On("GetInstanceImageID").Return("12345", nil)
+				h.On("GetZone").Return("1", nil)
+			},
+		},
+		{
+			name: "cloud gcp",
+			assertions: func(d *HostInfoData) {
+				assert.Equal(t, "", d.RegionAWS)
+				assert.Equal(t, "", d.RegionAzure)
+				assert.Equal(t, "us-east-1", d.RegionGCP)
+				assert.Equal(t, "", d.RegionAlibaba)
+			},
+			setMock: func(h *fakeHarvester) {
+				h.On("GetCloudType").Return(cloud.TypeGCP)
+				h.On("GetRegion").Return("us-east-1", nil)
+			},
+		},
+		{
+			name: "cloud alibaba",
+			assertions: func(d *HostInfoData) {
+				assert.Equal(t, "", d.RegionAWS)
+				assert.Equal(t, "", d.RegionAzure)
+				assert.Equal(t, "", d.RegionGCP)
+				assert.Equal(t, "us-east-1", d.RegionAlibaba)
+			},
+			setMock: func(h *fakeHarvester) {
+				h.On("GetCloudType").Return(cloud.TypeAlibaba)
+				h.On("GetRegion").Return("us-east-1", nil)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			h := new(fakeHarvester)
+			testCase.setMock(h)
+			data := &HostInfoData{}
+			cloudData, err := GetCloudData(h)
+			assert.NoError(t, err)
+			data.CloudData = cloudData
+			testCase.assertions(data)
+			h.AssertExpectations(t)
+		})
+	}
+}

--- a/internal/plugins/common/cloud_test.go
+++ b/internal/plugins/common/cloud_test.go
@@ -111,7 +111,6 @@ func TestGetCloudData(t *testing.T) {
 				assert.Equal(t, "northeurope", d.RegionAzure)
 				assert.Equal(t, "", d.RegionGCP)
 				assert.Equal(t, "", d.RegionAlibaba)
-				assert.Equal(t, "12345", d.AzureImageID)
 				assert.Equal(t, "1", d.AzureAvailabilityZone)
 				assert.Equal(t, "x123", d.AzureSubscriptionID)
 			},
@@ -119,7 +118,6 @@ func TestGetCloudData(t *testing.T) {
 				h.On("GetAccountID").Return("x123", nil)
 				h.On("GetCloudType").Return(cloud.TypeAzure)
 				h.On("GetRegion").Return("northeurope", nil)
-				h.On("GetInstanceImageID").Return("12345", nil)
 				h.On("GetZone").Return("1", nil)
 			},
 		},

--- a/internal/plugins/common/hostinfo.go
+++ b/internal/plugins/common/hostinfo.go
@@ -87,5 +87,6 @@ func (h *HostInfoCommon) GetCloudHostType() (string, error) {
 	if err != nil {
 		return hostType, err
 	}
+
 	return response, err
 }

--- a/internal/plugins/common/hostinfo.go
+++ b/internal/plugins/common/hostinfo.go
@@ -1,0 +1,27 @@
+// Copyright New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+type HostInfoData struct {
+	System   string `json:"id"`
+	HostType string `json:"host_type"`
+	CpuName  string `json:"cpu_name"`
+	// Number of cores within a single CPU ('cpu cores' field in /proc/cpuinfo)
+	// It is shown as 'coreCount' in New Relic UI
+	CpuNum string `json:"cpu_num"`
+	// Total number of cores in all the CPUs
+	// It is shown as 'processorCount' in New Relic UI
+	TotalCpu        string `json:"total_cpu"`
+	Ram             string `json:"ram"`
+	UpSince         string `json:"boot_timestamp"`
+	AgentVersion    string `json:"agent_version"`
+	AgentName       string `json:"agent_name"`
+	OperatingSystem string `json:"operating_system"`
+
+	// cloud metadata
+	AwsCloudData     `mapstructure:",squash"`
+	AzureCloudData   `mapstructure:",squash"`
+	GoogleCloudData  `mapstructure:",squash"`
+	AlibabaCloudData `mapstructure:",squash"`
+}

--- a/internal/plugins/common/hostinfo.go
+++ b/internal/plugins/common/hostinfo.go
@@ -18,8 +18,8 @@ type HostInfo interface {
 }
 
 type HostInfoCommon struct {
-	cloudMetadata bool
-	agentVersion  string
+	cloudMonitoring bool
+	agentVersion    string
 	cloud.Harvester
 }
 
@@ -45,9 +45,10 @@ type HostInfoData struct {
 	CloudData `mapstructure:",squash"`
 }
 
-func NewHostInfoCommon(agentVersion string, enableCloud bool, cloudHarvester cloud.Harvester) *HostInfoCommon {
+// NewHostInfoCommon return a new HostInfoCommon structure that implements HostInfo.
+func NewHostInfoCommon(agentVersion string, enableCloudMonitoring bool, cloudHarvester cloud.Harvester) *HostInfoCommon {
 	return &HostInfoCommon{
-		enableCloud,
+		enableCloudMonitoring,
 		agentVersion,
 		cloudHarvester,
 	}
@@ -58,7 +59,7 @@ func (h *HostInfoCommon) GetHostInfo() (HostInfoData, error) {
 	var cloudInfo CloudData
 	var err error
 
-	if h.cloudMetadata {
+	if h.cloudMonitoring {
 		cloudInfo, err = getCloudData(h)
 		if err != nil {
 			return HostInfoData{}, err
@@ -77,7 +78,7 @@ func (h *HostInfoCommon) GetHostInfo() (HostInfoData, error) {
 func (h *HostInfoCommon) GetCloudHostType() (string, error) {
 	hostType := "unknown"
 
-	if !h.cloudMetadata ||
+	if !h.cloudMonitoring ||
 		h.GetCloudType() == cloud.TypeNoCloud ||
 		h.GetCloudType() == cloud.TypeInProgress {
 		return hostType, ErrNoCloudHostTypeNotAvailable

--- a/internal/plugins/common/hostinfo.go
+++ b/internal/plugins/common/hostinfo.go
@@ -20,8 +20,5 @@ type HostInfoData struct {
 	OperatingSystem string `json:"operating_system"`
 
 	// cloud metadata
-	AwsCloudData     `mapstructure:",squash"`
-	AzureCloudData   `mapstructure:",squash"`
-	GoogleCloudData  `mapstructure:",squash"`
-	AlibabaCloudData `mapstructure:",squash"`
+	CloudData `mapstructure:",squash"`
 }

--- a/internal/plugins/common/hostinfo_test.go
+++ b/internal/plugins/common/hostinfo_test.go
@@ -69,6 +69,7 @@ func (f *fakeHarvester) GetHarvester() (cloud.Harvester, error) {
 }
 
 func TestGetHostInfo(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name       string
 		assertions func(data *HostInfoData)
@@ -156,6 +157,7 @@ func TestGetHostInfo(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 			h := new(fakeHarvester)
 			testCase.setMock(h)
 			hostInfo := NewHostInfoCommon("test", true, h)
@@ -168,6 +170,7 @@ func TestGetHostInfo(t *testing.T) {
 }
 
 func TestGetCloudHostType(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name       string
 		assertions func(string, error)
@@ -217,6 +220,7 @@ func TestGetCloudHostType(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 			h := new(fakeHarvester)
 			testCase.setMock(h)
 			hostInfo := NewHostInfoCommon("test", true, h)

--- a/internal/plugins/darwin/hostinfo.go
+++ b/internal/plugins/darwin/hostinfo.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/newrelic/infrastructure-agent/internal/agent"
 	"github.com/newrelic/infrastructure-agent/internal/os/distro"
+	"github.com/newrelic/infrastructure-agent/internal/plugins/common"
 	"github.com/newrelic/infrastructure-agent/pkg/entity"
 	"github.com/newrelic/infrastructure-agent/pkg/helpers"
 	"github.com/newrelic/infrastructure-agent/pkg/log"
@@ -56,13 +57,7 @@ type HostInfoData struct {
 	AgentMode           string `json:"agent_mode"`
 	OperatingSystem     string `json:"operating_system"`
 	ProductUuid         string `json:"product_uuid"`
-	RegionAWS           string `json:"aws_region,omitempty"`
-	RegionAzure         string `json:"region_name,omitempty"`
-	RegionGCP           string `json:"zone,omitempty"`
-	RegionAlibaba       string `json:"region_id,omitempty"`
-	AWSAccountID        string `json:"aws_account_id,omitempty"`
-	AWSAvailabilityZone string `json:"aws_availability_zone,omitempty"`
-	AWSImageID          string `json:"aws_image_id,omitempty"`
+	common.HostInfoData `mapstructure:",squash"`
 }
 
 func (hip *HostInfoData) SortKey() string {

--- a/internal/plugins/darwin/hostinfo_test.go
+++ b/internal/plugins/darwin/hostinfo_test.go
@@ -6,13 +6,10 @@
 package darwin
 
 import (
-	"github.com/newrelic/infrastructure-agent/internal/plugins/common"
 	"testing"
 
-	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/cloud"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 func TestGetKernelRelease_Success(t *testing.T) {
@@ -117,161 +114,6 @@ func TestValidateHardwareUUID(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.expected, validateHardwareUUID(test.input))
-		})
-	}
-}
-
-type fakeHarvester struct {
-	mock.Mock
-}
-
-// GetInstanceID will return the id of the cloud instance.
-func (f *fakeHarvester) GetInstanceID() (string, error) {
-	args := f.Called()
-	return args.String(0), args.Error(1)
-}
-
-// GetHostType will return the cloud instance type.
-func (f *fakeHarvester) GetHostType() (string, error) {
-	args := f.Called()
-	return args.String(0), args.Error(1)
-}
-
-// GetCloudType will return the cloud type on which the instance is running.
-func (f *fakeHarvester) GetCloudType() cloud.Type {
-	args := f.Called()
-	return args.Get(0).(cloud.Type)
-}
-
-// Returns a string key which will be used as a HostSource (see host_aliases plugin).
-func (f *fakeHarvester) GetCloudSource() string {
-	args := f.Called()
-	return args.String(0)
-}
-
-// GetRegion returns the cloud region
-func (f *fakeHarvester) GetRegion() (string, error) {
-	args := f.Called()
-	return args.String(0), args.Error(1)
-}
-
-// GetZone returns the cloud zone (availability zone)
-func (f *fakeHarvester) GetZone() (string, error) {
-	args := f.Called()
-	return args.String(0), args.Error(1)
-}
-
-// GetAccount returns the cloud account ID
-func (f *fakeHarvester) GetAccountID() (string, error) {
-	args := f.Called()
-	return args.String(0), args.Error(1)
-}
-
-// GetImageID returns the cloud instance ID
-func (f *fakeHarvester) GetInstanceImageID() (string, error) {
-	args := f.Called()
-	return args.String(0), args.Error(1)
-}
-
-// GetHarvester returns instance of the Harvester detected (or instance of themselves)
-func (f *fakeHarvester) GetHarvester() (cloud.Harvester, error) {
-	return f, nil
-}
-
-func TestHostinfoPluginSetCloudRegion(t *testing.T) {
-	testCases := []struct {
-		name       string
-		assertions func(*HostInfoDarwin)
-		setMock    func(*fakeHarvester)
-	}{
-		{
-			name: "no cloud",
-			assertions: func(d *HostInfoDarwin) {
-				assert.Equal(t, "", d.RegionAWS)
-				assert.Equal(t, "", d.RegionAzure)
-				assert.Equal(t, "", d.RegionGCP)
-				assert.Equal(t, "", d.RegionAlibaba)
-			},
-			setMock: func(h *fakeHarvester) {
-				h.On("GetCloudType").Return(cloud.TypeNoCloud)
-			},
-		},
-		{
-			name: "cloud aws",
-			assertions: func(d *HostInfoDarwin) {
-				assert.Equal(t, "us-east-1", d.RegionAWS)
-				assert.Equal(t, "us-east-1a", d.AWSAvailabilityZone)
-				assert.Equal(t, "ami-12345", d.AWSImageID)
-				assert.Equal(t, "x123", d.AWSAccountID)
-				assert.Equal(t, "", d.RegionAzure)
-				assert.Equal(t, "", d.RegionGCP)
-				assert.Equal(t, "", d.RegionAlibaba)
-			},
-			setMock: func(h *fakeHarvester) {
-				h.On("GetCloudType").Return(cloud.TypeAWS)
-				h.On("GetRegion").Return("us-east-1", nil)
-				h.On("GetZone").Return("us-east-1a", nil)
-				h.On("GetInstanceImageID").Return("ami-12345", nil)
-				h.On("GetAccountID").Return("x123", nil)
-			},
-		},
-		{
-			name: "cloud azure",
-			assertions: func(d *HostInfoDarwin) {
-				assert.Equal(t, "", d.RegionAWS)
-				assert.Equal(t, "northeurope", d.RegionAzure)
-				assert.Equal(t, "", d.RegionGCP)
-				assert.Equal(t, "", d.RegionAlibaba)
-				assert.Equal(t, "12345", d.AzureImageID)
-				assert.Equal(t, "1", d.AzureAvailabilityZone)
-				assert.Equal(t, "x123", d.AzureSubscriptionID)
-			},
-			setMock: func(h *fakeHarvester) {
-				h.On("GetAccountID").Return("x123", nil)
-				h.On("GetCloudType").Return(cloud.TypeAzure)
-				h.On("GetRegion").Return("northeurope", nil)
-				h.On("GetInstanceImageID").Return("12345", nil)
-				h.On("GetZone").Return("1", nil)
-			},
-		},
-		{
-			name: "cloud gcp",
-			assertions: func(d *HostInfoDarwin) {
-				assert.Equal(t, "", d.RegionAWS)
-				assert.Equal(t, "", d.RegionAzure)
-				assert.Equal(t, "us-east-1", d.RegionGCP)
-				assert.Equal(t, "", d.RegionAlibaba)
-			},
-			setMock: func(h *fakeHarvester) {
-				h.On("GetCloudType").Return(cloud.TypeGCP)
-				h.On("GetRegion").Return("us-east-1", nil)
-			},
-		},
-		{
-			name: "cloud alibaba",
-			assertions: func(d *HostInfoDarwin) {
-				assert.Equal(t, "", d.RegionAWS)
-				assert.Equal(t, "", d.RegionAzure)
-				assert.Equal(t, "", d.RegionGCP)
-				assert.Equal(t, "us-east-1", d.RegionAlibaba)
-			},
-			setMock: func(h *fakeHarvester) {
-				h.On("GetCloudType").Return(cloud.TypeAlibaba)
-				h.On("GetRegion").Return("us-east-1", nil)
-			},
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			h := new(fakeHarvester)
-			testCase.setMock(h)
-			data := &HostInfoDarwin{}
-			cloudData, err := common.GetCloudData(h)
-			assert.NoError(t, err)
-			data.CloudData = cloudData
-			testCase.assertions(data)
-			h.AssertExpectations(t)
 		})
 	}
 }

--- a/internal/plugins/darwin/hostinfo_test.go
+++ b/internal/plugins/darwin/hostinfo_test.go
@@ -183,12 +183,12 @@ func (f *fakeHarvester) GetHarvester() (cloud.Harvester, error) {
 func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 	testCases := []struct {
 		name       string
-		assertions func(*HostInfoData)
+		assertions func(*HostInfoDarwin)
 		setMock    func(*fakeHarvester)
 	}{
 		{
 			name: "no cloud",
-			assertions: func(d *HostInfoData) {
+			assertions: func(d *HostInfoDarwin) {
 				assert.Equal(t, "", d.RegionAWS)
 				assert.Equal(t, "", d.RegionAzure)
 				assert.Equal(t, "", d.RegionGCP)
@@ -200,7 +200,7 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 		},
 		{
 			name: "cloud aws",
-			assertions: func(d *HostInfoData) {
+			assertions: func(d *HostInfoDarwin) {
 				assert.Equal(t, "us-east-1", d.RegionAWS)
 				assert.Equal(t, "us-east-1a", d.AWSAvailabilityZone)
 				assert.Equal(t, "ami-12345", d.AWSImageID)
@@ -219,7 +219,7 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 		},
 		{
 			name: "cloud azure",
-			assertions: func(d *HostInfoData) {
+			assertions: func(d *HostInfoDarwin) {
 				assert.Equal(t, "", d.RegionAWS)
 				assert.Equal(t, "us-east-1", d.RegionAzure)
 				assert.Equal(t, "", d.RegionGCP)
@@ -232,7 +232,7 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 		},
 		{
 			name: "cloud gcp",
-			assertions: func(d *HostInfoData) {
+			assertions: func(d *HostInfoDarwin) {
 				assert.Equal(t, "", d.RegionAWS)
 				assert.Equal(t, "", d.RegionAzure)
 				assert.Equal(t, "us-east-1", d.RegionGCP)
@@ -245,7 +245,7 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 		},
 		{
 			name: "cloud alibaba",
-			assertions: func(d *HostInfoData) {
+			assertions: func(d *HostInfoDarwin) {
 				assert.Equal(t, "", d.RegionAWS)
 				assert.Equal(t, "", d.RegionAzure)
 				assert.Equal(t, "", d.RegionGCP)
@@ -262,7 +262,7 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			h := new(fakeHarvester)
 			testCase.setMock(h)
-			data := &HostInfoData{}
+			data := &HostInfoDarwin{}
 			p := &HostinfoPlugin{
 				PluginCommon: agent.PluginCommon{
 					ID:      ids.HostInfo,

--- a/internal/plugins/darwin/hostinfo_test.go
+++ b/internal/plugins/darwin/hostinfo_test.go
@@ -219,19 +219,19 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 			name: "cloud azure",
 			assertions: func(d *HostInfoDarwin) {
 				assert.Equal(t, "", d.RegionAWS)
-				assert.Equal(t, "us-east-1", d.RegionAzure)
+				assert.Equal(t, "northeurope", d.RegionAzure)
 				assert.Equal(t, "", d.RegionGCP)
 				assert.Equal(t, "", d.RegionAlibaba)
 				assert.Equal(t, "12345", d.AzureImageID)
-				assert.Equal(t, "europe", d.AzureLocation)
+				assert.Equal(t, "1", d.AzureAvailabilityZone)
 				assert.Equal(t, "x123", d.AzureSubscriptionID)
 			},
 			setMock: func(h *fakeHarvester) {
 				h.On("GetAccountID").Return("x123", nil)
 				h.On("GetCloudType").Return(cloud.TypeAzure)
-				h.On("GetRegion").Return("us-east-1", nil)
+				h.On("GetRegion").Return("northeurope", nil)
 				h.On("GetInstanceImageID").Return("12345", nil)
-				h.On("GetZone").Return("europe", nil)
+				h.On("GetZone").Return("1", nil)
 			},
 		},
 		{

--- a/internal/plugins/darwin/processorinfo_test_amd64.go
+++ b/internal/plugins/darwin/processorinfo_test_amd64.go
@@ -10,9 +10,11 @@ import (
 	"testing"
 
 	"github.com/newrelic/infrastructure-agent/internal/agent"
+	"github.com/newrelic/infrastructure-agent/internal/plugins/common"
 	testing2 "github.com/newrelic/infrastructure-agent/internal/plugins/testing"
 	"github.com/newrelic/infrastructure-agent/pkg/plugins/ids"
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/cloud"
+
 	"gotest.tools/assert"
 )
 
@@ -24,7 +26,7 @@ func TestData(t *testing.T) {
 		name                 string
 		unameOutput          string
 		systemProfilerOutput string
-		expectedData         HostInfoData
+		expectedData         HostInfoDarwin
 	}{
 		{
 			name:        "Intel arch output",
@@ -47,21 +49,23 @@ func TestData(t *testing.T) {
       Serial Number (system): abcd
       Hardware UUID: C3805006-DFCF-11EB-BA80-0242AC130004
 `,
-			expectedData: HostInfoData{
-				System:          "system",
-				Distro:          "macOS 11.2.3",
-				KernelVersion:   "20.3.0",
-				HostType:        "MacBook Pro MacBookPro15,1",
-				CpuName:         "6-Core Intel Core i7 @ 2.6 GHz",
-				CpuNum:          "6",
-				TotalCpu:        "6",
-				Ram:             "16777216 kB",
-				UpSince:         "2021-07-01 09:59:30",
-				AgentVersion:    "mock",
-				AgentName:       "Infrastructure",
-				AgentMode:       "root",
-				OperatingSystem: "macOS",
-				ProductUuid:     "C3805006-DFCF-11EB-BA80-0242AC130004",
+			expectedData: HostInfoDarwin{
+				HostInfoData: common.HostInfoData{
+					System:          "system",
+					HostType:        "MacBook Pro MacBookPro15,1",
+					CpuName:         "6-Core Intel Core i7 @ 2.6 GHz",
+					CpuNum:          "6",
+					TotalCpu:        "6",
+					Ram:             "16777216 kB",
+					UpSince:         "2021-07-01 09:59:30",
+					AgentVersion:    "mock",
+					AgentName:       "Infrastructure",
+					OperatingSystem: "macOS",
+				},
+				Distro:        "macOS 11.2.3",
+				KernelVersion: "20.3.0",
+				AgentMode:     "root",
+				ProductUuid:   "C3805006-DFCF-11EB-BA80-0242AC130004",
 			},
 		},
 	}
@@ -91,7 +95,7 @@ func TestData(t *testing.T) {
 			hip.Context.Config().RunMode = "root"
 			// Some values (distro, upSince) are being read from the host, so commented until fix those (out of scope in this task)
 			// assert.Equal(t, expected, hip.Data()[0])
-			data, ok := hip.Data()[0].(*HostInfoData)
+			data, ok := hip.Data()[0].(*HostInfoDarwin)
 			assert.Equal(t, true, ok)
 
 			assert.Equal(t, tt.expectedData.System, data.System)

--- a/internal/plugins/darwin/processorinfo_test_amd64.go
+++ b/internal/plugins/darwin/processorinfo_test_amd64.go
@@ -88,8 +88,7 @@ func TestData(t *testing.T) {
 
 					return ``, ErrUnknownCommand
 				},
-
-				cloudHarvester: cloud.NewDetector(true, 0, 0, 0, true),
+				HostInfo: common.NewHostInfoCommon("test", true, cloud.NewDetector(true, 0, 0, 0, true)),
 			}
 			hip.Context.Config().DisableCloudMetadata = true
 			hip.Context.Config().RunMode = "root"

--- a/internal/plugins/darwin/processorinfo_test_arm64.go
+++ b/internal/plugins/darwin/processorinfo_test_arm64.go
@@ -10,9 +10,11 @@ import (
 	"testing"
 
 	"github.com/newrelic/infrastructure-agent/internal/agent"
+	"github.com/newrelic/infrastructure-agent/internal/plugins/common"
 	testing2 "github.com/newrelic/infrastructure-agent/internal/plugins/testing"
 	"github.com/newrelic/infrastructure-agent/pkg/plugins/ids"
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/cloud"
+
 	"gotest.tools/assert"
 )
 
@@ -24,7 +26,7 @@ func TestData(t *testing.T) {
 		name                 string
 		unameOutput          string
 		systemProfilerOutput string
-		expectedData         HostInfoData
+		expectedData         HostInfoDarwin
 	}{
 		{
 			name:        "Arm arch output",
@@ -45,21 +47,23 @@ func TestData(t *testing.T) {
       Provisioning UDID: 00006000-000000000C1A801E
       Activation Lock Status: Disabled
 `,
-			expectedData: HostInfoData{
-				System:          "system",
-				Distro:          "macOS 11.2.3",
-				KernelVersion:   "21.6.0",
-				HostType:        "MacBook Pro MacBookPro18,4",
-				CpuName:         "Apple M1 Max",
-				CpuNum:          "10",
-				TotalCpu:        "10",
-				Ram:             "67108864 kB",
-				UpSince:         "2021-07-01 09:59:30",
-				AgentVersion:    "mock",
-				AgentName:       "Infrastructure",
-				AgentMode:       "root",
-				OperatingSystem: "macOS",
-				ProductUuid:     "E62094F3-9A33-5555-5555-F4C3A1E16AC5",
+			expectedData: HostInfoDarwin{
+				HostInfoData: common.HostInfoData{
+					System:          "system",
+					HostType:        "MacBook Pro MacBookPro18,4",
+					CpuName:         "Apple M1 Max",
+					CpuNum:          "10",
+					TotalCpu:        "10",
+					Ram:             "67108864 kB",
+					UpSince:         "2021-07-01 09:59:30",
+					AgentVersion:    "mock",
+					AgentName:       "Infrastructure",
+					OperatingSystem: "macOS",
+				},
+				Distro:        "macOS 11.2.3",
+				KernelVersion: "21.6.0",
+				AgentMode:     "root",
+				ProductUuid:   "E62094F3-9A33-5555-5555-F4C3A1E16AC5",
 			},
 		},
 	}
@@ -89,7 +93,7 @@ func TestData(t *testing.T) {
 			hip.Context.Config().RunMode = "root"
 			// Some values (distro, upSince) are being read from the host, so commented until fix those (out of scope in this task)
 			// assert.Equal(t, expected, hip.Data()[0])
-			data, ok := hip.Data()[0].(*HostInfoData)
+			data, ok := hip.Data()[0].(*HostInfoDarwin)
 			assert.Equal(t, true, ok)
 
 			assert.Equal(t, tt.expectedData.System, data.System)

--- a/internal/plugins/darwin/processorinfo_test_arm64.go
+++ b/internal/plugins/darwin/processorinfo_test_arm64.go
@@ -86,8 +86,7 @@ func TestData(t *testing.T) {
 
 					return ``, ErrUnknownCommand
 				},
-
-				cloudHarvester: cloud.NewDetector(true, 0, 0, 0, true),
+				HostInfo: common.NewHostInfoCommon("test", true, cloud.NewDetector(true, 0, 0, 0, true)),
 			}
 			hip.Context.Config().DisableCloudMetadata = true
 			hip.Context.Config().RunMode = "root"

--- a/internal/plugins/linux/hostinfo.go
+++ b/internal/plugins/linux/hostinfo.go
@@ -8,6 +8,7 @@ package linux
 import (
 	"bufio"
 	"fmt"
+	"github.com/newrelic/infrastructure-agent/internal/plugins/common"
 	"io/ioutil"
 	"os"
 	"regexp"
@@ -59,13 +60,7 @@ type HostinfoData struct {
 	OperatingSystem     string `json:"operating_system"`
 	ProductUuid         string `json:"product_uuid"`
 	BootId              string `json:"boot_id"`
-	RegionAWS           string `json:"aws_region,omitempty"`
-	RegionAzure         string `json:"region_name,omitempty"`
-	RegionGCP           string `json:"zone,omitempty"`
-	RegionAlibaba       string `json:"region_id,omitempty"`
-	AWSAccountID        string `json:"aws_account_id,omitempty"`
-	AWSAvailabilityZone string `json:"aws_availability_zone,omitempty"`
-	AWSImageID          string `json:"aws_image_id,omitempty"`
+	common.HostInfoData `mapstructure:",squash"`
 }
 
 func (self HostinfoData) SortKey() string {

--- a/internal/plugins/linux/hostinfo.go
+++ b/internal/plugins/linux/hostinfo.go
@@ -201,73 +201,19 @@ func (self *HostinfoPlugin) gatherHostinfo(context agent.AgentContext) *HostInfo
 		ProductUuid:   productUuid,
 		BootId:        fingerprint.GetBootId(),
 	}
-	err := self.setCloudRegion(data)
-	if err != nil {
-		hlog.WithError(err).WithField("cloudType", self.cloudHarvester.GetCloudType()).Debug(
-			"cloud region couldn't be set")
-	}
 
-	err = self.setCloudMetadata(data)
-	if err != nil {
-		hlog.WithError(err).WithField("cloudType", self.cloudHarvester.GetCloudType()).Debug(
-			"cloud metadata couldn't be set")
+	if !self.Context.Config().DisableCloudMetadata {
+		cloudData, err := common.GetCloudData(self.cloudHarvester)
+		if err != nil {
+			hlog.WithError(err).Debug("could not get cloud metadata")
+		}
+
+		data.CloudData = cloudData
 	}
 
 	helpers.LogStructureDetails(hlog, data, "HostInfoData", "raw", nil)
 
 	return data
-}
-
-func (self *HostinfoPlugin) setCloudRegion(data *HostInfoLinux) (err error) {
-	if self.Context.Config().DisableCloudMetadata ||
-		self.cloudHarvester.GetCloudType() == cloud.TypeNoCloud {
-		return
-	}
-
-	region, err := self.cloudHarvester.GetRegion()
-	if err != nil {
-		return fmt.Errorf("couldn't retrieve cloud region: %v", err)
-	}
-
-	switch self.cloudHarvester.GetCloudType() {
-	case cloud.TypeAWS:
-		data.RegionAWS = region
-	case cloud.TypeAzure:
-		data.RegionAzure = region
-	case cloud.TypeGCP:
-		data.RegionGCP = region
-	case cloud.TypeAlibaba:
-		data.RegionAlibaba = region
-	default:
-	}
-	return
-}
-
-// Only for AWS cloud instances
-func (self *HostinfoPlugin) setCloudMetadata(data *HostInfoLinux) (err error) {
-	if self.Context.Config().DisableCloudMetadata ||
-		self.cloudHarvester.GetCloudType() == cloud.TypeNoCloud {
-		return
-	}
-
-	if self.cloudHarvester.GetCloudType() == cloud.TypeAWS {
-		imageID, err := self.cloudHarvester.GetInstanceImageID()
-		if err != nil {
-			return fmt.Errorf("couldn't retrieve cloud image ID: %v", err)
-		}
-		data.AWSImageID = imageID
-		awsAccountID, err := self.cloudHarvester.GetAccountID()
-		if err != nil {
-			return fmt.Errorf("couldn't retrieve cloud account ID: %v", err)
-		}
-		data.AWSAccountID = awsAccountID
-		availabilityZone, err := self.cloudHarvester.GetZone()
-		if err != nil {
-			return fmt.Errorf("couldn't retrieve cloud availability zone: %v", err)
-		}
-		data.AWSAvailabilityZone = availabilityZone
-	}
-	return
 }
 
 func (self *HostinfoPlugin) getHostType() string {

--- a/internal/plugins/linux/hostinfo_test.go
+++ b/internal/plugins/linux/hostinfo_test.go
@@ -6,6 +6,7 @@
 package linux
 
 import (
+	"github.com/newrelic/infrastructure-agent/internal/plugins/common"
 	"io/ioutil"
 	"os"
 	"regexp"
@@ -43,7 +44,8 @@ func (s *HostinfoSuite) SetUpTest(c *C) {
 
 func (s *HostinfoSuite) NewPlugin(c *C) *HostinfoPlugin {
 	cloudDetector := cloud.NewDetector(true, 0, 0, 0, false)
-	v := NewHostinfoPlugin(s.agent, cloudDetector)
+	v := NewHostinfoPlugin(s.agent, common.NewHostInfoCommon("test", true, cloudDetector))
+
 	plugin, ok := v.(*HostinfoPlugin)
 	c.Assert(ok, Equals, true)
 	go plugin.Run()
@@ -73,7 +75,7 @@ func (s *HostinfoSuite) TestGetDistro(c *C) {
 
 	cloudDetector := cloud.NewDetector(true, 0, 0, 0, false)
 
-	v := NewHostinfoPlugin(s.agent, cloudDetector)
+	v := NewHostinfoPlugin(s.agent, common.NewHostInfoCommon("test", true, cloudDetector))
 	plugin, ok := v.(*HostinfoPlugin)
 	c.Assert(ok, Equals, true)
 	data := plugin.Data()

--- a/internal/plugins/linux/hostinfo_test.go
+++ b/internal/plugins/linux/hostinfo_test.go
@@ -6,6 +6,7 @@
 package linux
 
 import (
+	"github.com/newrelic/infrastructure-agent/internal/plugins/common"
 	"io/ioutil"
 	"os"
 	"regexp"
@@ -19,8 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/newrelic/infrastructure-agent/internal/agent"
-	"github.com/newrelic/infrastructure-agent/pkg/plugins/ids"
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/cloud"
 
 	. "github.com/newrelic/infrastructure-agent/pkg/go-better-check"
@@ -280,10 +279,16 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 				assert.Equal(t, "us-east-1", d.RegionAzure)
 				assert.Equal(t, "", d.RegionGCP)
 				assert.Equal(t, "", d.RegionAlibaba)
+				assert.Equal(t, "12345", d.AzureImageID)
+				assert.Equal(t, "europe", d.AzureLocation)
+				assert.Equal(t, "x123", d.AzureSubscriptionID)
 			},
 			setMock: func(h *fakeHarvester) {
+				h.On("GetAccountID").Return("x123", nil)
 				h.On("GetCloudType").Return(cloud.TypeAzure)
 				h.On("GetRegion").Return("us-east-1", nil)
+				h.On("GetInstanceImageID").Return("12345", nil)
+				h.On("GetZone").Return("europe", nil)
 			},
 		},
 		{
@@ -318,15 +323,9 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 			h := new(fakeHarvester)
 			testCase.setMock(h)
 			data := &HostInfoLinux{}
-			p := &HostinfoPlugin{
-				PluginCommon: agent.PluginCommon{
-					ID:      ids.HostInfo,
-					Context: testing2.NewMockAgent(),
-				},
-				cloudHarvester: h,
-			}
-			_ = p.setCloudRegion(data)
-			_ = p.setCloudMetadata(data)
+			cloudData, err := common.GetCloudData(h)
+			assert.NoError(t, err)
+			data.CloudData = cloudData
 			testCase.assertions(data)
 			h.AssertExpectations(t)
 		})

--- a/internal/plugins/linux/hostinfo_test.go
+++ b/internal/plugins/linux/hostinfo_test.go
@@ -6,7 +6,6 @@
 package linux
 
 import (
-	"github.com/newrelic/infrastructure-agent/internal/plugins/common"
 	"io/ioutil"
 	"os"
 	"regexp"
@@ -17,10 +16,8 @@ import (
 	"github.com/newrelic/infrastructure-agent/internal/os/fs"
 	testing2 "github.com/newrelic/infrastructure-agent/internal/plugins/testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/cloud"
+	"github.com/stretchr/testify/assert"
 
 	. "github.com/newrelic/infrastructure-agent/pkg/go-better-check"
 	. "gopkg.in/check.v1"
@@ -176,158 +173,4 @@ DISTRIB_DESCRIPTION="Ubuntu 14.04.5 LTS"
 func Test_getUpSince(t *testing.T) {
 	_, err := time.Parse("2006-01-02 15:04:05", getUpSince())
 	assert.NoError(t, err)
-}
-
-type fakeHarvester struct {
-	mock.Mock
-}
-
-// GetInstanceID will return the id of the cloud instance.
-func (f *fakeHarvester) GetInstanceID() (string, error) {
-	args := f.Called()
-	return args.String(0), args.Error(1)
-}
-
-// GetHostType will return the cloud instance type.
-func (f *fakeHarvester) GetHostType() (string, error) {
-	args := f.Called()
-	return args.String(0), args.Error(1)
-}
-
-// GetCloudType will return the cloud type on which the instance is running.
-func (f *fakeHarvester) GetCloudType() cloud.Type {
-	args := f.Called()
-	return args.Get(0).(cloud.Type)
-}
-
-// Returns a string key which will be used as a HostSource (see host_aliases plugin).
-func (f *fakeHarvester) GetCloudSource() string {
-	args := f.Called()
-	return args.String(0)
-}
-
-// GetRegion returns the cloud region
-func (f *fakeHarvester) GetRegion() (string, error) {
-	args := f.Called()
-	return args.String(0), args.Error(1)
-}
-
-// GetZone returns the cloud zone (availability zone)
-func (f *fakeHarvester) GetZone() (string, error) {
-	args := f.Called()
-	return args.String(0), args.Error(1)
-}
-
-// GetAccount returns the cloud account ID
-func (f *fakeHarvester) GetAccountID() (string, error) {
-	args := f.Called()
-	return args.String(0), args.Error(1)
-}
-
-// GetImageID returns the cloud instance ID
-func (f *fakeHarvester) GetInstanceImageID() (string, error) {
-	args := f.Called()
-	return args.String(0), args.Error(1)
-}
-
-// GetHarvester returns instance of the Harvester detected (or instance of themselves)
-func (f *fakeHarvester) GetHarvester() (cloud.Harvester, error) {
-	return f, nil
-}
-
-func TestHostinfoPluginSetCloudRegion(t *testing.T) {
-	testCases := []struct {
-		name       string
-		assertions func(*HostInfoLinux)
-		setMock    func(*fakeHarvester)
-	}{
-		{
-			name: "no cloud",
-			assertions: func(d *HostInfoLinux) {
-				assert.Equal(t, "", d.RegionAWS)
-				assert.Equal(t, "", d.RegionAzure)
-				assert.Equal(t, "", d.RegionGCP)
-				assert.Equal(t, "", d.RegionAlibaba)
-			},
-			setMock: func(h *fakeHarvester) {
-				h.On("GetCloudType").Return(cloud.TypeNoCloud)
-			},
-		},
-		{
-			name: "cloud aws",
-			assertions: func(d *HostInfoLinux) {
-				assert.Equal(t, "us-east-1", d.RegionAWS)
-				assert.Equal(t, "us-east-1a", d.AWSAvailabilityZone)
-				assert.Equal(t, "ami-12345", d.AWSImageID)
-				assert.Equal(t, "x123", d.AWSAccountID)
-				assert.Equal(t, "", d.RegionAzure)
-				assert.Equal(t, "", d.RegionGCP)
-				assert.Equal(t, "", d.RegionAlibaba)
-			},
-			setMock: func(h *fakeHarvester) {
-				h.On("GetCloudType").Return(cloud.TypeAWS)
-				h.On("GetRegion").Return("us-east-1", nil)
-				h.On("GetZone").Return("us-east-1a", nil)
-				h.On("GetInstanceImageID").Return("ami-12345", nil)
-				h.On("GetAccountID").Return("x123", nil)
-			},
-		},
-		{
-			name: "cloud azure",
-			assertions: func(d *HostInfoLinux) {
-				assert.Equal(t, "", d.RegionAWS)
-				assert.Equal(t, "northeurope", d.RegionAzure)
-				assert.Equal(t, "", d.RegionGCP)
-				assert.Equal(t, "", d.RegionAlibaba)
-				assert.Equal(t, "12345", d.AzureImageID)
-				assert.Equal(t, "1", d.AzureAvailabilityZone)
-				assert.Equal(t, "x123", d.AzureSubscriptionID)
-			},
-			setMock: func(h *fakeHarvester) {
-				h.On("GetAccountID").Return("x123", nil)
-				h.On("GetCloudType").Return(cloud.TypeAzure)
-				h.On("GetRegion").Return("northeurope", nil)
-				h.On("GetInstanceImageID").Return("12345", nil)
-				h.On("GetZone").Return("1", nil)
-			},
-		},
-		{
-			name: "cloud gcp",
-			assertions: func(d *HostInfoLinux) {
-				assert.Equal(t, "", d.RegionAWS)
-				assert.Equal(t, "", d.RegionAzure)
-				assert.Equal(t, "us-east-1", d.RegionGCP)
-				assert.Equal(t, "", d.RegionAlibaba)
-			},
-			setMock: func(h *fakeHarvester) {
-				h.On("GetCloudType").Return(cloud.TypeGCP)
-				h.On("GetRegion").Return("us-east-1", nil)
-			},
-		}, {
-			name: "cloud alibaba",
-			assertions: func(d *HostInfoLinux) {
-				assert.Equal(t, "", d.RegionAWS)
-				assert.Equal(t, "", d.RegionAzure)
-				assert.Equal(t, "", d.RegionGCP)
-				assert.Equal(t, "us-east-1", d.RegionAlibaba)
-			},
-			setMock: func(h *fakeHarvester) {
-				h.On("GetCloudType").Return(cloud.TypeAlibaba)
-				h.On("GetRegion").Return("us-east-1", nil)
-			},
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			h := new(fakeHarvester)
-			testCase.setMock(h)
-			data := &HostInfoLinux{}
-			cloudData, err := common.GetCloudData(h)
-			assert.NoError(t, err)
-			data.CloudData = cloudData
-			testCase.assertions(data)
-			h.AssertExpectations(t)
-		})
-	}
 }

--- a/internal/plugins/linux/hostinfo_test.go
+++ b/internal/plugins/linux/hostinfo_test.go
@@ -276,19 +276,19 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 			name: "cloud azure",
 			assertions: func(d *HostInfoLinux) {
 				assert.Equal(t, "", d.RegionAWS)
-				assert.Equal(t, "us-east-1", d.RegionAzure)
+				assert.Equal(t, "northeurope", d.RegionAzure)
 				assert.Equal(t, "", d.RegionGCP)
 				assert.Equal(t, "", d.RegionAlibaba)
 				assert.Equal(t, "12345", d.AzureImageID)
-				assert.Equal(t, "europe", d.AzureLocation)
+				assert.Equal(t, "1", d.AzureAvailabilityZone)
 				assert.Equal(t, "x123", d.AzureSubscriptionID)
 			},
 			setMock: func(h *fakeHarvester) {
 				h.On("GetAccountID").Return("x123", nil)
 				h.On("GetCloudType").Return(cloud.TypeAzure)
-				h.On("GetRegion").Return("us-east-1", nil)
+				h.On("GetRegion").Return("northeurope", nil)
 				h.On("GetInstanceImageID").Return("12345", nil)
-				h.On("GetZone").Return("europe", nil)
+				h.On("GetZone").Return("1", nil)
 			},
 		},
 		{

--- a/internal/plugins/linux/hostinfo_test.go
+++ b/internal/plugins/linux/hostinfo_test.go
@@ -82,7 +82,7 @@ func (s *HostinfoSuite) TestGetDistro(c *C) {
 	c.Assert(ok, Equals, true)
 	data := plugin.Data()
 	c.Assert(data, HasLen, 1)
-	hostInfo, ok := data[0].(*HostinfoData)
+	hostInfo, ok := data[0].(*HostInfoLinux)
 	c.Assert(ok, Equals, true)
 	c.Assert(hostInfo.Distro, HasPrefix, name)
 }
@@ -239,12 +239,12 @@ func (f *fakeHarvester) GetHarvester() (cloud.Harvester, error) {
 func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 	testCases := []struct {
 		name       string
-		assertions func(*HostinfoData)
+		assertions func(*HostInfoLinux)
 		setMock    func(*fakeHarvester)
 	}{
 		{
 			name: "no cloud",
-			assertions: func(d *HostinfoData) {
+			assertions: func(d *HostInfoLinux) {
 				assert.Equal(t, "", d.RegionAWS)
 				assert.Equal(t, "", d.RegionAzure)
 				assert.Equal(t, "", d.RegionGCP)
@@ -256,7 +256,7 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 		},
 		{
 			name: "cloud aws",
-			assertions: func(d *HostinfoData) {
+			assertions: func(d *HostInfoLinux) {
 				assert.Equal(t, "us-east-1", d.RegionAWS)
 				assert.Equal(t, "us-east-1a", d.AWSAvailabilityZone)
 				assert.Equal(t, "ami-12345", d.AWSImageID)
@@ -275,7 +275,7 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 		},
 		{
 			name: "cloud azure",
-			assertions: func(d *HostinfoData) {
+			assertions: func(d *HostInfoLinux) {
 				assert.Equal(t, "", d.RegionAWS)
 				assert.Equal(t, "us-east-1", d.RegionAzure)
 				assert.Equal(t, "", d.RegionGCP)
@@ -288,7 +288,7 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 		},
 		{
 			name: "cloud gcp",
-			assertions: func(d *HostinfoData) {
+			assertions: func(d *HostInfoLinux) {
 				assert.Equal(t, "", d.RegionAWS)
 				assert.Equal(t, "", d.RegionAzure)
 				assert.Equal(t, "us-east-1", d.RegionGCP)
@@ -300,7 +300,7 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 			},
 		}, {
 			name: "cloud alibaba",
-			assertions: func(d *HostinfoData) {
+			assertions: func(d *HostInfoLinux) {
 				assert.Equal(t, "", d.RegionAWS)
 				assert.Equal(t, "", d.RegionAzure)
 				assert.Equal(t, "", d.RegionGCP)
@@ -317,7 +317,7 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			h := new(fakeHarvester)
 			testCase.setMock(h)
-			data := &HostinfoData{}
+			data := &HostInfoLinux{}
 			p := &HostinfoPlugin{
 				PluginCommon: agent.PluginCommon{
 					ID:      ids.HostInfo,

--- a/internal/plugins/windows/hostinfo.go
+++ b/internal/plugins/windows/hostinfo.go
@@ -23,6 +23,7 @@ import (
 	"github.com/shirou/gopsutil/v3/mem"
 
 	"github.com/newrelic/infrastructure-agent/internal/agent"
+	"github.com/newrelic/infrastructure-agent/internal/plugins/common"
 	"github.com/newrelic/infrastructure-agent/pkg/helpers"
 	"github.com/newrelic/infrastructure-agent/pkg/log"
 	"github.com/newrelic/infrastructure-agent/pkg/plugins/ids"
@@ -55,13 +56,7 @@ type HostinfoData struct {
 	AgentVersion        string `json:"agent_version"`
 	AgentName           string `json:"agent_name"`
 	OperatingSystem     string `json:"operating_system"`
-	RegionAWS           string `json:"aws_region,omitempty"`
-	RegionAzure         string `json:"region_name,omitempty"`
-	RegionGCP           string `json:"zone,omitempty"`
-	RegionAlibaba       string `json:"region_id,omitempty"`
-	AWSAccountID        string `json:"aws_account_id,omitempty"`
-	AWSAvailabilityZone string `json:"aws_availability_zone,omitempty"`
-	AWSImageID          string `json:"aws_image_id,omitempty"`
+	common.HostInfoData `mapstructure:",squash"`
 }
 
 type cpuInfo struct {

--- a/internal/plugins/windows/hostinfo_test.go
+++ b/internal/plugins/windows/hostinfo_test.go
@@ -6,6 +6,7 @@
 package windows
 
 import (
+	"github.com/newrelic/infrastructure-agent/internal/plugins/common"
 	"testing"
 	"time"
 
@@ -38,7 +39,8 @@ func (s *HostinfoSuite) SetUpTest(c *C) {
 
 func (s *HostinfoSuite) NewPlugin(id ids.PluginID, c *C) *HostinfoPlugin {
 	cloudDetector := cloud.NewDetector(true, 0, 0, 0, false)
-	v := NewHostinfoPlugin(id, s.agent, cloudDetector)
+	v := NewHostinfoPlugin(id, s.agent,
+		common.NewHostInfoCommon("testing", true, cloudDetector))
 	plugin, ok := v.(*HostinfoPlugin)
 	c.Assert(ok, Equals, true)
 	go plugin.Run()

--- a/internal/plugins/windows/hostinfo_test.go
+++ b/internal/plugins/windows/hostinfo_test.go
@@ -6,11 +6,12 @@
 package windows
 
 import (
-	testing2 "github.com/newrelic/infrastructure-agent/internal/plugins/testing"
+	"github.com/newrelic/infrastructure-agent/internal/plugins/common"
 	"testing"
 	"time"
 
-	"github.com/newrelic/infrastructure-agent/internal/agent"
+	testing2 "github.com/newrelic/infrastructure-agent/internal/plugins/testing"
+
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/cloud"
 
 	"github.com/newrelic/infrastructure-agent/pkg/plugins/ids"
@@ -174,10 +175,16 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 				assert.Equal(t, "us-east-1", d.RegionAzure)
 				assert.Equal(t, "", d.RegionGCP)
 				assert.Equal(t, "", d.RegionAlibaba)
+				assert.Equal(t, "12345", d.AzureImageID)
+				assert.Equal(t, "europe", d.AzureLocation)
+				assert.Equal(t, "x123", d.AzureSubscriptionID)
 			},
 			setMock: func(h *fakeHarvester) {
+				h.On("GetAccountID").Return("x123", nil)
 				h.On("GetCloudType").Return(cloud.TypeAzure)
 				h.On("GetRegion").Return("us-east-1", nil)
+				h.On("GetInstanceImageID").Return("12345", nil)
+				h.On("GetZone").Return("europe", nil)
 			},
 		},
 		{
@@ -212,15 +219,9 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 			h := new(fakeHarvester)
 			testCase.setMock(h)
 			data := &HostInfoWindows{}
-			p := &HostinfoPlugin{
-				PluginCommon: agent.PluginCommon{
-					ID:      ids.HostInfo,
-					Context: testing2.NewMockAgent(),
-				},
-				cloudHarvester: h,
-			}
-			p.setCloudRegion(data)
-			p.setCloudMetadata(data)
+			cloudData, err := common.GetCloudData(h)
+			assert.NoError(t, err)
+			data.CloudData = cloudData
 			testCase.assertions(data)
 			h.AssertExpectations(t)
 		})

--- a/internal/plugins/windows/hostinfo_test.go
+++ b/internal/plugins/windows/hostinfo_test.go
@@ -172,19 +172,19 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 			name: "cloud azure",
 			assertions: func(d *HostInfoWindows) {
 				assert.Equal(t, "", d.RegionAWS)
-				assert.Equal(t, "us-east-1", d.RegionAzure)
+				assert.Equal(t, "northeurope", d.RegionAzure)
 				assert.Equal(t, "", d.RegionGCP)
 				assert.Equal(t, "", d.RegionAlibaba)
 				assert.Equal(t, "12345", d.AzureImageID)
-				assert.Equal(t, "europe", d.AzureLocation)
+				assert.Equal(t, "1", d.AzureAvailabilityZone)
 				assert.Equal(t, "x123", d.AzureSubscriptionID)
 			},
 			setMock: func(h *fakeHarvester) {
 				h.On("GetAccountID").Return("x123", nil)
 				h.On("GetCloudType").Return(cloud.TypeAzure)
-				h.On("GetRegion").Return("us-east-1", nil)
+				h.On("GetRegion").Return("northeurope", nil)
 				h.On("GetInstanceImageID").Return("12345", nil)
-				h.On("GetZone").Return("europe", nil)
+				h.On("GetZone").Return("1", nil)
 			},
 		},
 		{

--- a/internal/plugins/windows/hostinfo_test.go
+++ b/internal/plugins/windows/hostinfo_test.go
@@ -133,12 +133,12 @@ func (f *fakeHarvester) GetInstanceImageID() (string, error) {
 func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 	testCases := []struct {
 		name       string
-		assertions func(*HostinfoData)
+		assertions func(*HostInfoWindows)
 		setMock    func(*fakeHarvester)
 	}{
 		{
 			name: "no cloud",
-			assertions: func(d *HostinfoData) {
+			assertions: func(d *HostInfoWindows) {
 				assert.Equal(t, "", d.RegionAWS)
 				assert.Equal(t, "", d.RegionAzure)
 				assert.Equal(t, "", d.RegionGCP)
@@ -150,7 +150,7 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 		},
 		{
 			name: "cloud aws",
-			assertions: func(d *HostinfoData) {
+			assertions: func(d *HostInfoWindows) {
 				assert.Equal(t, "us-east-1", d.RegionAWS)
 				assert.Equal(t, "us-east-1a", d.AWSAvailabilityZone)
 				assert.Equal(t, "ami-12345", d.AWSImageID)
@@ -169,7 +169,7 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 		},
 		{
 			name: "cloud azure",
-			assertions: func(d *HostinfoData) {
+			assertions: func(d *HostInfoWindows) {
 				assert.Equal(t, "", d.RegionAWS)
 				assert.Equal(t, "us-east-1", d.RegionAzure)
 				assert.Equal(t, "", d.RegionGCP)
@@ -182,7 +182,7 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 		},
 		{
 			name: "cloud gcp",
-			assertions: func(d *HostinfoData) {
+			assertions: func(d *HostInfoWindows) {
 				assert.Equal(t, "", d.RegionAWS)
 				assert.Equal(t, "", d.RegionAzure)
 				assert.Equal(t, "us-east-1", d.RegionGCP)
@@ -194,7 +194,7 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 			},
 		}, {
 			name: "cloud alibaba",
-			assertions: func(d *HostinfoData) {
+			assertions: func(d *HostInfoWindows) {
 				assert.Equal(t, "", d.RegionAWS)
 				assert.Equal(t, "", d.RegionAzure)
 				assert.Equal(t, "", d.RegionGCP)
@@ -211,7 +211,7 @@ func TestHostinfoPluginSetCloudRegion(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			h := new(fakeHarvester)
 			testCase.setMock(h)
-			data := &HostinfoData{}
+			data := &HostInfoWindows{}
 			p := &HostinfoPlugin{
 				PluginCommon: agent.PluginCommon{
 					ID:      ids.HostInfo,

--- a/internal/plugins/windows/hostinfo_test.go
+++ b/internal/plugins/windows/hostinfo_test.go
@@ -6,7 +6,6 @@
 package windows
 
 import (
-	"github.com/newrelic/infrastructure-agent/internal/plugins/common"
 	"testing"
 	"time"
 
@@ -16,9 +15,6 @@ import (
 
 	"github.com/newrelic/infrastructure-agent/pkg/plugins/ids"
 	"github.com/shirou/gopsutil/v3/host"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
 	. "gopkg.in/check.v1"
 )
 
@@ -72,158 +68,4 @@ func (s *HostinfoSuite) TestCPUAndRamInfo(c *C) {
 
 	ram := getRam()
 	c.Assert(ram, NotNil)
-}
-
-type fakeHarvester struct {
-	mock.Mock
-}
-
-// GetInstanceID will return the id of the cloud instance.
-func (f *fakeHarvester) GetInstanceID() (string, error) {
-	args := f.Called()
-	return args.String(0), args.Error(1)
-}
-
-// GetHostType will return the cloud instance type.
-func (f *fakeHarvester) GetHostType() (string, error) {
-	args := f.Called()
-	return args.String(0), args.Error(1)
-}
-
-// GetCloudType will return the cloud type on which the instance is running.
-func (f *fakeHarvester) GetCloudType() cloud.Type {
-	args := f.Called()
-	return args.Get(0).(cloud.Type)
-}
-
-// Returns a string key which will be used as a HostSource (see host_aliases plugin).
-func (f *fakeHarvester) GetCloudSource() string {
-	args := f.Called()
-	return args.String(0)
-}
-
-// GetRegion returns the cloud region
-func (f *fakeHarvester) GetRegion() (string, error) {
-	args := f.Called()
-	return args.String(0), args.Error(1)
-}
-
-// GetHarvester returns instance of the Harvester detected (or instance of themselves)
-func (f *fakeHarvester) GetHarvester() (cloud.Harvester, error) {
-	return f, nil
-}
-
-// GetZone returns the cloud zone (availability zone)
-func (f *fakeHarvester) GetZone() (string, error) {
-	args := f.Called()
-	return args.String(0), args.Error(1)
-}
-
-// GetAccount returns the cloud account ID
-func (f *fakeHarvester) GetAccountID() (string, error) {
-	args := f.Called()
-	return args.String(0), args.Error(1)
-}
-
-// GetImageID returns the cloud instance ID
-func (f *fakeHarvester) GetInstanceImageID() (string, error) {
-	args := f.Called()
-	return args.String(0), args.Error(1)
-}
-
-func TestHostinfoPluginSetCloudRegion(t *testing.T) {
-	testCases := []struct {
-		name       string
-		assertions func(*HostInfoWindows)
-		setMock    func(*fakeHarvester)
-	}{
-		{
-			name: "no cloud",
-			assertions: func(d *HostInfoWindows) {
-				assert.Equal(t, "", d.RegionAWS)
-				assert.Equal(t, "", d.RegionAzure)
-				assert.Equal(t, "", d.RegionGCP)
-				assert.Equal(t, "", d.RegionAlibaba)
-			},
-			setMock: func(h *fakeHarvester) {
-				h.On("GetCloudType").Return(cloud.TypeNoCloud)
-			},
-		},
-		{
-			name: "cloud aws",
-			assertions: func(d *HostInfoWindows) {
-				assert.Equal(t, "us-east-1", d.RegionAWS)
-				assert.Equal(t, "us-east-1a", d.AWSAvailabilityZone)
-				assert.Equal(t, "ami-12345", d.AWSImageID)
-				assert.Equal(t, "x123", d.AWSAccountID)
-				assert.Equal(t, "", d.RegionAzure)
-				assert.Equal(t, "", d.RegionGCP)
-				assert.Equal(t, "", d.RegionAlibaba)
-			},
-			setMock: func(h *fakeHarvester) {
-				h.On("GetCloudType").Return(cloud.TypeAWS)
-				h.On("GetRegion").Return("us-east-1", nil)
-				h.On("GetZone").Return("us-east-1a", nil)
-				h.On("GetInstanceImageID").Return("ami-12345", nil)
-				h.On("GetAccountID").Return("x123", nil)
-			},
-		},
-		{
-			name: "cloud azure",
-			assertions: func(d *HostInfoWindows) {
-				assert.Equal(t, "", d.RegionAWS)
-				assert.Equal(t, "northeurope", d.RegionAzure)
-				assert.Equal(t, "", d.RegionGCP)
-				assert.Equal(t, "", d.RegionAlibaba)
-				assert.Equal(t, "12345", d.AzureImageID)
-				assert.Equal(t, "1", d.AzureAvailabilityZone)
-				assert.Equal(t, "x123", d.AzureSubscriptionID)
-			},
-			setMock: func(h *fakeHarvester) {
-				h.On("GetAccountID").Return("x123", nil)
-				h.On("GetCloudType").Return(cloud.TypeAzure)
-				h.On("GetRegion").Return("northeurope", nil)
-				h.On("GetInstanceImageID").Return("12345", nil)
-				h.On("GetZone").Return("1", nil)
-			},
-		},
-		{
-			name: "cloud gcp",
-			assertions: func(d *HostInfoWindows) {
-				assert.Equal(t, "", d.RegionAWS)
-				assert.Equal(t, "", d.RegionAzure)
-				assert.Equal(t, "us-east-1", d.RegionGCP)
-				assert.Equal(t, "", d.RegionAlibaba)
-			},
-			setMock: func(h *fakeHarvester) {
-				h.On("GetCloudType").Return(cloud.TypeGCP)
-				h.On("GetRegion").Return("us-east-1", nil)
-			},
-		}, {
-			name: "cloud alibaba",
-			assertions: func(d *HostInfoWindows) {
-				assert.Equal(t, "", d.RegionAWS)
-				assert.Equal(t, "", d.RegionAzure)
-				assert.Equal(t, "", d.RegionGCP)
-				assert.Equal(t, "ap-southeast-2", d.RegionAlibaba)
-			},
-			setMock: func(h *fakeHarvester) {
-				h.On("GetCloudType").Return(cloud.TypeAlibaba)
-				h.On("GetRegion").Return("ap-southeast-2", nil)
-			},
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			h := new(fakeHarvester)
-			testCase.setMock(h)
-			data := &HostInfoWindows{}
-			cloudData, err := common.GetCloudData(h)
-			assert.NoError(t, err)
-			data.CloudData = cloudData
-			testCase.assertions(data)
-			h.AssertExpectations(t)
-		})
-	}
 }

--- a/pkg/plugins/plugins_darwin.go
+++ b/pkg/plugins/plugins_darwin.go
@@ -17,7 +17,7 @@ import (
 
 func RegisterPlugins(a *agent.Agent) error {
 	a.RegisterPlugin(darwin.NewHostinfoPlugin(a.Context,
-		common.NewHostInfoCommon(a.Context.Version(), a.Context.Config().DisableCloudMetadata, a.GetCloudHarvester())))
+		common.NewHostInfoCommon(a.Context.Version(), !a.Context.Config().DisableCloudMetadata, a.GetCloudHarvester())))
 	a.RegisterPlugin(NewHostAliasesPlugin(a.Context, a.GetCloudHarvester()))
 	config := a.Context.Config()
 

--- a/pkg/plugins/plugins_darwin.go
+++ b/pkg/plugins/plugins_darwin.go
@@ -4,6 +4,7 @@ package plugins
 
 import (
 	"github.com/newrelic/infrastructure-agent/internal/agent"
+	"github.com/newrelic/infrastructure-agent/internal/plugins/common"
 	"github.com/newrelic/infrastructure-agent/internal/plugins/darwin"
 	"github.com/newrelic/infrastructure-agent/pkg/metrics"
 	"github.com/newrelic/infrastructure-agent/pkg/metrics/network"
@@ -15,7 +16,8 @@ import (
 )
 
 func RegisterPlugins(a *agent.Agent) error {
-	a.RegisterPlugin(darwin.NewHostinfoPlugin(a.Context, a.GetCloudHarvester()))
+	a.RegisterPlugin(darwin.NewHostinfoPlugin(a.Context,
+		common.NewHostInfoCommon(a.Context.Version(), a.Context.Config().DisableCloudMetadata, a.GetCloudHarvester())))
 	a.RegisterPlugin(NewHostAliasesPlugin(a.Context, a.GetCloudHarvester()))
 	config := a.Context.Config()
 

--- a/pkg/plugins/plugins_linux.go
+++ b/pkg/plugins/plugins_linux.go
@@ -48,7 +48,7 @@ func RegisterPlugins(agent *agnt.Agent) error {
 
 	// Enabling the hostinfo plugin will make the host appear in the UI
 	agent.RegisterPlugin(pluginsLinux.NewHostinfoPlugin(agent.Context,
-		common.NewHostInfoCommon(agent.Context.Version(), agent.Context.Config().DisableCloudMetadata, agent.GetCloudHarvester())))
+		common.NewHostInfoCommon(agent.Context.Version(), !agent.Context.Config().DisableCloudMetadata, agent.GetCloudHarvester())))
 
 	agent.RegisterPlugin(NewHostAliasesPlugin(agent.Context, agent.GetCloudHarvester()))
 	agent.RegisterPlugin(NewAgentConfigPlugin(ids.PluginID{"metadata", "agent_config"}, agent.Context))

--- a/pkg/plugins/plugins_linux.go
+++ b/pkg/plugins/plugins_linux.go
@@ -4,6 +4,7 @@ package plugins
 
 import (
 	agnt "github.com/newrelic/infrastructure-agent/internal/agent"
+	"github.com/newrelic/infrastructure-agent/internal/plugins/common"
 	pluginsLinux "github.com/newrelic/infrastructure-agent/internal/plugins/linux"
 	config2 "github.com/newrelic/infrastructure-agent/pkg/config"
 	"github.com/newrelic/infrastructure-agent/pkg/helpers"
@@ -46,7 +47,9 @@ func RegisterPlugins(agent *agnt.Agent) error {
 	agent.RegisterPlugin(NewCustomAttrsPlugin(agent.Context))
 
 	// Enabling the hostinfo plugin will make the host appear in the UI
-	agent.RegisterPlugin(pluginsLinux.NewHostinfoPlugin(agent.Context, agent.GetCloudHarvester()))
+	agent.RegisterPlugin(pluginsLinux.NewHostinfoPlugin(agent.Context,
+		common.NewHostInfoCommon(agent.Context.Version(), agent.Context.Config().DisableCloudMetadata, agent.GetCloudHarvester())))
+
 	agent.RegisterPlugin(NewHostAliasesPlugin(agent.Context, agent.GetCloudHarvester()))
 	agent.RegisterPlugin(NewAgentConfigPlugin(ids.PluginID{"metadata", "agent_config"}, agent.Context))
 	if config.ProxyConfigPlugin {

--- a/pkg/plugins/plugins_windows.go
+++ b/pkg/plugins/plugins_windows.go
@@ -24,7 +24,7 @@ func RegisterPlugins(a *agent.Agent) error {
 
 	// Enabling the hostinfo plugin will make the host appear in the UI
 	a.RegisterPlugin(pluginsWindows.NewHostinfoPlugin(ids.PluginID{"metadata", "system"}, a.Context,
-		common.NewHostInfoCommon(a.Context.Version(), a.Context.Config().DisableCloudMetadata, a.GetCloudHarvester())))
+		common.NewHostInfoCommon(a.Context.Version(), !a.Context.Config().DisableCloudMetadata, a.GetCloudHarvester())))
 	a.RegisterPlugin(NewHostAliasesPlugin(a.Context, a.GetCloudHarvester()))
 	a.RegisterPlugin(NewAgentConfigPlugin(ids.PluginID{"metadata", "agent_config"}, a.Context))
 	if config.ProxyConfigPlugin {

--- a/pkg/plugins/plugins_windows.go
+++ b/pkg/plugins/plugins_windows.go
@@ -3,6 +3,7 @@
 package plugins
 
 import (
+	"github.com/newrelic/infrastructure-agent/internal/plugins/common"
 	"github.com/newrelic/infrastructure-agent/pkg/metrics/network"
 	metricsSender "github.com/newrelic/infrastructure-agent/pkg/metrics/sender"
 	"github.com/newrelic/infrastructure-agent/pkg/metrics/storage"
@@ -22,7 +23,8 @@ func RegisterPlugins(a *agent.Agent) error {
 	}
 
 	// Enabling the hostinfo plugin will make the host appear in the UI
-	a.RegisterPlugin(pluginsWindows.NewHostinfoPlugin(ids.PluginID{"metadata", "system"}, a.Context, a.GetCloudHarvester()))
+	a.RegisterPlugin(pluginsWindows.NewHostinfoPlugin(ids.PluginID{"metadata", "system"}, a.Context,
+		common.NewHostInfoCommon(a.Context.Version(), a.Context.Config().DisableCloudMetadata, a.GetCloudHarvester())))
 	a.RegisterPlugin(NewHostAliasesPlugin(a.Context, a.GetCloudHarvester()))
 	a.RegisterPlugin(NewAgentConfigPlugin(ids.PluginID{"metadata", "agent_config"}, a.Context))
 	if config.ProxyConfigPlugin {

--- a/pkg/sysinfo/cloud/cloud_aws_test.go
+++ b/pkg/sysinfo/cloud/cloud_aws_test.go
@@ -4,15 +4,16 @@ package cloud
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/private/protocol"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/aws/aws-sdk-go/private/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newTestServer(t *testing.T, token string, tokenCounter *int32, expectedTTL string, expectedFieldName string) *httptest.Server {

--- a/pkg/sysinfo/cloud/cloud_azure.go
+++ b/pkg/sysinfo/cloud/cloud_azure.go
@@ -12,10 +12,11 @@ import (
 )
 
 // Metadata sample: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/instance-metadata-service?tabs=linux
+// API versions: https://learn.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service?tabs=windows#endpoint-categories
 
 const (
 	// azureEndpoint is the URL used for requesting Azure metadata.
-	azureEndpoint = "http://169.254.169.254/metadata/instance?api-version=2017-04-02"
+	azureEndpoint = "http://169.254.169.254/metadata/instance?api-version=2017-12-01"
 )
 
 // AzureHarvester is used to fetch data from Azure api.

--- a/pkg/sysinfo/cloud/cloud_azure_test.go
+++ b/pkg/sysinfo/cloud/cloud_azure_test.go
@@ -1,0 +1,72 @@
+// Copyright New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloud
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+// output generated with: curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2017-12-01"
+func TestParseAzureMetadata(t *testing.T) {
+	response := &http.Response{
+		StatusCode: 200,
+		Body: ioutil.NopCloser(bytes.NewBuffer([]byte(`{
+			"compute": {
+				 "location": "northeurope",
+				 "name": "tests",
+				 "offer": "0001-com-ubuntu-server-focal",
+				 "osType": "Linux",
+				 "placementGroupId": "",
+				 "platformFaultDomain": "0",
+				 "platformUpdateDomain": "0",
+				 "publisher": "canonical",
+				 "resourceGroupName": "testing",
+				 "sku": "20_04-lts-gen2",
+				 "subscriptionId": "11111-2222-3333-4444-5555",
+				 "tags": "env:testing;team:best",
+				 "version": "20.04.202210180",
+				 "vmId": "aaaaaa-bbbbb-cccc-dddd-aaaaaaa3a749",
+				 "vmScaleSetName": "",
+				 "vmSize": "Standard_B2s",
+				 "zone": "1"
+			  },
+			  "network": {
+				 "interface": [
+				   {
+					  "ipv4": {
+						"ipAddress": [
+						  {
+							"privateIpAddress": "10.0.0.4",
+							"publicIpAddress": ""
+						  }
+						],
+						"subnet": [
+						  {
+							"address": "10.0.0.0",
+							"prefix": "24"
+						  }
+						]
+					  },
+					  "ipv6": {
+						"ipAddress": []
+					  },
+					  "macAddress": "00000AAAAAAA"
+				   }
+				 ]
+			  }
+	}`))),
+	}
+
+	metadata, err := parseAzureMetadataResponse(response)
+	assert.NoError(t, err)
+	assert.Equal(t, metadata.Compute.SubscriptionID, "11111-2222-3333-4444-5555")
+	assert.Equal(t, metadata.Compute.Location, "northeurope")
+	assert.Equal(t, metadata.Compute.Zone, "1")
+	assert.Equal(t, metadata.Compute.VmSize, "Standard_B2s")
+	assert.Equal(t, metadata.Compute.VmId, "aaaaaa-bbbbb-cccc-dddd-aaaaaaa3a749")
+}

--- a/test/harvest/hostinfo_darwin_test.go
+++ b/test/harvest/hostinfo_darwin_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestHostinfoData(t *testing.T) {
+func TestHostInfoDarwin(t *testing.T) {
 	const timeout = 5 * time.Second
 
 	testClient := ihttp.NewRequestRecorderClient()

--- a/test/harvest/hostinfo_darwin_test.go
+++ b/test/harvest/hostinfo_darwin_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/newrelic/infrastructure-agent/internal/plugins/common"
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/cloud"
 
 	"github.com/newrelic/infrastructure-agent/pkg/backend/inventoryapi"
@@ -35,7 +36,7 @@ func TestHostInfoDarwin(t *testing.T) {
 	a.Context.SetAgentIdentity(entity.Identity{10, "abcdef"})
 
 	cloudDetector := cloud.NewDetector(true, 0, 0, 0, false)
-	a.RegisterPlugin(darwin.NewHostinfoPlugin(a.Context, cloudDetector))
+	a.RegisterPlugin(darwin.NewHostinfoPlugin(a.Context, common.NewHostInfoCommon("test", true, cloudDetector)))
 	go a.Run()
 
 	var req http.Request

--- a/test/harvest/hostinfo_linux_test.go
+++ b/test/harvest/hostinfo_linux_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestHostinfoData(t *testing.T) {
+func TestHostInfoLinux(t *testing.T) {
 	const timeout = 5 * time.Second
 
 	testClient := ihttp.NewRequestRecorderClient()

--- a/test/harvest/hostinfo_linux_test.go
+++ b/test/harvest/hostinfo_linux_test.go
@@ -34,7 +34,7 @@ func TestHostInfoLinux(t *testing.T) {
 
 	cloudDetector := cloud.NewDetector(true, 0, 0, 0, false)
 	a.RegisterPlugin(pluginsLinux.NewHostinfoPlugin(a.Context,
-		common.NewHostInfoCommon(a.Context.Version(), a.Context.Config().DisableCloudMetadata, cloudDetector)))
+		common.NewHostInfoCommon(a.Context.Version(), !a.Context.Config().DisableCloudMetadata, cloudDetector)))
 	go a.Run()
 
 	var req http.Request

--- a/test/harvest/hostinfo_linux_test.go
+++ b/test/harvest/hostinfo_linux_test.go
@@ -6,6 +6,7 @@
 package harvest
 
 import (
+	"github.com/newrelic/infrastructure-agent/internal/plugins/common"
 	"github.com/newrelic/infrastructure-agent/pkg/entity"
 	"net/http"
 	"testing"
@@ -32,7 +33,8 @@ func TestHostInfoLinux(t *testing.T) {
 	a.Context.SetAgentIdentity(entity.Identity{10, "abcdef"})
 
 	cloudDetector := cloud.NewDetector(true, 0, 0, 0, false)
-	a.RegisterPlugin(pluginsLinux.NewHostinfoPlugin(a.Context, cloudDetector))
+	a.RegisterPlugin(pluginsLinux.NewHostinfoPlugin(a.Context,
+		common.NewHostInfoCommon(a.Context.Version(), a.Context.Config().DisableCloudMetadata, cloudDetector)))
 	go a.Run()
 
 	var req http.Request

--- a/test/harvest/hostinfo_test.go
+++ b/test/harvest/hostinfo_test.go
@@ -111,7 +111,7 @@ func TestHostInfo(t *testing.T) {
 	os.Setenv("HOST_PROC", procDir.Path)
 
 	cloudDetector := cloud.NewDetector(true, 0, 0, 0, false)
-	hostInfoPlugin := pluginsLinux.NewHostinfoPlugin(ctx, cloudDetector)
+	hostInfoPlugin := pluginsLinux.NewHostinfoPlugin(ctx, common.NewHostInfoCommon(ctx.Version(), ctx.Config().DisableCloudMetadata, cloudDetector))
 	hostInfoPlugin.Run()
 	ctx.AssertExpectations(t)
 

--- a/test/harvest/hostinfo_test.go
+++ b/test/harvest/hostinfo_test.go
@@ -17,7 +17,9 @@ import (
 
 	"github.com/newrelic/infrastructure-agent/internal/agent"
 	"github.com/newrelic/infrastructure-agent/internal/agent/mocks"
+	"github.com/newrelic/infrastructure-agent/internal/plugins/common"
 	pluginsLinux "github.com/newrelic/infrastructure-agent/internal/plugins/linux"
+
 	"github.com/newrelic/infrastructure-agent/internal/testhelpers"
 	"github.com/newrelic/infrastructure-agent/pkg/config"
 	"github.com/newrelic/infrastructure-agent/pkg/plugins/ids"
@@ -122,7 +124,7 @@ func TestHostInfo(t *testing.T) {
 		}
 	}
 
-	actualUpSince := actual.Data[0].(*pluginsLinux.HostinfoData).UpSince
+	actualUpSince := actual.Data[0].(*pluginsLinux.HostInfoLinux).UpSince
 
 	// The last |^$|unknown prevents the test to fail in some old linux distros where `uptime -s` returns
 	// error because the -s argument is not accepted.
@@ -136,22 +138,24 @@ func TestHostInfo(t *testing.T) {
 		},
 		Entity: entity.NewFromNameWithoutID(agentIdentifier),
 		Data: agent.PluginInventoryDataset{
-			&pluginsLinux.HostinfoData{
-				System:          "system",
-				Distro:          distroName,
-				KernelVersion:   kernelVersion,
-				HostType:        fmt.Sprintf("%s %s", sysVendor, productName),
-				CpuName:         cpuName,
-				CpuNum:          strconv.Itoa(cpuCores),
-				TotalCpu:        strconv.Itoa(totalCPU),
-				Ram:             ram,
-				AgentVersion:    agentVersion,
-				AgentName:       "Infrastructure",
-				OperatingSystem: "linux",
-				ProductUuid:     productUUID,
-				BootId:          bootId,
-				UpSince:         actualUpSince,
-				AgentMode:       "privileged",
+			&pluginsLinux.HostInfoLinux{
+				HostInfoData: common.HostInfoData{
+					System:          "system",
+					HostType:        fmt.Sprintf("%s %s", sysVendor, productName),
+					CpuName:         cpuName,
+					CpuNum:          strconv.Itoa(cpuCores),
+					TotalCpu:        strconv.Itoa(totalCPU),
+					Ram:             ram,
+					AgentVersion:    agentVersion,
+					AgentName:       "Infrastructure",
+					OperatingSystem: "linux",
+					UpSince:         actualUpSince,
+				},
+				Distro:        distroName,
+				KernelVersion: kernelVersion,
+				ProductUuid:   productUUID,
+				BootId:        bootId,
+				AgentMode:     "privileged",
 			},
 		},
 	}

--- a/test/harvest/hostinfo_test.go
+++ b/test/harvest/hostinfo_test.go
@@ -111,7 +111,7 @@ func TestHostInfo(t *testing.T) {
 	os.Setenv("HOST_PROC", procDir.Path)
 
 	cloudDetector := cloud.NewDetector(true, 0, 0, 0, false)
-	hostInfoPlugin := pluginsLinux.NewHostinfoPlugin(ctx, common.NewHostInfoCommon(ctx.Version(), ctx.Config().DisableCloudMetadata, cloudDetector))
+	hostInfoPlugin := pluginsLinux.NewHostinfoPlugin(ctx, common.NewHostInfoCommon(ctx.Version(), !ctx.Config().DisableCloudMetadata, cloudDetector))
 	hostInfoPlugin.Run()
 	ctx.AssertExpectations(t)
 


### PR DESCRIPTION
- Refactor: 
1. moves duplicated code from HostInfoData to common package that can be used by any
2. decopules cloud harvester

- Add Azure metadata
1. Subscription id
2. Availability zone