### PR TITLE
Nr 72398 do not let infra agents fluent bit config files fill up the disk

### DIFF
--- a/pkg/integrations/v4/supervisor_fb.go
+++ b/pkg/integrations/v4/supervisor_fb.go
@@ -36,7 +36,7 @@ type FBSupervisorConfig struct {
 }
 
 const (
-	MaxNumberOfTempFiles int = 5
+	MaxNumberOfFbConfigTempFiles int = 50
 )
 
 // IsLogForwarderAvailable checks whether all the required files for FluentBit execution are available
@@ -106,7 +106,7 @@ func buildFbExecutor(fbIntCfg FBSupervisorConfig, cfgLoader *logs.CfgLoader) fun
 			return nil, errors.Wrap(err, "failed to create temporary fb sFBLogger config file")
 		}
 
-		if fbConfigTempFiles, err := removeFbConfigTempFiles(); err != nil || fbConfigTempFiles != nil {
+		if fbConfigTempFiles, err := removeFbConfigTempFiles(MaxNumberOfFbConfigTempFiles); err != nil || fbConfigTempFiles != nil {
 
 			for _, file := range fbConfigTempFiles {
 				log.Debugf("Removed %s config temp file.", file)
@@ -163,7 +163,7 @@ func saveToTempFile(config []byte) (string, error) {
 	return file.Name(), nil
 }
 
-func removeFbConfigTempFiles() ([]string, error) {
+func removeFbConfigTempFiles(maxNumberOfFbConfigTempFiles int) ([]string, error) {
 
 	files, err := os.ReadDir(os.TempDir())
 	if err != nil {
@@ -178,7 +178,7 @@ func removeFbConfigTempFiles() ([]string, error) {
 		}
 	}
 
-	if len(fbConfigTempFiles) > MaxNumberOfTempFiles {
+	if len(fbConfigTempFiles) > maxNumberOfFbConfigTempFiles {
 
 		var removedConfigTempFilenames []string
 
@@ -190,7 +190,7 @@ func removeFbConfigTempFiles() ([]string, error) {
 			return fileInfo1.ModTime().Before(fileInfo2.ModTime())
 		})
 
-		for i := 0; i < len(fbConfigTempFiles)-MaxNumberOfTempFiles; i++ {
+		for i := 0; i < len(fbConfigTempFiles)-maxNumberOfFbConfigTempFiles; i++ {
 
 			// TODO if windows
 			fbConfigTempFileContent, err := os.ReadFile(filepath.Join(os.TempDir(), fbConfigTempFiles[i].Name()))

--- a/pkg/integrations/v4/supervisor_fb.go
+++ b/pkg/integrations/v4/supervisor_fb.go
@@ -130,15 +130,14 @@ func buildFbExecutor(fbIntCfg FBSupervisorConfig, cfgLoader *logs.CfgLoader) fun
 			return nil, errors.Wrap(err, "failed to create temporary fb sFBLogger config file")
 		}
 
-		if removedFbConfigTempFiles, err := removeFbConfigTempFiles(MaxNumberOfFbConfigTempFiles); err != nil || removedFbConfigTempFiles != nil {
+		removedFbConfigTempFiles, err := removeFbConfigTempFiles(MaxNumberOfFbConfigTempFiles)
 
-			for _, file := range removedFbConfigTempFiles {
-				log.Debugf("Removed %s config temp file.", file)
-			}
+		if err != nil {
+			log.WithError(err).Warn("Failed removing config temp files.")
+		}
 
-			if err != nil {
-				log.WithError(err).Warn("Failed removing config temp files.")
-			}
+		for _, file := range removedFbConfigTempFiles {
+			log.Debugf("Removed %s config temp file.", file)
 		}
 
 		args := []string{

--- a/pkg/integrations/v4/supervisor_fb.go
+++ b/pkg/integrations/v4/supervisor_fb.go
@@ -40,12 +40,12 @@ const (
 	MaxNumberOfFbConfigTempFiles int = 50
 )
 
-// ErrorsList error representing a list of errors
-type ErrorsList struct {
+// errorsList error representing a list of errors
+type errorsList struct {
 	Errors []error
 }
 
-func (s *ErrorsList) Error() (err string) {
+func (s *errorsList) Error() (err string) {
 	err = "List of errors: "
 	for _, e := range s.Errors {
 		err += fmt.Sprintf("%s ", e.Error())
@@ -53,10 +53,10 @@ func (s *ErrorsList) Error() (err string) {
 	return err
 }
 
-func (s *ErrorsList) Add(e error) { s.Errors = append(s.Errors, e) }
+func (s *errorsList) Add(e error) { s.Errors = append(s.Errors, e) }
 
 // ErrorOrNil returns an error interface if the Error slice is not empty or nil otherwise
-func (s *ErrorsList) ErrorOrNil() error {
+func (s *errorsList) ErrorOrNil() error {
 	if s == nil || len(s.Errors) == 0 {
 		return nil
 	}
@@ -216,7 +216,7 @@ func removeFbConfigTempFiles(maxNumberOfFbConfigTempFiles int) ([]string, error)
 
 	var removedConfigTempFiles []string
 	var configTempFilesToRemove []string
-	var errors ErrorsList
+	var errors errorsList
 
 	// create list of fbConfigTempFiles to remove
 	for i := 0; i < len(fbConfigTempFiles)-maxNumberOfFbConfigTempFiles; i++ {

--- a/pkg/integrations/v4/supervisor_fb.go
+++ b/pkg/integrations/v4/supervisor_fb.go
@@ -192,7 +192,6 @@ func removeFbConfigTempFiles(maxNumberOfFbConfigTempFiles int) ([]string, error)
 
 		for i := 0; i < len(fbConfigTempFiles)-maxNumberOfFbConfigTempFiles; i++ {
 
-			// TODO if windows
 			fbConfigTempFileContent, err := os.ReadFile(filepath.Join(os.TempDir(), fbConfigTempFiles[i].Name()))
 
 			if err != nil {

--- a/pkg/integrations/v4/supervisor_fb.go
+++ b/pkg/integrations/v4/supervisor_fb.go
@@ -224,8 +224,8 @@ func removeFbConfigTempFiles(maxNumberOfFbConfigTempFiles int) ([]string, error)
 	}
 
 	// extract lua filter filenames from config temp files to remove
-	for _, fbLuaFilterTempFilename := range configTempFilesToRemove {
-		if fbLuaFilterTempFilenames, err := extractLuaFilterFilenames(fbLuaFilterTempFilename); err != nil {
+	for _, configTempFileToRemove := range configTempFilesToRemove {
+		if fbLuaFilterTempFilenames, err := extractLuaFilterFilenames(configTempFileToRemove); err != nil {
 			errors.Add(err)
 		} else {
 			configTempFilesToRemove = append(configTempFilesToRemove, fbLuaFilterTempFilenames...)
@@ -233,11 +233,11 @@ func removeFbConfigTempFiles(maxNumberOfFbConfigTempFiles int) ([]string, error)
 	}
 
 	// remove all config and lua filter temp files from temporary directory
-	for _, fbLuaFilterTempFilename := range configTempFilesToRemove {
-		if err := os.Remove(filepath.Join(os.TempDir(), fbLuaFilterTempFilename)); err != nil {
+	for _, configTempFileToRemove := range configTempFilesToRemove {
+		if err := os.Remove(filepath.Join(os.TempDir(), configTempFileToRemove)); err != nil {
 			errors.Add(err)
 		} else {
-			removedConfigTempFiles = append(removedConfigTempFiles, fbLuaFilterTempFilename)
+			removedConfigTempFiles = append(removedConfigTempFiles, configTempFileToRemove)
 		}
 	}
 

--- a/pkg/integrations/v4/supervisor_fb_test.go
+++ b/pkg/integrations/v4/supervisor_fb_test.go
@@ -133,7 +133,7 @@ func TestRemoveFbConfigTempFiles(t *testing.T) {
 		wantErr                  bool
 	}{
 		{
-			name:                     "Any config file is removed",
+			name:                     "No config files are removed",
 			maxNumConfFiles:          10,
 			expectedRemovedConfFiles: []string{},
 			expectedKeptConfFiles:    []string{"nr_fb_config1", "nr_fb_config2", "nr_fb_config3", "nr_fb_config4", "nr_fb_config5", "nr_fb_config6", "nr_fb_lua_filter1", "nr_fb_lua_filter2", "nr_fb_lua_filter3", "nr_fb_lua_filter4"},

--- a/pkg/integrations/v4/supervisor_fb_test.go
+++ b/pkg/integrations/v4/supervisor_fb_test.go
@@ -116,7 +116,7 @@ func TestRemoveFbConfigTempFiles(t *testing.T) {
 		{"nr_fb_config1", "nr_fb_lua_filter1,nr_fb_lua_filter2"},
 		{"nr_fb_config2", ""},
 		{"nr_fb_config3", "nr_fb_lua_filter3"},
-		{"nr_fb_config4", "nr_fb_lua_filter4"},
+		{"nr_fb_config4", "nr_fb_lua_filter0"},
 		{"nr_fb_config5", ""},
 		{"nr_fb_config6", ""},
 		{"nr_fb_lua_filter1", ""},
@@ -152,6 +152,13 @@ func TestRemoveFbConfigTempFiles(t *testing.T) {
 			expectedRemovedConfFiles: []string{"nr_fb_config1", "nr_fb_config2", "nr_fb_config3", "nr_fb_lua_filter1", "nr_fb_lua_filter2", "nr_fb_lua_filter3"},
 			expectedKeptConfFiles:    []string{"nr_fb_config4", "nr_fb_config5", "nr_fb_config6", "nr_fb_lua_filter4"},
 			wantErr:                  false,
+		},
+		{
+			name:                     "Config files 1, 2 and 3 and config lua files 1, 2 and 3 are removed. Error removing non-existing lua file 0 referenced by config file 4.",
+			maxNumConfFiles:          2,
+			expectedRemovedConfFiles: []string{"nr_fb_config1", "nr_fb_config2", "nr_fb_config3", "nr_fb_lua_filter1", "nr_fb_lua_filter2", "nr_fb_lua_filter3"},
+			expectedKeptConfFiles:    []string{"nr_fb_config4", "nr_fb_config5", "nr_fb_config6", "nr_fb_lua_filter4"},
+			wantErr:                  true,
 		},
 	}
 

--- a/pkg/integrations/v4/supervisor_fb_test.go
+++ b/pkg/integrations/v4/supervisor_fb_test.go
@@ -154,10 +154,10 @@ func TestRemoveFbConfigTempFiles(t *testing.T) {
 			wantErr:                  false,
 		},
 		{
-			name:                     "Config files 1, 2 and 3 and config lua files 1, 2 and 3 are removed. Error removing non-existing lua file 0 referenced by config file 4.",
-			maxNumConfFiles:          2,
-			expectedRemovedConfFiles: []string{"nr_fb_config1", "nr_fb_config2", "nr_fb_config3", "nr_fb_lua_filter1", "nr_fb_lua_filter2", "nr_fb_lua_filter3"},
-			expectedKeptConfFiles:    []string{"nr_fb_config4", "nr_fb_config5", "nr_fb_config6", "nr_fb_lua_filter4"},
+			name:                     "Config files 1, 2, 3, 4 and 5 and config lua files 1, 2 and 3 are removed. Error removing non-existing lua file 0 referenced by config file 4.",
+			maxNumConfFiles:          1,
+			expectedRemovedConfFiles: []string{"nr_fb_config1", "nr_fb_config2", "nr_fb_config3", "nr_fb_config4", "nr_fb_config5", "nr_fb_lua_filter1", "nr_fb_lua_filter2", "nr_fb_lua_filter3"},
+			expectedKeptConfFiles:    []string{"nr_fb_config6", "nr_fb_lua_filter4"},
 			wantErr:                  true,
 		},
 	}


### PR DESCRIPTION
### Context

The New Relic Logging Platform team has identified an issue that eventually could fill up the disk where the infrastructure agent is installed. This issue is  related to the FluentBit plugging. Every time the plugging detects some change in the logging config file or in the hostname of the machine, creates a new config temp file in the temporary directory with the pattern _nr_fb_config#####_. Depending on the plugging configuration, some other temp config files with pattern _nr_fb_lua_filter#####_  could also be created in the same directory. If these files are never removed it could cause a full disk error with the corresponding consequences for the customers.  

### The solution

The code included in this pull request prevents the creation of config temp files indefinitely by placing a limit on the number of files that can be stored in the temporary directory at one time. Just after a new config temp file is created the _removeFbConfigTempFiles_ function is invoked. This function reads the temporary directory and checks if the limit of number of files (50 by default) has been reached. If so, it removes the oldest _nr_fb_config#####_ files and the _nr_fb_lua_filter#####_ ones referenced by them until the number reaches that limit. In the case of some error during this process, a warning log is written and the agent keeps running without any inconvenience.

This pull request includes the corresponding unit tests to check the solution.

### Ticket

- https://issues.newrelic.com/browse/NR-72398

  