### PR TITLE
NR-98861 fix:use GH API to get the previous tag of given tag

### DIFF
--- a/.github/actions/external_runner/main.go
+++ b/.github/actions/external_runner/main.go
@@ -224,10 +224,10 @@ func printLogsInfo(params Config, taskID string) {
 	fmt.Fprintf(log.Writer(), "Fetching logs from: %s\n", source)
 	fmt.Fprintf(log.Writer(), "Tail logs:\n")
 	fmt.Fprintf(log.Writer(), "    tools/aws_logs.sh --group-name=/%s --stream-name=%s --tail\n",
-		params.CloudWatchLogsStreamName, source)
+		params.CloudWatchLogsGroupName, source)
 	fmt.Fprintf(log.Writer(), "Download full logs:\n")
 	fmt.Fprintf(log.Writer(), "    tools/aws_logs.sh --group-name=/%s --stream-name=%s --output-file=%s.txt\n",
-		params.CloudWatchLogsStreamName, source, params.ActionID)
+		params.CloudWatchLogsGroupName, source, params.ActionID)
 }
 
 // ContainerOverride returns a list of containers definition with an override command

--- a/tools/provision-alerts/alerts.mk
+++ b/tools/provision-alerts/alerts.mk
@@ -9,9 +9,9 @@ provision-alerts/fetch-inventory:
 .PHONY: provision-alerts/pre-release
 provision-alerts/pre-release: validate-aws-credentials ec2-install-deps ec2-build provision-alerts/fetch-inventory
 	@echo "creating alerts with inventory from $(CURDIR)/tools/provision-alerts/inventory.ec2"
-	bash $(CURDIR)/tools/provision-alerts/create_alerts.sh $(CURDIR)/tools/provision-alerts/inventory.ec2 $(NR_API_KEY)
+	bash $(CURDIR)/tools/provision-alerts/create_alerts.sh $(CURDIR)/tools/provision-alerts/inventory.ec2 $(NR_API_KEY) $(TAG)
 	@echo "creating alerts with inventory from $(CURDIR)/tools/provision-alerts/inventory.macos.ec2"
-	bash $(CURDIR)/tools/provision-alerts/create_alerts.sh $(CURDIR)/tools/provision-alerts/inventory.macos.ec2 $(NR_API_KEY)
+	bash $(CURDIR)/tools/provision-alerts/create_alerts.sh $(CURDIR)/tools/provision-alerts/inventory.macos.ec2 $(NR_API_KEY) $(TAG)
 
 .PHONY: provision-alerts-install-deps
 provision-alerts-install-deps:

--- a/tools/provision-alerts/create_alerts.sh
+++ b/tools/provision-alerts/create_alerts.sh
@@ -2,6 +2,7 @@
 
 INVENTORY=$1
 API_KEY=$2
+CURRENT_TAG=$3
 
 export TEMPLATE="tools/provision-alerts/template/template.yml"
 export PREFIX="[pre-release]"

--- a/tools/spin-ec2/main.go
+++ b/tools/spin-ec2/main.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"math/rand"
 	"net/http"
