### PR TITLE
Cciutea/fixmsi

### DIFF
--- a/build/package/windows/newrelic-infra-386-installer/newrelic-infra/Product.wxs
+++ b/build/package/windows/newrelic-infra-386-installer/newrelic-infra/Product.wxs
@@ -192,10 +192,19 @@
             ExeCommand="cmd /C &quot;dir /al /s &quot;[NewRelicInfraDataFolder]&quot; >nul 2>&amp;1 &quot; &amp;&amp; (EXIT /B 1) || (EXIT /B 0)"
             Execute="deferred"
             Impersonate="no" />
+
+        <!-- Duplicate CheckSymlinks action because SKIPSL flag is not available in older Windows 2012.
+             When support will be dropped for 2012 this CheckSymlinks2 can be removed and add /SKIPSL flag to takeown command.
+        -->
+        <CustomAction Id="CheckSymlinks2"
+            Directory="NewRelicInfraDataFolder"
+            ExeCommand="cmd /C &quot;dir /al /s &quot;[NewRelicInfraDataFolder]&quot; >nul 2>&amp;1 &quot; &amp;&amp; (EXIT /B 1) || (EXIT /B 0)"
+            Execute="deferred"
+            Impersonate="no" />
             
         <InstallExecuteSequence>
             <!-- Perform the check for symolic link Only on install and not on remove -->
-            <Custom Action="CheckSymlinks" After="CreateFolders">NOT REMOVE</Custom>
+            <Custom Action="CheckSymlinks2" After="CreateFolders">NOT REMOVE</Custom>
             <Custom Action="TakeOwnership" After="CheckSymlinks">NOT REMOVE</Custom>
             <Custom Action="ResetPermissions" After="TakeOwnership">NOT REMOVE</Custom>
             <Custom Action="CheckSymlinks" After="ResetPermissions">NOT REMOVE</Custom>

--- a/build/package/windows/newrelic-infra-386-installer/newrelic-infra/Product.wxs
+++ b/build/package/windows/newrelic-infra-386-installer/newrelic-infra/Product.wxs
@@ -177,7 +177,7 @@
 
         <CustomAction Id="TakeOwnership"
             Directory="NewRelicInfraDataFolder"
-            ExeCommand="cmd /C &quot;takeown /f &quot;[NewRelicInfraDataFolder]*&quot; /a /r /SKIPSL /d N >nul 2>&amp;1&quot;"
+            ExeCommand="cmd /C &quot;takeown /f &quot;[NewRelicInfraDataFolder]*&quot; /a /r /d N >nul 2>&amp;1&quot;"
             Execute="deferred"
             Impersonate="no" />
 
@@ -195,7 +195,8 @@
             
         <InstallExecuteSequence>
             <!-- Perform the check for symolic link Only on install and not on remove -->
-            <Custom Action="TakeOwnership" After="CreateFolders">NOT REMOVE</Custom>
+            <Custom Action="CheckSymlinks" After="CreateFolders">NOT REMOVE</Custom>
+            <Custom Action="TakeOwnership" After="CheckSymlinks">NOT REMOVE</Custom>
             <Custom Action="ResetPermissions" After="TakeOwnership">NOT REMOVE</Custom>
             <Custom Action="CheckSymlinks" After="ResetPermissions">NOT REMOVE</Custom>
 

--- a/build/package/windows/newrelic-infra-amd64-installer/newrelic-infra/Product.wxs
+++ b/build/package/windows/newrelic-infra-amd64-installer/newrelic-infra/Product.wxs
@@ -186,7 +186,7 @@
 
         <CustomAction Id="TakeOwnership"
             Directory="NewRelicInfraDataFolder"
-            ExeCommand="cmd /C &quot;takeown /f &quot;[NewRelicInfraDataFolder]*&quot; /a /r /SKIPSL /d N >nul 2>&amp;1&quot;"
+            ExeCommand="cmd /C &quot;takeown /f &quot;[NewRelicInfraDataFolder]*&quot; /a /r /d N >nul 2>&amp;1&quot;"
             Execute="deferred"
             Impersonate="no" />
 
@@ -204,7 +204,8 @@
 
         <InstallExecuteSequence>
             <!-- Perform the check for symolic link Only on install and not on remove -->
-            <Custom Action="TakeOwnership" After="CreateFolders">NOT REMOVE</Custom>
+            <Custom Action="CheckSymlinks" After="CreateFolders">NOT REMOVE</Custom>
+            <Custom Action="TakeOwnership" After="CheckSymlinks">NOT REMOVE</Custom>
             <Custom Action="ResetPermissions" After="TakeOwnership">NOT REMOVE</Custom>
             <Custom Action="CheckSymlinks" After="ResetPermissions">NOT REMOVE</Custom>
 

--- a/build/package/windows/newrelic-infra-amd64-installer/newrelic-infra/Product.wxs
+++ b/build/package/windows/newrelic-infra-amd64-installer/newrelic-infra/Product.wxs
@@ -202,9 +202,18 @@
             Execute="deferred"
             Impersonate="no" />
 
+         <!-- Duplicate CheckSymlinks action because SKIPSL flag is not available in older Windows 2012.
+               When support will be dropped for 2012 this CheckSymlinks2 can be removed and add /SKIPSL flag to takeown command.
+          -->
+          <CustomAction Id="CheckSymlinks2"
+              Directory="NewRelicInfraDataFolder"
+              ExeCommand="cmd /C &quot;dir /al /s &quot;[NewRelicInfraDataFolder]&quot; >nul 2>&amp;1 &quot; &amp;&amp; (EXIT /B 1) || (EXIT /B 0)"
+              Execute="deferred"
+              Impersonate="no" />
+
         <InstallExecuteSequence>
             <!-- Perform the check for symolic link Only on install and not on remove -->
-            <Custom Action="CheckSymlinks" After="CreateFolders">NOT REMOVE</Custom>
+            <Custom Action="CheckSymlinks2" After="CreateFolders">NOT REMOVE</Custom>
             <Custom Action="TakeOwnership" After="CheckSymlinks">NOT REMOVE</Custom>
             <Custom Action="ResetPermissions" After="TakeOwnership">NOT REMOVE</Custom>
             <Custom Action="CheckSymlinks" After="ResetPermissions">NOT REMOVE</Custom>


### PR DESCRIPTION
This PR will remove the SKIPSL flag in the custom action performed during msi installer since is unsupported on older Windows 2012