### PR TITLE
bump integrations versions

### DIFF
--- a/build/embed/integrations.version
+++ b/build/embed/integrations.version
@@ -1,5 +1,5 @@
 #ohi-repo-name,version
-nri-docker,v1.8.2
+nri-docker,v1.8.4
 nri-flex,v1.8.4
 nri-winservices,v1.0.1
-nri-prometheus,v2.18.0
+nri-prometheus,v2.18.1

--- a/build/embed/integrations.version
+++ b/build/embed/integrations.version
@@ -1,5 +1,5 @@
 #ohi-repo-name,version
 nri-docker,v1.8.2
-nri-flex,v1.8.3
+nri-flex,v1.8.4
 nri-winservices,v1.0.1
 nri-prometheus,v2.18.0


### PR DESCRIPTION
nri-flex v1.8.3 -> 1.8.4
nri-docker v1.8.2 -> 1.8.4
nri-prometheus v2.18.0 -> v2.18.1