### PR TITLE
support for urls in discovery

### DIFF
--- a/pkg/databind/pkg/databind/replacer.go
+++ b/pkg/databind/pkg/databind/replacer.go
@@ -23,8 +23,8 @@ type replaceConfig struct {
 // Option provide extra behaviour configuration to the replacement process.
 type ReplaceOption func(rc *replaceConfig)
 
-// This regular expression matches any variable mark ${...} with dots and index marks [ ]
-var regex = regexp.MustCompile(`\$\{[\w\d\._\s\[\]-]*\}`)
+// This regular expression matches any variable mark ${...} with dots, index marks [ ], and /.
+var regex = regexp.MustCompile(`\$\{[\w\d\._\s\[\]\/-]*\}`)
 
 // Replace receives one template, which may be a map or a struct whose string fields may
 // contain ${variable} placeholders, and returns an array of items of the same type of the


### PR DESCRIPTION
This configurations is not working in the current version due to slashed in the labels.

https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels

```
discovery: 
  command: 
    exec: /var/db/newrelic-infra/nri-discovery-kubernetes --tls --port 10250
    match: 
      label.app: test
integrations: 
  - env: 
      CLUSTER_ENVIRONMENT: ${discovery.clusterName}
      app: ${discovery.label.app}
      dashses: ${discovery.label.with-dashes-tld}
      dots: ${discovery.label.with.dots.tld}
      url: ${discovery.label.with.dots.tld/and-url}
      url_scaped: ${discovery.label.with.dots.tld\/and-url}
    exec: /bin/bash -c se
    interval: 2s
    name: bash-test
```