### PR TITLE
Attempt to fix value not found: discovery.ip when using docker discovery

### DIFF
--- a/pkg/databind/internal/discovery/docker/docker.go
+++ b/pkg/databind/internal/discovery/docker/docker.go
@@ -80,8 +80,10 @@ func getDiscoveries(containers []types.Container, matcher *discovery.FieldsMatch
 		for _, network := range cont.NetworkSettings.Networks {
 			if index == 0 {
 				labels[data.PrivateIP] = network.IPAddress
+				labels[data.IP] = network.IPAddress
 			}
 			labels[data.PrivateIP+"."+strconv.Itoa(index)] = network.IPAddress
+			labels[data.IP+"."+strconv.Itoa(index)] = network.IPAddress
 			index++
 		}
 


### PR DESCRIPTION
Getting error : level=error msg="can't start integration" component=integrations.runner.Runner env=dev environment=dev error="value not found: discovery.ip" Assume it's caused by not setting default discovery.ip when no ports are exposed.