### PR TITLE
NEWRELIC-6817 ci: replace macos-11 for macos-13

### DIFF
--- a/.github/workflows/component_macos_harvest_test.yml
+++ b/.github/workflows/component_macos_harvest_test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macos-11, macos-12 ]
+        os: [ macos-12, macos-13 ]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/component_macos_linter.yml
+++ b/.github/workflows/component_macos_linter.yml
@@ -10,7 +10,7 @@ jobs:
 
   run-lint:
     name: Lint tests
-    runs-on: macos-11
+    runs-on: macos-13
     continue-on-error: true
 
     steps:

--- a/.github/workflows/component_macos_unit_test.yml
+++ b/.github/workflows/component_macos_unit_test.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   unit-test-macos:
     name: unit tests
-    runs-on: macos-11
+    runs-on: macos-13
 
     steps:
       - uses: actions/checkout@v2

--- a/internal/plugins/darwin/hostinfo_test.go
+++ b/internal/plugins/darwin/hostinfo_test.go
@@ -6,9 +6,10 @@
 package darwin
 
 import (
+	"testing"
+
 	"github.com/newrelic/infrastructure-agent/internal/plugins/common"
 	testing2 "github.com/newrelic/infrastructure-agent/internal/plugins/testing"
-	"testing"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
Macos-13 runners still not available: https://github.com/actions/runner-images/issues/6426