### PR TITLE
chore: use ubuntu-20.04 runner

### DIFF
--- a/.github/workflows/component_linux_harvest_test.yml
+++ b/.github/workflows/component_linux_harvest_test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-18.04 ]
+        os: [ ubuntu-20.04 ]
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
ubuntu-18.04 was deprecated: https://github.com/actions/runner-images/issues/6002