@@ -300,6 +301,10 @@ func cliMode() {
 
 	cmdPrune.PersistentFlags().Bool("dry_run", false, "dry run")
 	viper.BindPFlag("dry_run", cmdPrune.PersistentFlags().Lookup("dry_run"))
+
+	cmdPreviousCanaryVersion.PersistentFlags().StringP("tag", "t", "", "the reference tag to look previous for")
+	viper.BindPFlag("tag", cmdPreviousCanaryVersion.PersistentFlags().Lookup("tag"))
+	cmdPreviousCanaryVersion.MarkPersistentFlagRequired("tag")
 
 	cmdRoot := &cobra.Command{Use: "spin-ec2"}
 	cmdRoot.AddCommand(cmdCanaries)
@@ -625,17 +630,56 @@ func pruneCanaries(cmd *cobra.Command, args []string) error {
 	return terminateInstances(idsToTerminate, instances, dryRun)
 }
 
-// previousCanaryVersion returned previous version of canaries
-// based on ec2 instances.
+// previousCanaryVersion returned previous agent version of the provided tag
+// using github api. Quick and dirty as we are moving to create alerts with terraform
+// and this is only used for that purpose
 func previousCanaryVersion(cmd *cobra.Command, args []string) error {
-	instances, err := getAWSInstances(hostPrefix+":v", "")
-	if err != nil {
-		return err
-	}
+	tag := viper.GetString("tag")
+	perPage := 100
+	page := 1
+	client := http.DefaultClient
+	previousVersion := "previous version not found :("
 
-	previousVersion, err := getPreviousCanaryVersion(instances)
-	if err != nil {
-		return err
+	var tags []string
+	for {
+		url := fmt.Sprintf("https://api.github.com/repos/newrelic/infrastructure-agent/releases?page=%d&per_page=%d", page, perPage)
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			return err
+		}
+		req.Header.Add("Accept", "application/vnd.github+json")
+		req.Header.Add("X-GitHub-Api-Version", "2022-11-28")
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		if resp.StatusCode != 200 {
+			return fmt.Errorf("expected response code was 200 and got %d", resp.StatusCode)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		var tagsResp []struct {
+			TagName string `json:"tag_name"`
+		}
+		err = json.Unmarshal(body, &tagsResp)
+		if err != nil {
+			return err
+		}
+		if len(tagsResp) == 0 {
+			break
+		}
+		for i := range tagsResp {
+			tags = append(tags, tagsResp[i].TagName)
+		}
+		page++
+	}
+	semver.Sort(tags)
+	for i := 0; i < len(tags); i++ {
+		if tags[i] == tag && i > 1 {
+			previousVersion = tags[i-1]
+		}
 	}
 
 	fmt.Printf("%s", previousVersion)

--- a/tools/spin-ec2/main.go
+++ b/tools/spin-ec2/main.go
@@ -635,6 +635,17 @@ func pruneCanaries(cmd *cobra.Command, args []string) error {
 // and this is only used for that purpose
 func previousCanaryVersion(cmd *cobra.Command, args []string) error {
 	tag := viper.GetString("tag")
+
+	previousVersion, err := getPreviousVersion(tag)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s", previousVersion)
+
+	return nil
+}
+
+func getPreviousVersion(referenceVersion string) (string, error) {
 	perPage := 100
 	page := 1
 	client := http.DefaultClient
@@ -645,27 +656,27 @@ func previousCanaryVersion(cmd *cobra.Command, args []string) error {
 		url := fmt.Sprintf("https://api.github.com/repos/newrelic/infrastructure-agent/releases?page=%d&per_page=%d", page, perPage)
 		req, err := http.NewRequest("GET", url, nil)
 		if err != nil {
-			return err
+			return "", err
 		}
 		req.Header.Add("Accept", "application/vnd.github+json")
 		req.Header.Add("X-GitHub-Api-Version", "2022-11-28")
 		resp, err := client.Do(req)
 		if err != nil {
-			return err
+			return "", err
 		}
 		if resp.StatusCode != 200 {
-			return fmt.Errorf("expected response code was 200 and got %d", resp.StatusCode)
+			return "", fmt.Errorf("expected response code was 200 and got %d", resp.StatusCode)
 		}
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return err
+			return "", err
 		}
 		var tagsResp []struct {
 			TagName string `json:"tag_name"`
 		}
 		err = json.Unmarshal(body, &tagsResp)
 		if err != nil {
-			return err
+			return "", err
 		}
 		if len(tagsResp) == 0 {
 			break
@@ -677,14 +688,11 @@ func previousCanaryVersion(cmd *cobra.Command, args []string) error {
 	}
 	semver.Sort(tags)
 	for i := 0; i < len(tags); i++ {
-		if tags[i] == tag && i > 1 {
+		if tags[i] == referenceVersion && i > 1 {
 			previousVersion = tags[i-1]
 		}
 	}
-
-	fmt.Printf("%s", previousVersion)
-
-	return nil
+	return previousVersion, nil
 }
 
 // latestRelease returns tha latest release (pre-released not taken into account)

--- a/tools/spin-ec2/main_test.go
+++ b/tools/spin-ec2/main_test.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_previousCanaryVersion(t *testing.T) {
+	testCases := []struct {
+		name             string
+		referenceVersion string
+		expectedVersion  string
+	}{
+		{
+			name:             "patch version",
+			referenceVersion: "1.33.2",
+			expectedVersion:  "1.33.1",
+		},
+		{
+			name:             "minor version",
+			referenceVersion: "1.34.0",
+			expectedVersion:  "1.33.2",
+		},
+	}
+
+	for i := range testCases {
+		testCase := testCases[i]
+		t.Run(testCase.name, func(t *testing.T) {
+			previousVersion, err := getPreviousVersion(testCase.referenceVersion)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expectedVersion, previousVersion)
+		})
+	}
+}


### PR DESCRIPTION
Canaries alerts provisioning is broken as the previous version was retrieved from inventory and we don't have that anymore. 

This is a quick&dirty solution to get the previous version using GH API and it's tempñorary as we are moving to Terraform and we'll need to manage it differently.