### PR TITLE
NR-86991 - Added MemBufferLimit parameter to limit the amount of memo…

### DIFF
--- a/pkg/integrations/v4/logs/cfg.go
+++ b/pkg/integrations/v4/logs/cfg.go
@@ -26,6 +26,7 @@ const (
 	stagingEndpoint         = "https://staging-log-api.newrelic.com/log/v1"
 	logRecordModifierSource = "nri-agent"
 	defaultBufferMaxSize    = 128
+	memBufferLimit          = 16384
 	fluentBitDbName         = "fb.db"
 )
 
@@ -180,6 +181,7 @@ type FBCfgInput struct {
 	DB                    string
 	Path                  string // plugin: tail
 	BufferMaxSize         string // plugin: tail
+	MemBufferLimit        string // plugin: tail
 	PathKey               string // plugin: tail
 	SkipLongLines         string // always on
 	Systemd_Filter        string // plugin: systemd
@@ -491,13 +493,14 @@ func newFBExternalConfig(l LogExternalFBCfg) FBCfgExternal {
 
 func newFileInput(filePath string, dbPath string, tag string, bufSize int) FBCfgInput {
 	return FBCfgInput{
-		Name:          fbInputTypeTail,
-		PathKey:       "filePath",
-		Path:          filePath,
-		DB:            dbPath,
-		Tag:           tag,
-		BufferMaxSize: fmt.Sprintf("%dk", bufSize),
-		SkipLongLines: "On",
+		Name:           fbInputTypeTail,
+		PathKey:        "filePath",
+		Path:           filePath,
+		DB:             dbPath,
+		Tag:            tag,
+		BufferMaxSize:  fmt.Sprintf("%dk", bufSize),
+		MemBufferLimit: fmt.Sprintf("%dk", memBufferLimit),
+		SkipLongLines:  "On",
 	}
 }
 

--- a/pkg/integrations/v4/logs/cfg_template.go
+++ b/pkg/integrations/v4/logs/cfg_template.go
@@ -14,6 +14,9 @@ var fbConfigFormat = `{{- range .Inputs }}
     {{- if .BufferMaxSize }}
     Buffer_Max_Size {{ .BufferMaxSize }}
     {{- end }}
+	{{- if .MemBufferLimit }}
+    Mem_Buf_Limit {{ .MemBufferLimit }}
+    {{- end }}
     {{- if .SkipLongLines }}
     Skip_Long_Lines {{ .SkipLongLines }}
     {{- end }}

--- a/pkg/integrations/v4/logs/cfg_test.go
+++ b/pkg/integrations/v4/logs/cfg_test.go
@@ -95,13 +95,14 @@ func TestNewFBConf(t *testing.T) {
 		}, FBCfg{
 			Inputs: []FBCfgInput{
 				{
-					Name:          "tail",
-					Tag:           "log-file",
-					DB:            dbDbPath,
-					Path:          "file.path",
-					BufferMaxSize: "128k",
-					SkipLongLines: "On",
-					PathKey:       "filePath",
+					Name:           "tail",
+					Tag:            "log-file",
+					DB:             dbDbPath,
+					Path:           "file.path",
+					BufferMaxSize:  "128k",
+					MemBufferLimit: "16384k",
+					SkipLongLines:  "On",
+					PathKey:        "filePath",
 				},
 			},
 			Filters: []FBCfgFilter{
@@ -118,13 +119,14 @@ func TestNewFBConf(t *testing.T) {
 		}, FBCfg{
 			Inputs: []FBCfgInput{
 				{
-					Name:          "tail",
-					Tag:           "log-file",
-					DB:            dbDbPath,
-					Path:          "file.path",
-					BufferMaxSize: "128k",
-					SkipLongLines: "On",
-					PathKey:       "filePath",
+					Name:           "tail",
+					Tag:            "log-file",
+					DB:             dbDbPath,
+					Path:           "file.path",
+					BufferMaxSize:  "128k",
+					MemBufferLimit: "16384k",
+					SkipLongLines:  "On",
+					PathKey:        "filePath",
 				},
 			},
 			Filters: []FBCfgFilter{
@@ -141,13 +143,14 @@ func TestNewFBConf(t *testing.T) {
 		}, FBCfg{
 			Inputs: []FBCfgInput{
 				{
-					Name:          "tail",
-					Tag:           "log-file",
-					DB:            dbDbPath,
-					Path:          "file.path",
-					BufferMaxSize: "128k",
-					SkipLongLines: "On",
-					PathKey:       "filePath",
+					Name:           "tail",
+					Tag:            "log-file",
+					DB:             dbDbPath,
+					Path:           "file.path",
+					BufferMaxSize:  "128k",
+					MemBufferLimit: "16384k",
+					SkipLongLines:  "On",
+					PathKey:        "filePath",
 				},
 			},
 			Filters: []FBCfgFilter{
@@ -165,13 +168,14 @@ func TestNewFBConf(t *testing.T) {
 		}, FBCfg{
 			Inputs: []FBCfgInput{
 				{
-					Name:          "tail",
-					Tag:           "log-file",
-					DB:            dbDbPath,
-					Path:          "file.path",
-					BufferMaxSize: "128k",
-					SkipLongLines: "On",
-					PathKey:       "filePath",
+					Name:           "tail",
+					Tag:            "log-file",
+					DB:             dbDbPath,
+					Path:           "file.path",
+					BufferMaxSize:  "128k",
+					MemBufferLimit: "16384k",
+					SkipLongLines:  "On",
+					PathKey:        "filePath",
 				},
 			},
 			Filters: []FBCfgFilter{
@@ -223,13 +227,14 @@ func TestNewFBConf(t *testing.T) {
 		}, FBCfg{
 			Inputs: []FBCfgInput{
 				{
-					Name:          "tail",
-					Tag:           "one-file",
-					DB:            dbDbPath,
-					Path:          "/foo/file.foo",
-					BufferMaxSize: "128k",
-					SkipLongLines: "On",
-					PathKey:       "filePath",
+					Name:           "tail",
+					Tag:            "one-file",
+					DB:             dbDbPath,
+					Path:           "/foo/file.foo",
+					BufferMaxSize:  "128k",
+					MemBufferLimit: "16384k",
+					SkipLongLines:  "On",
+					PathKey:        "filePath",
 				},
 			},
 			Filters: []FBCfgFilter{
@@ -258,13 +263,14 @@ func TestNewFBConf(t *testing.T) {
 		}, FBCfg{
 			Inputs: []FBCfgInput{
 				{
-					Name:          "tail",
-					Tag:           "reserved-test",
-					DB:            dbDbPath,
-					Path:          "/foo/file.foo",
-					BufferMaxSize: "128k",
-					SkipLongLines: "On",
-					PathKey:       "filePath",
+					Name:           "tail",
+					Tag:            "reserved-test",
+					DB:             dbDbPath,
+					Path:           "/foo/file.foo",
+					BufferMaxSize:  "128k",
+					MemBufferLimit: "16384k",
+					SkipLongLines:  "On",
+					PathKey:        "filePath",
 				},
 			},
 			Filters: []FBCfgFilter{

--- a/pkg/integrations/v4/logs/loader_test.go
+++ b/pkg/integrations/v4/logs/loader_test.go
@@ -55,13 +55,14 @@ logs:
 	expectedCfg := FBCfg{
 		Inputs: []FBCfgInput{
 			{
-				Name:          "tail",
-				Tag:           "foo",
-				Path:          "/file/path",
-				BufferMaxSize: "128k",
-				DB:            dbDbPath,
-				SkipLongLines: "On",
-				PathKey:       "filePath",
+				Name:           "tail",
+				Tag:            "foo",
+				Path:           "/file/path",
+				BufferMaxSize:  "128k",
+				MemBufferLimit: "16384k",
+				DB:             dbDbPath,
+				SkipLongLines:  "On",
+				PathKey:        "filePath",
 			},
 		},
 		Filters: []FBCfgFilter{
@@ -172,13 +173,14 @@ func TestCfgLoader_LoadAll_TroubleshootLogFile(t *testing.T) {
 	assert.Equal(t, FBCfg{
 		Inputs: []FBCfgInput{
 			{
-				Name:          "tail",
-				DB:            dbDbPath,
-				Path:          "/agent_log_file",
-				BufferMaxSize: "128k",
-				SkipLongLines: "On",
-				PathKey:       "filePath",
-				Tag:           fluentBitTagTroubleshoot,
+				Name:           "tail",
+				DB:             dbDbPath,
+				Path:           "/agent_log_file",
+				BufferMaxSize:  "128k",
+				MemBufferLimit: "16384k",
+				SkipLongLines:  "On",
+				PathKey:        "filePath",
+				Tag:            fluentBitTagTroubleshoot,
 			},
 		},
 		Filters: []FBCfgFilter{


### PR DESCRIPTION
### Context
In some specific situations, the td-agent-bit process consumes a very large amount of memory, filling the server's swap capacity and putting at risk of crashing. It happens when the a user configures the Infra-Agent log forwarder to tag huge files or several files using a wildcard. This can cause the Infra-Agent to consume an unbounded amount of memory.

### The solution
Added a new _memBufferLimit_ constant with value 16384 (KBs) linked to Input Tail plugin _Mem_Buf_Limit_ option. This is the maximum amount of memory that Tail plugin will be able to use when appending data to the Engine. If the limit is reach, it will be paused; when the data is flushed it resumes. This configuration avoids the above scenario.

### Ticket
- https://issues.newrelic.com/browse/NR-86991

### More info

- https://docs.fluentbit.io/manual/administration/backpressure
- https://docs.fluentbit.io/manual/pipeline/inputs/tail