### PR TITLE
NR-93077 feat: use custom tmp folder

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,13 @@ linters-settings:
     allow-assign-and-anything: true
   funlen:
     lines: 100
+  gci:
+    sections:
+      - standard # Standard section: captures all standard packages.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - prefix(github.com/newrelic/infrastructure-agent) # Custom section: groups all imports with the specified Prefix.
+#      - blank # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
+
 
 linters:
   enable-all: true

--- a/cmd/newrelic-infra/initialize/initialize.go
+++ b/cmd/newrelic-infra/initialize/initialize.go
@@ -1,0 +1,45 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Package initialize performs OS-specific initialization actions during the
+// startup of the agent. The execution order of the functions in this package is:
+// 1 - OsProcess (when the operating system process starts and the configuration is loaded)
+// 2 - AgentService (before the Agent starts)
+package initialize
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/newrelic/infrastructure-agent/pkg/config"
+)
+
+const tempFolderMode = 0o755
+
+var (
+	removeFunc = os.RemoveAll // nolint:gochecknoglobals
+	mkdirFunc  = os.MkdirAll  // nolint:gochecknoglobals
+)
+
+// nolint:godot
+// emptyTemporaryFolder deletes all files inside the default agent's temporary folder,
+// only if configuration option matches the default value.
+//
+// Default (Linux): /var/db/newrelic-infra/tmp
+// Default (MacOS AMD): /usr/local/var/db/newrelic-infra/tmp
+// Default (MacOS ARM): /opt/homebrew/var/db/newrelic-infra/tmp
+// Default (Windows): c:\ProgramData\New Relic\newrelic-infra\tmp
+func emptyTemporaryFolder(cfg *config.Config) error {
+	if cfg.AgentTempDir == agentTemporaryFolder {
+		err := removeFunc(agentTemporaryFolder)
+		if err != nil {
+			return fmt.Errorf("can't empty agent temporary folder: %w", err)
+		}
+
+		err = mkdirFunc(agentTemporaryFolder, tempFolderMode)
+		if err != nil {
+			return fmt.Errorf("can't create agent temporary folder: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/cmd/newrelic-infra/initialize/initialize_darwin_amd64.go
+++ b/cmd/newrelic-infra/initialize/initialize_darwin_amd64.go
@@ -7,12 +7,25 @@
 package initialize
 
 import (
+	"os"
+
 	"github.com/newrelic/infrastructure-agent/pkg/config"
+	"github.com/newrelic/infrastructure-agent/pkg/log"
 )
+
+const agentTemporaryFolder = "/usr/local/var/db/newrelic-infra/tmp"
 
 // AgentService performs OS-specific initialization steps for the Agent service.
 // It is executed after the initialize.osProcess function.
 func AgentService(cfg *config.Config) error {
+	err := emptyTemporaryFolder(cfg)
+	if err != nil {
+		log.WithField("temporaryFolder", agentTemporaryFolder).
+			WithError(err).
+			Error("error emptying temporary folder")
+		os.Exit(1)
+	}
+
 	return nil
 }
 

--- a/cmd/newrelic-infra/initialize/initialize_darwin_arm64.go
+++ b/cmd/newrelic-infra/initialize/initialize_darwin_arm64.go
@@ -1,0 +1,36 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Package initialize performs OS-specific initialization actions during the
+// startup of the agent. The execution order of the functions in this package is:
+// 1 - OsProcess (when the operating system process starts and the configuration is loaded)
+// 2 - AgentService (before the Agent starts)
+package initialize
+
+import (
+	"os"
+
+	"github.com/newrelic/infrastructure-agent/pkg/config"
+	"github.com/newrelic/infrastructure-agent/pkg/log"
+)
+
+const agentTemporaryFolder = "/opt/homebrew/var/db/newrelic-infra/tmp"
+
+// AgentService performs OS-specific initialization steps for the Agent service.
+// It is executed after the initialize.osProcess function.
+func AgentService(cfg *config.Config) error {
+	err := emptyTemporaryFolder(cfg)
+	if err != nil {
+		log.WithField("temporaryFolder", agentTemporaryFolder).
+			WithError(err).
+			Error("error emptying temporary folder")
+		os.Exit(1)
+	}
+
+	return nil
+}
+
+// OsProcess performs initialization steps for the OS process that contains the
+// agent. It is executed before the initialize.AgentService function.
+func OsProcess(config *config.Config) error {
+	return nil
+}

--- a/cmd/newrelic-infra/initialize/initialize_linux.go
+++ b/cmd/newrelic-infra/initialize/initialize_linux.go
@@ -22,9 +22,24 @@ import (
 	"github.com/newrelic/infrastructure-agent/pkg/log"
 )
 
+const (
+	agentTemporaryFolder       = "/var/db/newrelic-infra/tmp"
+	pidFolderPermissions       = 0o755
+	pidFilePermissions         = 0o644
+	integrationsDirPermissions = 0o755
+)
+
 // AgentService performs OS-specific initialization steps for the Agent service.
 // It is executed after the initialize.osProcess function.
 func AgentService(cfg *config.Config) error {
+	err := emptyTemporaryFolder(cfg)
+	if err != nil {
+		log.WithField("temporaryFolder", agentTemporaryFolder).
+			WithError(err).
+			Error("error emptying temporary folder")
+		os.Exit(1)
+	}
+
 	return nil
 }
 
@@ -63,7 +78,7 @@ func verifySingularity(pidfile string) error {
 	if os.IsNotExist(err) {
 		// If the user removed the pid file folder, recreate it.
 		// This only works when running the agent as root.
-		if err := os.MkdirAll(pidFolder, 0755); err != nil {
+		if err = os.MkdirAll(pidFolder, pidFolderPermissions); err != nil {
 			return fmt.Errorf("No pid-file. Can't create pid-file folder, err: %s", err.Error())
 		}
 	}
@@ -84,14 +99,13 @@ func verifySingularity(pidfile string) error {
 		}
 	}
 
-	if err := disk.WriteFile(pidfile, []byte(fmt.Sprintf("%d", os.Getpid())), 0644); err != nil {
+	if err := disk.WriteFile(pidfile, []byte(fmt.Sprintf("%d", os.Getpid())), pidFilePermissions); err != nil {
 		return fmt.Errorf("Can't write pid-file: %s", err)
 	}
 	return nil
 }
 
 func assertTempFolderOwnership(config *config.Config) error {
-
 	// Folder already exists. Check ownership.
 	if fi, err := os.Stat(config.DefaultIntegrationsTempDir); !os.IsNotExist(err) {
 		var currentUserUID string
@@ -133,7 +147,7 @@ func assertTempFolderOwnership(config *config.Config) error {
 	}
 
 	// If we got here, either the folder does not exist or we removed it, so let's create it.
-	err := os.MkdirAll(config.DefaultIntegrationsTempDir, 0755)
+	err := os.MkdirAll(config.DefaultIntegrationsTempDir, integrationsDirPermissions)
 	if err != nil {
 		log.WithField("folder", config.DefaultIntegrationsTempDir).
 			WithError(err).

--- a/cmd/newrelic-infra/initialize/initialize_test.go
+++ b/cmd/newrelic-infra/initialize/initialize_test.go
@@ -1,0 +1,95 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package initialize
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/newrelic/infrastructure-agent/pkg/config"
+	"github.com/newrelic/infrastructure-agent/pkg/log"
+	logHelper "github.com/newrelic/infrastructure-agent/test/log"
+)
+
+var (
+	errForMkdir = errors.New("this is an error for mkdir")
+	errForRmdir = errors.New("this is an error for rmdir")
+)
+
+//nolint:tparallel
+func Test_emptyTemporaryFolder(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		agentTempDir  string
+		removeFunc    func(string) error
+		mkdirFunc     func(string, os.FileMode) error
+		expectedError error
+	}{
+		{
+			name:         "Empty conf option should not be deleted",
+			agentTempDir: "",
+		},
+		{
+			name:         "Some Random Existing Path should not be deleted",
+			agentTempDir: "/some/random/path",
+		},
+		{
+			name:         "Default path should be deleted",
+			agentTempDir: agentTemporaryFolder,
+			removeFunc:   func(string) error { return nil },
+			mkdirFunc:    func(string, os.FileMode) error { return nil },
+		},
+		{
+			name:          "Error removing should log",
+			agentTempDir:  agentTemporaryFolder,
+			removeFunc:    func(string) error { return errForRmdir },
+			mkdirFunc:     func(string, os.FileMode) error { return nil },
+			expectedError: fmt.Errorf("can't empty agent temporary folder: %w", errForRmdir),
+		},
+		{
+			name:          "Error creating should log",
+			agentTempDir:  agentTemporaryFolder,
+			removeFunc:    func(string) error { return nil },
+			mkdirFunc:     func(string, os.FileMode) error { return errForMkdir },
+			expectedError: fmt.Errorf("can't create agent temporary folder: %w", errForMkdir),
+		},
+		{
+			name:          "Error creating and removing should log both",
+			agentTempDir:  agentTemporaryFolder,
+			removeFunc:    func(string) error { return errForRmdir },
+			mkdirFunc:     func(string, os.FileMode) error { return errForMkdir },
+			expectedError: fmt.Errorf("can't empty agent temporary folder: %w", errForRmdir),
+		},
+	}
+
+	defer func() {
+		removeFunc = os.RemoveAll
+		mkdirFunc = os.MkdirAll
+	}()
+
+	//nolint:paralleltest
+	for i := range testCases {
+		testCase := testCases[i]
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := &config.Config{
+				AgentTempDir: testCase.agentTempDir,
+			}
+
+			hook := logHelper.NewInMemoryEntriesHook([]logrus.Level{logrus.FatalLevel, logrus.ErrorLevel})
+			log.AddHook(hook)
+
+			mkdirFunc = testCase.mkdirFunc
+			removeFunc = testCase.removeFunc
+			err := emptyTemporaryFolder(cfg)
+			assert.Equal(t, testCase.expectedError, err)
+		})
+	}
+}

--- a/cmd/newrelic-infra/initialize/initialize_windows.go
+++ b/cmd/newrelic-infra/initialize/initialize_windows.go
@@ -9,6 +9,7 @@ package initialize
 import (
 	"errors"
 	"fmt"
+	"os"
 	"syscall"
 
 	"github.com/sirupsen/logrus"
@@ -26,6 +27,7 @@ const (
 	idlePriorityClass        = 0x00000040
 	normalPriorityClass      = 0x00000020
 	realtimePriorityClass    = 0x00000100
+	agentTemporaryFolder     = "C:\\ProgramData\\New Relic\\newrelic-infra\\tmp"
 )
 
 var priorityClasses = map[string]uint{
@@ -40,6 +42,14 @@ var priorityClasses = map[string]uint{
 // AgentService performs OS-specific initialization steps for the Agent service.
 // It is executed after the initialize.osProcess function
 func AgentService(cfg *config.Config) error {
+	err := emptyTemporaryFolder(cfg)
+	if err != nil {
+		log.WithField("temporaryFolder", agentTemporaryFolder).
+			WithError(err).
+			Error("error emptying temporary folder")
+		os.Exit(1)
+	}
+
 	logger := log.WithField("action", "AgentService")
 	// Set up Windows shared WMI Interface if active
 	if !cfg.DisableWinSharedWMI {

--- a/cmd/newrelic-infra/newrelic-infra.go
+++ b/cmd/newrelic-infra/newrelic-infra.go
@@ -8,7 +8,6 @@ import (
 	context2 "context"
 	"flag"
 	"fmt"
-	"github.com/newrelic/infrastructure-agent/cmd/newrelic-infra/dnschecks"
 	"io"
 	"net"
 	"net/http"
@@ -22,6 +21,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
+	"github.com/newrelic/infrastructure-agent/cmd/newrelic-infra/dnschecks"
 	"github.com/newrelic/infrastructure-agent/pkg/disk"
 	"github.com/newrelic/infrastructure-agent/pkg/helpers"
 	http2 "github.com/newrelic/infrastructure-agent/pkg/http"
@@ -47,7 +49,6 @@ import (
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/configrequest"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/track"
 	"github.com/newrelic/infrastructure-agent/pkg/plugins"
-	"github.com/sirupsen/logrus"
 
 	"github.com/newrelic/infrastructure-agent/cmd/newrelic-infra/initialize"
 	"github.com/newrelic/infrastructure-agent/internal/agent"
@@ -80,7 +81,7 @@ var (
 	debug       bool
 	cpuprofile  string
 	memprofile  string
-	//v3tov4       string
+	// v3tov4       string # v3tov4 disabled.
 	verbose      int
 	startTime    time.Time
 	buildVersion = "development"
@@ -103,7 +104,7 @@ func init() {
 	flag.BoolVar(&debug, "debug", false, "Enables agent debugging functionality")
 	flag.StringVar(&cpuprofile, "cpuprofile", "", "Writes cpu profile to `file`")
 	flag.StringVar(&memprofile, "memprofile", "", "Writes memory profile to `file`")
-	//flag.StringVar(&v3tov4, "v3tov4", "", "Converts v3 config into v4. v3tov4=/path/to/config:/path/to/definition:/path/to/output:overwrite")
+	// flag.StringVar(&v3tov4, "v3tov4", "", "Converts v3 config into v4. v3tov4=/path/to/config:/path/to/definition:/path/to/output:overwrite")
 
 	flag.IntVar(&verbose, "verbose", 0, "Higher numbers increase levels of logging. When enabled overrides provided config.")
 }
@@ -463,6 +464,7 @@ func initializeAgentAndRun(c *config.Config, logFwCfg config.LogForward) error {
 		FluentBitNRLibPath:   c.FluentBitNRLibPath,
 		FluentBitParsersPath: c.FluentBitParsersPath,
 		FluentBitVerbose:     c.Log.Level == config.LogLevelTrace && c.Log.HasIncludeFilter(config.TracesFieldName, config.SupervisorTrace),
+		ConfTemporaryFolder:  filepath.Join(c.AgentTempDir, v4.FbConfTempFolderNameDefault),
 	}
 
 	if fbIntCfg.IsLogForwarderAvailable() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,6 +57,7 @@ const (
 	TraceLogging              = 4
 	TraceTroubleshootLogging  = 5
 	defaultMemProfileInterval = 60 * 5
+	agentTemporaryFolderName  = "tmp"
 )
 
 const (
@@ -1139,6 +1140,16 @@ type Config struct {
 	// Default: none
 	// Public: Yes
 	NtpMetrics NtpConfig `yaml:"ntp_metrics" envconfig:"ntp_metrics"`
+
+	// AgentTempDir is the directory where the agent stores temporary files (i.e. fb config, discovery...)
+	// It will be DELETED on every agent restart only if it matches default value
+	//
+	// Default (Linux): /var/db/newrelic-infra/tmp
+	// Default (MacOS AMD): /usr/local/var/db/newrelic-infra/tmp
+	// Default (MacOS ARM): /opt/homebrew/var/db/newrelic-infra/tmp
+	// Default (Windows): C:\ProgramData\New Relic\newrelic-infra\tmp
+	// Public: no
+	AgentTempDir string `yaml:"-" envconfig:"-"`
 }
 
 // Troubleshoot trobleshoot mode configuration.
@@ -1686,6 +1697,7 @@ func NewConfig() *Config {
 		IncludeMetricsMatchers:      defaultMetricsMatcherConfig,
 		InventoryQueueLen:           DefaultInventoryQueue,
 		NtpMetrics:                  NewNtpConfig(),
+		AgentTempDir:                defaultAgentTempDir,
 	}
 }
 

--- a/pkg/config/config_darwin_amd64.go
+++ b/pkg/config/config_darwin_amd64.go
@@ -12,4 +12,5 @@ func init() { //nolint:gochecknoinits
 		filepath.Join("/usr", "local", "etc", "newrelic-infra", "newrelic-infra.yml"),
 	}
 	defaultAgentDir = filepath.Join("/usr", "local", "var", "db", "newrelic-infra")
+	defaultAgentTempDir = filepath.Join(defaultAgentDir, agentTemporaryFolderName)
 }

--- a/pkg/config/config_darwin_arm64.go
+++ b/pkg/config/config_darwin_arm64.go
@@ -12,4 +12,5 @@ func init() { //nolint:gochecknoinits
 		filepath.Join("/opt", "homebrew", "etc", "newrelic-infra", "newrelic-infra.yml"),
 	}
 	defaultAgentDir = filepath.Join("/opt", "homebrew", "var", "db", "newrelic-infra")
+	defaultAgentTempDir = filepath.Join(defaultAgentDir, agentTemporaryFolderName)
 }

--- a/pkg/config/config_darwin_test.go
+++ b/pkg/config/config_darwin_test.go
@@ -6,10 +6,12 @@
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -39,6 +41,8 @@ custom_attributes:
 	assert.Equal(t, 0, cfg.Log.Rotate.MaxFiles)
 	assert.Equal(t, false, cfg.Log.Rotate.CompressionEnabled)
 	assert.Equal(t, "", cfg.Log.Rotate.FilePattern)
+
+	assert.Equal(t, filepath.Join(cfg.AgentDir, agentTemporaryFolderName), cfg.AgentTempDir)
 }
 
 func TestRotateConfig(t *testing.T) {

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -49,6 +49,8 @@ func init() {
 
 	// this is the default dir the infra sdk uses to store "temporary" data
 	defaultIntegrationsTempDir = filepath.Join("/tmp", "nr-integrations")
+
+	defaultAgentTempDir = filepath.Join(defaultAgentDir, agentTemporaryFolderName)
 }
 
 func configOverride(cfg *Config) {

--- a/pkg/config/config_linux_test.go
+++ b/pkg/config/config_linux_test.go
@@ -3,11 +3,12 @@
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	. "gopkg.in/check.v1"
 )
 
@@ -125,6 +126,8 @@ log:
 	assert.Equal(t, 0, cfg.Log.Rotate.MaxFiles)
 	assert.Equal(t, false, cfg.Log.Rotate.CompressionEnabled)
 	assert.Equal(t, "", cfg.Log.Rotate.FilePattern)
+
+	assert.Equal(t, filepath.Join(cfg.AgentDir, agentTemporaryFolderName), cfg.AgentTempDir)
 }
 
 func TestRotateConfig(t *testing.T) {

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -68,6 +68,8 @@ func init() {
 	defaultFluentBitExe = "fluent-bit.exe"
 	defaultFluentBitParsers = "parsers.conf"
 	defaultFluentBitNRLib = "out_newrelic.dll"
+
+	defaultAgentTempDir = filepath.Join(defaultAppDataDir, agentTemporaryFolderName)
 }
 
 func runtimeValues() (userMode, agentUser, executablePath string) {

--- a/pkg/config/config_windows_test.go
+++ b/pkg/config/config_windows_test.go
@@ -6,10 +6,12 @@
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -38,6 +40,8 @@ log:
 	assert.Equal(t, 5, cfg.Log.Rotate.MaxFiles)
 	assert.Equal(t, true, cfg.Log.Rotate.CompressionEnabled)
 	assert.Equal(t, "", cfg.Log.Rotate.FilePattern)
+
+	assert.Equal(t, filepath.Join(cfg.AppDataDir, agentTemporaryFolderName), cfg.AgentTempDir)
 }
 
 func TestRotateConfig(t *testing.T) {

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -111,6 +111,7 @@ var (
 )
 
 // Default internal values
+// nolint:gochecknoglobals
 var (
 	defaultAgentDir                string
 	defaultConfigFiles             []string
@@ -127,6 +128,7 @@ var (
 	defaultFluentBitParsers        string
 	defaultFluentBitNRLib          string
 	defaultIntegrationsTempDir     string
+	defaultAgentTempDir            string
 )
 
 func getDefaultFacterHomeDir() (string, error) {


### PR DESCRIPTION
This PR adds 
* a custom `tmp` folder for the Infra Agent, not to use the OS one.
* refactored FB temp files to be stored in the new `tmp` folder