### PR TITLE
NR-72398 - Do not let Infra Agent's Fluent Bit config files fill up the disk

### DIFF
--- a/pkg/integrations/v4/supervisor_fb.go
+++ b/pkg/integrations/v4/supervisor_fb.go
@@ -206,8 +206,8 @@ func removeFbConfigTempFiles(maxNumberOfFbConfigTempFiles int) ([]string, error)
 		return fileInfo1.ModTime().Before(fileInfo2.ModTime())
 	})
 
-	var removedConfigTempFiles []string
 	var configTempFilesToRemove []string
+	var removedConfigTempFiles []string
 	var listErrors listError
 
 	// create list of fbConfigTempFiles to remove

--- a/pkg/integrations/v4/supervisor_fb_test.go
+++ b/pkg/integrations/v4/supervisor_fb_test.go
@@ -5,6 +5,7 @@ package v4
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	executor2 "github.com/newrelic/infrastructure-agent/internal/integrations/v4/executor"
@@ -104,4 +105,95 @@ func TestFBSupervisorConfig_LicenseKeyShouldBePassedAsEnvVar(t *testing.T) {
 
 	assert.Contains(t, exec.(*executor2.Executor).Cfg.Environment, "NR_LICENSE_KEY_ENV_VAR")       // nolint:forcetypeassert
 	assert.Equal(t, exec.(*executor2.Executor).Cfg.Environment["NR_LICENSE_KEY_ENV_VAR"], license) //nolint:forcetypeassert
+}
+
+func TestRemoveFbConfigTempFiles(t *testing.T) {
+
+	configFiles := []struct {
+		name    string
+		content string
+	}{
+		{"nr_fb_config1", "nr_fb_lua_filter1,nr_fb_lua_filter2"},
+		{"nr_fb_config2", ""},
+		{"nr_fb_config3", "nr_fb_lua_filter3"},
+		{"nr_fb_config4", "nr_fb_lua_filter0"},
+		{"nr_fb_config5", ""},
+		{"nr_fb_config6", ""},
+		{"nr_fb_lua_filter1", ""},
+		{"nr_fb_lua_filter2", ""},
+		{"nr_fb_lua_filter3", ""},
+		{"nr_fb_lua_filter4", ""},
+	}
+
+	tests := []struct {
+		name                     string
+		maxNumConfFiles          int
+		expectedRemovedConfFiles []string
+		expectedKeptConfFiles    []string
+		wantErr                  bool
+	}{
+		{
+			name:                     "No config files are removed",
+			maxNumConfFiles:          10,
+			expectedRemovedConfFiles: []string{},
+			expectedKeptConfFiles:    []string{"nr_fb_config1", "nr_fb_config2", "nr_fb_config3", "nr_fb_config4", "nr_fb_config5", "nr_fb_config6", "nr_fb_lua_filter1", "nr_fb_lua_filter2", "nr_fb_lua_filter3", "nr_fb_lua_filter4"},
+			wantErr:                  false,
+		},
+		{
+			name:                     "Config file 1 and config lua files 1 and 2 are removed",
+			maxNumConfFiles:          5,
+			expectedRemovedConfFiles: []string{"nr_fb_config1", "nr_fb_lua_filter1", "nr_fb_lua_filter2"},
+			expectedKeptConfFiles:    []string{"nr_fb_config2", "nr_fb_config3", "nr_fb_config4", "nr_fb_config5", "nr_fb_config6", "nr_fb_lua_filter3", "nr_fb_lua_filter4"},
+			wantErr:                  false,
+		},
+		{
+			name:                     "Config files 1, 2 and 3 and config lua files 1, 2 and 3 are removed",
+			maxNumConfFiles:          3,
+			expectedRemovedConfFiles: []string{"nr_fb_config1", "nr_fb_config2", "nr_fb_config3", "nr_fb_lua_filter1", "nr_fb_lua_filter2", "nr_fb_lua_filter3"},
+			expectedKeptConfFiles:    []string{"nr_fb_config4", "nr_fb_config5", "nr_fb_config6", "nr_fb_lua_filter4"},
+			wantErr:                  false,
+		},
+		{
+			name:                     "Config files 1, 2, 3, 4 and 5 and config lua files 1, 2 and 3 are removed. Error removing non-existing lua file 0 referenced by config file 4.",
+			maxNumConfFiles:          1,
+			expectedRemovedConfFiles: []string{"nr_fb_config1", "nr_fb_config2", "nr_fb_config3", "nr_fb_config4", "nr_fb_config5", "nr_fb_lua_filter1", "nr_fb_lua_filter2", "nr_fb_lua_filter3"},
+			expectedKeptConfFiles:    []string{"nr_fb_config6", "nr_fb_lua_filter4"},
+			wantErr:                  true,
+		},
+	}
+
+	for _, tt := range tests {
+
+		// create temp directory and set it as default directory to use for temporary files
+		tmpDir := t.TempDir()
+		t.Setenv("TMPDIR", tmpDir)
+
+		t.Run(tt.name, func(t *testing.T) {
+
+			// create config files in temp directory
+			for _, file := range configFiles {
+				addFile(t, tmpDir, file.name, file.content)
+			}
+
+			got, err := removeFbConfigTempFiles(tt.maxNumConfFiles)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("removeFbConfigTempFiles() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			// read the remaining config file names from the temp directory
+			files, err := os.Open(tmpDir)
+			require.NoError(t, err)
+			keptConfTempFilenames, err := files.Readdirnames(0)
+			require.NoError(t, err)
+
+			assert.ElementsMatchf(t, tt.expectedRemovedConfFiles, got, "Config files removed do not match")
+			assert.ElementsMatchf(t, tt.expectedKeptConfFiles, keptConfTempFilenames, "Config files kept do not match")
+		})
+	}
+}
+
+func addFile(t *testing.T, dir, name, contents string) {
+	filePath := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(filePath, []byte(contents), 0666))
 }

