### PR TITLE
NR-122708: handle error when no task is found

### DIFF
--- a/pkg/metrics/containerd_sampler_mock_test.go
+++ b/pkg/metrics/containerd_sampler_mock_test.go
@@ -55,15 +55,8 @@ func (mc *MockContainerContainerdImpl) Namespaces() ([]string, error) {
 }
 
 func (mc *MockContainerContainerdImpl) Containers(_ ...string) (map[string][]containerd.Container, error) {
-	// container with a running task
-	container := &MockContainerdContainer{
-		id: func() string {
-			return containerID
-		},
-		task: func(_ context.Context, _ cio.Attach) (containerd.Task, error) {
-			return &MockContainerdTask{}, nil
-		},
-	}
+	// default container with a running task
+	container := &MockContainerdContainer{}
 
 	// container without a running task
 	noRunningContainer := &MockContainerdContainer{
@@ -105,6 +98,10 @@ type MockContainerdContainer struct {
 }
 
 func (m *MockContainerdContainer) ID() string {
+	// return default containerID if no custom id function is set
+	if m.id == nil {
+		return containerID
+	}
 	return m.id()
 }
 
@@ -132,6 +129,10 @@ func (m *MockContainerdContainer) Spec(_ context.Context) (*oci.Spec, error) {
 }
 
 func (m *MockContainerdContainer) Task(ctx context.Context, attach cio.Attach) (containerd.Task, error) { //nolint:ireturn
+	// return empty task if no custom task function is set
+	if m.task == nil {
+		return &MockContainerdTask{}, nil
+	}
 	return m.task(ctx, attach)
 }
 

--- a/pkg/metrics/containerd_sampler_mock_test.go
+++ b/pkg/metrics/containerd_sampler_mock_test.go
@@ -56,7 +56,14 @@ func (mc *MockContainerContainerdImpl) Namespaces() ([]string, error) {
 
 func (mc *MockContainerContainerdImpl) Containers(_ ...string) (map[string][]containerd.Container, error) {
 	// default container with a running task
-	container := &MockContainerdContainer{}
+	container := &MockContainerdContainer{
+		id: func() string {
+			return containerID
+		},
+		task: func(_ context.Context, _ cio.Attach) (containerd.Task, error) {
+			return &MockContainerdTask{}, nil
+		},
+	}
 
 	// container without a running task
 	noRunningContainer := &MockContainerdContainer{

--- a/pkg/metrics/containerd_sampler_test.go
+++ b/pkg/metrics/containerd_sampler_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 const containerID = "container1"
+const containerID2 = "container2"
 
 func TestInitializeContainerdClient(t *testing.T) {
 	t.Parallel()
@@ -90,6 +91,10 @@ func TestContainerdProcessDecoratorDecorateProcessSample(t *testing.T) {
 
 	decorator, err := newContainerdDecorator(mock, pidsCache)
 	assert.NoError(t, err)
+
+	// ensure container without running state is not cached
+	_, found := pidsCache.get(containerID2)
+	assert.Equal(t, false, found)
 
 	process := metricTypes.ProcessSample{ProcessID: 123} //nolint:exhaustruct
 	decorator.Decorate(&process)


### PR DESCRIPTION
If the container is not running, the execution task is not available.

How to reproduce?

Run the following command twice in an instance with Containerd:

`sudo ctr run docker.io/library/nginx:latest hello`

Error:

`ctr: snapshot "hello": already exists`