### PR TITLE
fix: use agent tmp folder only in windows

### DIFF
--- a/cmd/newrelic-infra/initialize/initialize_darwin_amd64.go
+++ b/cmd/newrelic-infra/initialize/initialize_darwin_amd64.go
@@ -7,25 +7,15 @@
 package initialize
 
 import (
-	"os"
-
 	"github.com/newrelic/infrastructure-agent/pkg/config"
-	"github.com/newrelic/infrastructure-agent/pkg/log"
 )
 
+// only used in windows. it will be refactored.
 const agentTemporaryFolder = "/usr/local/var/db/newrelic-infra/tmp"
 
 // AgentService performs OS-specific initialization steps for the Agent service.
 // It is executed after the initialize.osProcess function.
 func AgentService(cfg *config.Config) error {
-	err := emptyTemporaryFolder(cfg)
-	if err != nil {
-		log.WithField("temporaryFolder", agentTemporaryFolder).
-			WithError(err).
-			Error("error emptying temporary folder")
-		os.Exit(1)
-	}
-
 	return nil
 }
 

--- a/cmd/newrelic-infra/initialize/initialize_darwin_arm64.go
+++ b/cmd/newrelic-infra/initialize/initialize_darwin_arm64.go
@@ -7,25 +7,15 @@
 package initialize
 
 import (
-	"os"
-
 	"github.com/newrelic/infrastructure-agent/pkg/config"
-	"github.com/newrelic/infrastructure-agent/pkg/log"
 )
 
+// only used in windows. it will be refactored.
 const agentTemporaryFolder = "/opt/homebrew/var/db/newrelic-infra/tmp"
 
 // AgentService performs OS-specific initialization steps for the Agent service.
 // It is executed after the initialize.osProcess function.
 func AgentService(cfg *config.Config) error {
-	err := emptyTemporaryFolder(cfg)
-	if err != nil {
-		log.WithField("temporaryFolder", agentTemporaryFolder).
-			WithError(err).
-			Error("error emptying temporary folder")
-		os.Exit(1)
-	}
-
 	return nil
 }
 

--- a/cmd/newrelic-infra/initialize/initialize_linux.go
+++ b/cmd/newrelic-infra/initialize/initialize_linux.go
@@ -32,14 +32,6 @@ const (
 // AgentService performs OS-specific initialization steps for the Agent service.
 // It is executed after the initialize.osProcess function.
 func AgentService(cfg *config.Config) error {
-	err := emptyTemporaryFolder(cfg)
-	if err != nil {
-		log.WithField("temporaryFolder", agentTemporaryFolder).
-			WithError(err).
-			Error("error emptying temporary folder")
-		os.Exit(1)
-	}
-
 	return nil
 }
 

--- a/pkg/config/config_darwin_amd64.go
+++ b/pkg/config/config_darwin_amd64.go
@@ -3,6 +3,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 )
 
@@ -12,5 +13,5 @@ func init() { //nolint:gochecknoinits
 		filepath.Join("/usr", "local", "etc", "newrelic-infra", "newrelic-infra.yml"),
 	}
 	defaultAgentDir = filepath.Join("/usr", "local", "var", "db", "newrelic-infra")
-	defaultAgentTempDir = filepath.Join(defaultAgentDir, agentTemporaryFolderName)
+	defaultAgentTempDir = os.TempDir()
 }

--- a/pkg/config/config_darwin_arm64.go
+++ b/pkg/config/config_darwin_arm64.go
@@ -3,6 +3,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 )
 
@@ -12,5 +13,5 @@ func init() { //nolint:gochecknoinits
 		filepath.Join("/opt", "homebrew", "etc", "newrelic-infra", "newrelic-infra.yml"),
 	}
 	defaultAgentDir = filepath.Join("/opt", "homebrew", "var", "db", "newrelic-infra")
-	defaultAgentTempDir = filepath.Join(defaultAgentDir, agentTemporaryFolderName)
+	defaultAgentTempDir = os.TempDir()
 }

--- a/pkg/config/config_darwin_test.go
+++ b/pkg/config/config_darwin_test.go
@@ -8,7 +8,6 @@ package config
 import (
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,7 +41,7 @@ custom_attributes:
 	assert.Equal(t, false, cfg.Log.Rotate.CompressionEnabled)
 	assert.Equal(t, "", cfg.Log.Rotate.FilePattern)
 
-	assert.Equal(t, filepath.Join(cfg.AgentDir, agentTemporaryFolderName), cfg.AgentTempDir)
+	assert.Equal(t, os.TempDir(), cfg.AgentTempDir)
 }
 
 func TestRotateConfig(t *testing.T) {

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -50,7 +50,7 @@ func init() {
 	// this is the default dir the infra sdk uses to store "temporary" data
 	defaultIntegrationsTempDir = filepath.Join("/tmp", "nr-integrations")
 
-	defaultAgentTempDir = filepath.Join(defaultAgentDir, agentTemporaryFolderName)
+	defaultAgentTempDir = os.TempDir()
 }
 
 func configOverride(cfg *Config) {

--- a/pkg/config/config_linux_test.go
+++ b/pkg/config/config_linux_test.go
@@ -5,7 +5,6 @@ package config
 import (
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -127,7 +126,7 @@ log:
 	assert.Equal(t, false, cfg.Log.Rotate.CompressionEnabled)
 	assert.Equal(t, "", cfg.Log.Rotate.FilePattern)
 
-	assert.Equal(t, filepath.Join(cfg.AgentDir, agentTemporaryFolderName), cfg.AgentTempDir)
+	assert.Equal(t, os.TempDir(), cfg.AgentTempDir)
 }
 
 func TestRotateConfig(t *testing.T) {


### PR DESCRIPTION
Only use agent `/tmp` folder in windows. In K8S it might be broken wen fs is mounted as `ro`