### PR TITLE
config/envvar: add test case for yaml block scalars

### DIFF
--- a/pkg/config/envvar/envvar_test.go
+++ b/pkg/config/envvar/envvar_test.go
@@ -85,6 +85,8 @@ instances:
      q6: 'foo'# comment "foo"
      q7: 'foo#bar'
      q8: ['foo#bar', 'baz' ]  # another inline comment
+     m1: |-
+       multiline # string
      # some comments
      # some comments
     labels:
@@ -117,6 +119,8 @@ instances:
      q6: 'foo'
      q7: 'foo#bar'
      q8: ['foo#bar', 'baz' ]  
+     m1: |-
+       multiline # string
     labels:
       foo: bar
 `


### PR DESCRIPTION
The yaml comment replacer does not seem to handle [multiline strings (a.k.a. block style)](https://yaml-multiline.info/) correctly. This PRs add a simple test case to demonstrate this.