### PR TITLE
Pin ubuntu 20.04 to pkg component molecule runner

### DIFF
--- a/.github/workflows/component_molecule_packaging.yml
+++ b/.github/workflows/component_molecule_packaging.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   molecule-test-packages:
     name: Test package installation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: newrelic/pkg-installation-testing-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,6 @@ jobs:
 
   molecule-packaging-tests:
     uses: ./.github/workflows/component_molecule_packaging.yml
-    needs: [publishing-to-s3-linux]
+    needs: [publishing-to-s3-linux, purge-cdn]
     with:
       TAG: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
Pin ubuntu 20.04 to pkg component molecule runner and make molecule depend on purge when releasing.