### PR TITLE
NR-103816: Cloud metadata client

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,4 +1,4 @@
-// Copyright 2020 New Relic Corporation. All rights reserved.
+// Copyright 2023 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 // Contains all the bits and pieces we need to parse and manage
 // the external configuration

--- a/pkg/sysinfo/cloud/client.go
+++ b/pkg/sysinfo/cloud/client.go
@@ -1,0 +1,29 @@
+// Copyright New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloud
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+var (
+	// limits the time spent establishing a TCP connection.
+	defaultDialTimeout   = 2 * time.Second
+	defaultDialKeepAlive = 30 * time.Second
+)
+
+// DRY function to construct a standard client for making cloud metadata calls that timeout quickly.
+func clientWithFastTimeout(disableKeepAlive bool) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout:   defaultDialTimeout,
+				KeepAlive: defaultDialKeepAlive,
+			}).DialContext, // time out after 2 seconds => non-cloud instance.
+			DisableKeepAlives: disableKeepAlive,
+		},
+	}
+}

--- a/pkg/sysinfo/cloud/client.go
+++ b/pkg/sysinfo/cloud/client.go
@@ -13,11 +13,15 @@ var (
 	// limits the time spent establishing a TCP connection.
 	defaultDialTimeout   = 2 * time.Second
 	defaultDialKeepAlive = 30 * time.Second
+
+	// decreased default's http client timeout to prevent the agent being initialized for 2 minutes.
+	defaultClientTimeout = 30 * time.Second
 )
 
 // DRY function to construct a standard client for making cloud metadata calls that timeout quickly.
 func clientWithFastTimeout(disableKeepAlive bool) *http.Client {
 	return &http.Client{
+		Timeout: defaultClientTimeout,
 		Transport: &http.Transport{
 			DialContext: (&net.Dialer{
 				Timeout:   defaultDialTimeout,

--- a/pkg/sysinfo/cloud/client_test.go
+++ b/pkg/sysinfo/cloud/client_test.go
@@ -1,0 +1,39 @@
+// Copyright New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloud
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHttpClientTimeout(t *testing.T) {
+	t.Parallel()
+
+	testURI := "/valid"
+	mux := http.NewServeMux()
+	mux.Handle(testURI, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(defaultDialTimeout * 2)
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("i-db519dd1\n"))
+		return
+	}))
+
+	server := httptest.NewServer(mux)
+
+	// create default fast client
+	client := clientWithFastTimeout(false)
+
+	resp, err := client.Get(fmt.Sprintf("%s/%s", server.URL, testURI))
+	defer resp.Body.Close()
+
+	// should fail as server hangs more time than the defaultDialTimeout
+	assert.Error(t, err)
+}

--- a/pkg/sysinfo/cloud/cloud.go
+++ b/pkg/sysinfo/cloud/cloud.go
@@ -4,8 +4,6 @@ package cloud
 
 import (
 	"errors"
-	"net"
-	"net/http"
 	"sync"
 	"time"
 
@@ -287,19 +285,6 @@ func (d *Detector) detect(harvesters ...Harvester) error {
 		}
 	}
 	return ErrCouldNotDetect
-}
-
-// DRY function to construct a standard client for making cloud metadata calls that timeout quickly.
-func clientWithFastTimeout(disableKeepAlive bool) *http.Client {
-	return &http.Client{
-		Transport: &http.Transport{
-			DialContext: (&net.Dialer{
-				Timeout:   2 * time.Second,
-				KeepAlive: 30 * time.Second,
-			}).DialContext, // time out after 2 seconds => non-cloud instance.
-			DisableKeepAlives: disableKeepAlive,
-		},
-	}
 }
 
 // Timeout is used to check if a period of time has passed.


### PR DESCRIPTION
Great blog about Go http timeouts: https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/

Considering that cloud metadata endpoints are local and should be very fast (we also perform retries), we set up the default timeout to 30s, it can be parametrized in the future if needed.


Linter issues:
- response body must be closed (bodyclose) -> Request will always fail and function exits before "body" is provided
- global variables -> Already defined, in the future we might want to parametrize the defaultHttpClientTimeout