### PR TITLE
Update nri-winservice to v1.0.0 (NR-97468)

### DIFF
--- a/build/embed/integrations.version
+++ b/build/embed/integrations.version
@@ -1,5 +1,5 @@
 #ohi-repo-name,version
 nri-docker,v1.8.0
 nri-flex,v1.7.2
-nri-winservices,v0.6.0-beta
+nri-winservices,v1.0.0
 nri-prometheus,v2.18.0


### PR DESCRIPTION
- Bumps `nri-winservice` to the first stable version [v1.0.0](https://github.com/newrelic/nri-winservices/releases/tag/v1.0.0).