### PR TITLE
NR-119605 chore: Bump fluent-bit-plugin to 1.17.1 (Go 1.20.5)

### DIFF
--- a/build/embed/fluent-bit.version
+++ b/build/embed/fluent-bit.version
@@ -5,5 +5,5 @@
 #
 # OS, newrelic_plugin_version, fluent-bit
 
-linux,1.9.2
-windows,1.9.2,1.9.3
+linux,1.17.1
+windows,1.17.1,1.9.3


### PR DESCRIPTION
Waiting for [this PR](https://github.com/newrelic/newrelic-fluent-bit-output/pull/132) to be released