--- a/pkg/integrations/v4/supervisor_fb_test.go
+++ b/pkg/integrations/v4/supervisor_fb_test.go
@@ -107,8 +107,8 @@ func TestFBSupervisorConfig_LicenseKeyShouldBePassedAsEnvVar(t *testing.T) {
 	assert.Equal(t, exec.(*executor2.Executor).Cfg.Environment["NR_LICENSE_KEY_ENV_VAR"], license) //nolint:forcetypeassert
 }
 
+// nolint:paralleltest
 func TestRemoveFbConfigTempFiles(t *testing.T) {
-
 	configFiles := []struct {
 		name    string
 		content string
@@ -162,22 +162,21 @@ func TestRemoveFbConfigTempFiles(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-
+	for _, test := range tests {
 		// create temp directory and set it as default directory to use for temporary files
 		tmpDir := t.TempDir()
 		t.Setenv("TMPDIR", tmpDir)
 
-		t.Run(tt.name, func(t *testing.T) {
-
+		t.Run(test.name, func(t *testing.T) {
 			// create config files in temp directory
 			for _, file := range configFiles {
 				addFile(t, tmpDir, file.name, file.content)
 			}
 
-			got, err := removeFbConfigTempFiles(tt.maxNumConfFiles)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("removeFbConfigTempFiles() error = %v, wantErr %v", err, tt.wantErr)
+			got, err := removeFbConfigTempFiles(test.maxNumConfFiles)
+			if (err != nil) != test.wantErr {
+				t.Errorf("removeFbConfigTempFiles() error = %v, wantErr %v", err, test.wantErr)
+
 				return
 			}
 
@@ -187,13 +186,15 @@ func TestRemoveFbConfigTempFiles(t *testing.T) {
 			keptConfTempFilenames, err := files.Readdirnames(0)
 			require.NoError(t, err)
 
-			assert.ElementsMatchf(t, tt.expectedRemovedConfFiles, got, "Config files removed do not match")
-			assert.ElementsMatchf(t, tt.expectedKeptConfFiles, keptConfTempFilenames, "Config files kept do not match")
+			assert.ElementsMatchf(t, test.expectedRemovedConfFiles, got, "Config files removed do not match")
+			assert.ElementsMatchf(t, test.expectedKeptConfFiles, keptConfTempFilenames, "Config files kept do not match")
 		})
 	}
 }
 
+// nolint:gofumpt
 func addFile(t *testing.T, dir, name, contents string) {
+	t.Helper()
 	filePath := filepath.Join(dir, name)
-	require.NoError(t, os.WriteFile(filePath, []byte(contents), 0666))
+	require.NoError(t, os.WriteFile(filePath, []byte(contents), 0600))
 }

--- a/pkg/integrations/v4/supervisor_fb_test.go
+++ b/pkg/integrations/v4/supervisor_fb_test.go
@@ -192,9 +192,8 @@ func TestRemoveFbConfigTempFiles(t *testing.T) {
 	}
 }
 
-// nolint:gofumpt
 func addFile(t *testing.T, dir, name, contents string) {
 	t.Helper()
 	filePath := filepath.Join(dir, name)
-	require.NoError(t, os.WriteFile(filePath, []byte(contents), 0600))
+	require.NoError(t, os.WriteFile(filePath, []byte(contents), 0o0600))
 }


### PR DESCRIPTION
### Context
The New Relic Logging Platform team has identified an issue that eventually could fill up the disk where the infrastructure agent is installed. This issue is related to the FluentBit plugging. Every time the plugging detects some change in the logging config file or in the hostname of the machine, creates a new config temp file in the temporary directory with the pattern _nr_fb_config#####_. Depending on the plugging configuration, some other temp config files with pattern _nr_fb_lua_filter#####_ could also be created in the same directory. If these files are never removed it could cause a full disk error with the corresponding consequences for the customers.

### The solution
The code included in this pull request prevents the creation of config temp files indefinitely by placing a limit on the number of files that can be stored in the temporary directory at one time. Just after a new config temp file is created the removeFbConfigTempFiles function is invoked. This function reads the temporary directory and checks if the limit of number of files (50 by default) has been reached. If so, it removes the oldest _nr_fb_config#####_ files and the _nr_fb_lua_filter#####_ ones referenced by them until the number reaches that limit. In the case of some error during this process, a warning log is written and the agent keeps running without any inconvenience.

This pull request includes the corresponding unit tests to check the solution.

### Ticket
- https://issues.newrelic.com/browse/NR-72398