### PR TITLE
ci: pin trivy action version

### DIFF
--- a/.github/workflows/component_trivy.yml
+++ b/.github/workflows/component_trivy.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Sarif newrelic/infrastructure
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.8.0
         with:
           image-ref: "docker.io/newrelic/infrastructure:${{ github.event.inputs.tag }}"
           format: 'sarif'


### PR DESCRIPTION
See issue with latest Trivy version: https://github.com/aquasecurity/trivy-action/pull/213