### PR TITLE
NR-181605 Add sendMetrics param to newrelic output plugin in FB conf file

### DIFF
--- a/build/embed/fluent-bit.version
+++ b/build/embed/fluent-bit.version
@@ -5,5 +5,5 @@
 #
 # OS, newrelic_plugin_version, fluent-bit
 
-linux,1.17.1
-windows,1.17.1,1.9.3
+linux,1.19.1
+windows,1.19.1,1.9.3

--- a/cmd/newrelic-infra/newrelic-infra.go
+++ b/cmd/newrelic-infra/newrelic-infra.go
@@ -454,7 +454,6 @@ func initializeAgentAndRun(c *config.Config, logFwCfg config.LogForward) error {
 		os.Exit(1)
 	}
 
-	fbVerbose := c.Log.Level == config.LogLevelTrace && c.Log.HasIncludeFilter(config.TracesFieldName, config.SupervisorTrace)
 	confTempFolder := filepath.Join(c.AgentTempDir, v4.FbConfTempFolderNameDefault)
 	fbIntCfg := v4.NewFBSupervisorConfig(
 		ffManager,
@@ -464,7 +463,7 @@ func initializeAgentAndRun(c *config.Config, logFwCfg config.LogForward) error {
 		c.FluentBitExePath,
 		c.FluentBitNRLibPath,
 		c.FluentBitParsersPath,
-		fbVerbose,
+		logFwCfg.FluentBitVerbose,
 		confTempFolder,
 	)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1501,14 +1501,15 @@ func (config *Config) populateLogConfig() {
 
 // LogForward log forwarder config values.
 type LogForward struct {
-	Troubleshoot Troubleshoot
-	ConfigsDir   string
-	HomeDir      string
-	License      string
-	IsFedramp    bool
-	IsStaging    bool
-	ProxyCfg     LogForwardProxy
-	RetryLimit   string
+	Troubleshoot     Troubleshoot
+	ConfigsDir       string
+	HomeDir          string
+	License          string
+	IsFedramp        bool
+	IsStaging        bool
+	ProxyCfg         LogForwardProxy
+	RetryLimit       string
+	FluentBitVerbose bool
 }
 
 type LogForwardProxy struct {
@@ -1522,13 +1523,14 @@ type LogForwardProxy struct {
 // NewLogForward creates a valid log forwarder config.
 func NewLogForward(config *Config, troubleshoot Troubleshoot) LogForward {
 	return LogForward{
-		Troubleshoot: troubleshoot,
-		ConfigsDir:   config.LoggingConfigsDir,
-		HomeDir:      config.LoggingHomeDir,
-		License:      config.License,
-		IsFedramp:    config.Fedramp,
-		IsStaging:    config.Staging,
-		RetryLimit:   config.LoggingRetryLimit,
+		Troubleshoot:     troubleshoot,
+		ConfigsDir:       config.LoggingConfigsDir,
+		HomeDir:          config.LoggingHomeDir,
+		License:          config.License,
+		IsFedramp:        config.Fedramp,
+		IsStaging:        config.Staging,
+		RetryLimit:       config.LoggingRetryLimit,
+		FluentBitVerbose: config.Log.Level == LogLevelTrace && config.Log.HasIncludeFilter(TracesFieldName, SupervisorTrace),
 		ProxyCfg: LogForwardProxy{
 			IgnoreSystemProxy: config.IgnoreSystemProxy,
 			Proxy:             config.Proxy,

--- a/pkg/integrations/v4/logs/cfg.go
+++ b/pkg/integrations/v4/logs/cfg.go
@@ -232,6 +232,7 @@ type FBCfgOutput struct {
 	CABundleDir       string
 	ValidateCerts     bool
 	Retry_Limit       string
+	SendMetrics       bool
 }
 
 type FBWinlogLuaScript struct {
@@ -694,6 +695,7 @@ func newNROutput(cfg *config.LogForward) FBCfgOutput {
 		CABundleDir:       cfg.ProxyCfg.CABundleDir,
 		ValidateCerts:     cfg.ProxyCfg.ValidateCerts,
 		Retry_Limit:       cfg.RetryLimit,
+		SendMetrics:       cfg.FluentBitVerbose,
 	}
 
 	if cfg.IsStaging {

--- a/pkg/integrations/v4/logs/cfg_template.go
+++ b/pkg/integrations/v4/logs/cfg_template.go
@@ -129,6 +129,9 @@ var fbConfigFormat = `{{- range .Inputs }}
     {{- end }}
     {{- if .Output.Retry_Limit}}
     Retry_Limit         {{ .Output.Retry_Limit }}
+    {{- end }}
+    {{- if .Output.SendMetrics}}
+    sendMetrics         {{ .Output.SendMetrics}}
     {{- end}}
 {{ end -}}
 


### PR DESCRIPTION
Issue link: [NR-181605](https://new-relic.atlassian.net/browse/NR-181605)

**Description**
- For log forwarding, a new param - `sendMetrics` is introduced in the newrelic-fluent-bit-output plugin. 
- While constructing the FluentBit config file, the output plugin should contain sendMetrics param if verbose logging is enabled for supervisor via log_filter in the newrelic-infra.yml file.

**Changes**
- the new param is introduced in the template file
- from `config/config.go LogForward`, verbose logging mode is checked and set to this field - `FluentBitVerbose`
- The above `FluentBitVerbose` field is used to check if sendMetrics param should be in fluentBit config file.

**Test cases**
- Test cases for the new changes are added in cfg_test.go and loader_test.go