### PR TITLE
Print original length instead of the limit

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1034,7 +1034,7 @@ func (c *context) SendEvent(event sample.Event, entityKey entity.Key) {
 		if truncated {
 			aclog.
 				WithField("entity_key", entityKey.String()).
-				WithField("length", metric.NRDBLimit).
+				WithField("length", len(origValue)).
 				WithField("original", origValue).
 				WithField("truncated", fmt.Sprintf("+%v", event)).
 				Warn("event truncated to NRDB limit")


### PR DESCRIPTION
Logging the limit just logs a static known value.
Instead logging the length of the original data helps us
undestand the size of the attributes being sent to the
forwarder.
