### PR TITLE
Add sdk temp dir (NR-219553)

### DIFF
--- a/cmd/newrelic-infra/newrelic-infra.go
+++ b/cmd/newrelic-infra/newrelic-infra.go
@@ -282,6 +282,7 @@ func initializeAgentAndRun(c *config.Config, logFwCfg config.LogForward) error {
 
 	v4ManagerConfig := v4.NewManagerConfig(
 		c.Log.VerboseEnabled(),
+		c.DefaultIntegrationsTempDir,
 		c.Features,
 		c.PassthroughEnvironment,
 		c.PluginInstanceDirs,
@@ -526,6 +527,7 @@ func newInstancesLookup(cfg v4.ManagerConfig) integration.InstancesLookup {
 	legacyDefinedCommands := v3legacy.NewDefinitionsRepo(v3legacy.LegacyConfig{
 		DefinitionFolders: cfg.DefinitionFolders,
 		Verbose:           cfg.Verbose,
+		TempDir:           cfg.TempDir,
 	})
 	return integration.InstancesLookup{
 		Legacy: legacyDefinedCommands.NewDefinitionCommand,
@@ -705,6 +707,7 @@ func executeIntegrationsDryRunMode(configPath string, ac *config.Config) {
 
 	v4ManagerConfig := v4.NewManagerConfig(
 		ac.Log.VerboseEnabled(),
+		ac.DefaultIntegrationsTempDir,
 		ac.Features,
 		ac.PassthroughEnvironment,
 		integrationConfigPaths,

--- a/internal/integrations/v4/constants/constants.go
+++ b/internal/integrations/v4/constants/constants.go
@@ -4,3 +4,4 @@ package constants
 
 const EnableVerbose = "enable_verbose"
 const HostID = "host_id"
+const TmpDir = "tmp_dir"

--- a/internal/integrations/v4/executor/executor.go
+++ b/internal/integrations/v4/executor/executor.go
@@ -162,6 +162,12 @@ func (r *Executor) buildCommand(ctx context.Context) *exec.Cmd {
 		cmd.Env = append(cmd.Env, "NRI_HOST_ID="+hostID)
 	}
 
+	tmpDir, ok := ctx.Value(constants.TmpDir).(string)
+
+	if ok && tmpDir != "" {
+		cmd.Env = append(cmd.Env, "TEMP_DIR="+tmpDir)
+	}
+
 	cmd.Dir = r.Cfg.Directory
 	return cmd
 }

--- a/internal/integrations/v4/v3legacy/definitions_repo.go
+++ b/internal/integrations/v4/v3legacy/definitions_repo.go
@@ -48,6 +48,7 @@ type DefinitionContext struct {
 type LegacyConfig struct {
 	DefinitionFolders []string
 	Verbose           int
+	TempDir           string
 }
 
 // DefinitionsRepo stores all the definitions from all the files
@@ -125,7 +126,7 @@ func (dcb *DefinitionsRepo) NewDefinitionCommand(dcc integration.DefinitionComma
 	// Legacy integrations don't allow setting the environment, as it will be used
 	// for passing the "arguments" entry.
 	dcc.Common.ExecutorConfig.Environment =
-		legacy.ArgumentsToEnvVars(dcb.Config.Verbose, dcc.Arguments)
+		legacy.ArgumentsToEnvVars(dcb.Config.Verbose, dcb.Config.TempDir, dcc.Arguments)
 
 	// We need to set the Working Directory to the folder where the definition file is placed
 	dcc.Common.ExecutorConfig.Directory = definition.Dir

--- a/pkg/integrations/legacy/runner.go
+++ b/pkg/integrations/legacy/runner.go
@@ -372,9 +372,10 @@ func (ep *externalPlugin) detailedLogFields() logrus.Fields {
 // ArgumentsToEnvVars returns the environment variables that will be passed to the
 // external plugin command. This implies that the plugin arguments are
 // passed as environment variables to the integrations.
-func ArgumentsToEnvVars(verbose int, arguments map[string]string) map[string]string {
+func ArgumentsToEnvVars(verbose int, tempDir string, arguments map[string]string) map[string]string {
 	envVars := make(map[string]string)
 	envVars["VERBOSE"] = fmt.Sprintf("%v", verbose)
+	envVars["TEMP_DIR"] = fmt.Sprintf("%s", tempDir)
 
 	// Pass the integration arguments as environment variables to the command
 	for k, v := range arguments {
@@ -430,7 +431,7 @@ func (ep *externalPlugin) appendEnvPassthrough(envVars map[string]string) {
 // `PassthroughEnvironment`, the value from the environment takes precedence.
 func (ep *externalPlugin) envVars() map[string]string {
 	cfg := ep.Context.Config()
-	envVars := ArgumentsToEnvVars(cfg.Log.VerboseEnabled(), ep.pluginInstance.Arguments)
+	envVars := ArgumentsToEnvVars(cfg.Log.VerboseEnabled(), cfg.DefaultIntegrationsTempDir, ep.pluginInstance.Arguments)
 	ep.appendEnvPassthrough(envVars)
 	return envVars
 }

--- a/pkg/integrations/legacy/runner_test.go
+++ b/pkg/integrations/legacy/runner_test.go
@@ -517,6 +517,7 @@ func newFakePlugin(ctx customContext, pluginVersion int) externalPlugin {
 				Arguments: map[string]string{
 					"PATH":       "Path should be replaced by path env var",
 					"CUSTOM_ARG": "testValue",
+					"TEMP_DIR":   "a/path",
 				},
 			},
 			pluginRunner: &PluginRunner{
@@ -1433,7 +1434,6 @@ func (rs *RunnerSuite) TestGenerateExecWithEnvVars(c *C) {
 	}
 	c.Assert(envVarMap["PATH"], Equals, os.Getenv("PATH"))             // The config has a PATH set as well, but the env var should take precedence
 	c.Assert(envVarMap["VERBOSE"], Equals, "0")                        // Should be set based on config
-	c.Assert(envVarMap["TEMP_DIR"], Equals, "a/path")                  // Should be set based on config
 	c.Assert(envVarMap["CUSTOM_ARG"], Equals, "testValue")             // Should match the config on the plugin instance
 	c.Assert(envVarMap["PASSWORD1"], Equals, "pa$$word")               // should be kept
 	c.Assert(envVarMap["PASSWORD2"], Equals, "pa$tor")                 // should be kept
@@ -2186,7 +2186,7 @@ func TestLogFields(t *testing.T) {
 
 	envVars := map[string]string{
 		"VERBOSE":    "0",
-		"TEMP_DIR":   "",
+		"TEMP_DIR":   "a/path",
 		"PATH":       pathEnv,
 		"CUSTOM_ARG": "testValue",
 	}
@@ -2204,6 +2204,7 @@ func TestLogFields(t *testing.T) {
 	assert.Equal(t, fields["arguments"], map[string]string{
 		"PATH":       "Path should be replaced by path env var",
 		"CUSTOM_ARG": "testValue",
+		"TEMP_DIR":   "a/path",
 	})
 	assert.Equal(t, fields["labels"], map[string]string{
 		"role":        "fileserver",

--- a/pkg/integrations/legacy/runner_test.go
+++ b/pkg/integrations/legacy/runner_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/newrelic/infrastructure-agent/internal/agent/types"
 	"io"
 	"io/ioutil"
 	"os"
@@ -19,6 +18,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/newrelic/infrastructure-agent/internal/agent/types"
 
 	"github.com/newrelic/infrastructure-agent/pkg/databind/pkg/data"
 	"github.com/newrelic/infrastructure-agent/pkg/databind/pkg/databind"
@@ -1230,6 +1231,7 @@ func TestGenerateExecCmdWithDatabind(t *testing.T) {
 				Environment: map[string]string{
 					"PATH":       os.Getenv("PATH"), // The config has a PATH set as well, but the env var should take precedence.
 					"VERBOSE":    "0",
+					"TEMP_DIR":   "a/path",
 					"CUSTOM_ARG": "testValue",
 					"ComSpec":    os.Getenv("ComSpec"),
 					"SystemRoot": os.Getenv("SystemRoot"),
@@ -1262,6 +1264,7 @@ func TestGenerateExecCmdWithDatabind(t *testing.T) {
 	}
 	assert.Equal(t, os.Getenv("PATH"), envVarMap["PATH"]) // The config has a PATH set as well, but the env var should take precedence
 	assert.Equal(t, "0", envVarMap["VERBOSE"])            // Should be set based on config
+	assert.Equal(t, "a/path", envVarMap["TEMP_DIR"])      // Should be set based on config
 	assert.Equal(t, "testValue", envVarMap["CUSTOM_ARG"]) // Should match the config on the plugin instance
 
 	// In config.go, these environment variables are also configured to pass through
@@ -1430,6 +1433,7 @@ func (rs *RunnerSuite) TestGenerateExecWithEnvVars(c *C) {
 	}
 	c.Assert(envVarMap["PATH"], Equals, os.Getenv("PATH"))             // The config has a PATH set as well, but the env var should take precedence
 	c.Assert(envVarMap["VERBOSE"], Equals, "0")                        // Should be set based on config
+	c.Assert(envVarMap["TEMP_DIR"], Equals, "a/path")                  // Should be set based on config
 	c.Assert(envVarMap["CUSTOM_ARG"], Equals, "testValue")             // Should match the config on the plugin instance
 	c.Assert(envVarMap["PASSWORD1"], Equals, "pa$$word")               // should be kept
 	c.Assert(envVarMap["PASSWORD2"], Equals, "pa$tor")                 // should be kept
@@ -2182,6 +2186,7 @@ func TestLogFields(t *testing.T) {
 
 	envVars := map[string]string{
 		"VERBOSE":    "0",
+		"TEMP_DIR":   "",
 		"PATH":       pathEnv,
 		"CUSTOM_ARG": "testValue",
 	}
@@ -2232,6 +2237,7 @@ func TestLogFields(t *testing.T) {
 			"windir",
 			//We add the ones defined above
 			"VERBOSE",
+			"TEMP_DIR",
 			"CUSTOM_ARG",
 		}
 		//We check that env vars are present as we cannot assert the content

--- a/pkg/integrations/v4/manager.go
+++ b/pkg/integrations/v4/manager.go
@@ -255,6 +255,7 @@ func NewManager(
 func (mgr *Manager) Start(ctx context.Context) {
 	for path, rc := range mgr.runners.List() {
 		illog.WithField("file", path).Debug("Starting integrations group.")
+		ctx = contextWithTmpDir(ctx, mgr.managerConfig.TempDir)
 		rc.start(contextWithVerbose(ctx, mgr.managerConfig.Verbose))
 	}
 
@@ -271,6 +272,7 @@ func (mgr *Manager) RunOnce(ctx context.Context) {
 
 		wg.Add(1)
 		go func(g *groupContext) {
+			ctx = contextWithTmpDir(ctx, mgr.managerConfig.TempDir)
 			g.runOnce(contextWithVerbose(ctx, mgr.managerConfig.Verbose))
 			wg.Done()
 		}(group)
@@ -523,4 +525,8 @@ func foundFilesLogFields(configs v4Config.YAMLMap) func() logrus.Fields {
 
 func contextWithVerbose(ctx context.Context, verbose int) context.Context {
 	return context.WithValue(ctx, constants.EnableVerbose, verbose)
+}
+
+func contextWithTmpDir(ctx context.Context, tmpDir string) context.Context {
+	return context.WithValue(ctx, constants.TmpDir, tmpDir)
 }

--- a/pkg/integrations/v4/manager.go
+++ b/pkg/integrations/v4/manager.go
@@ -253,9 +253,10 @@ func NewManager(
 
 // Start in background the v4 integrations lifecycle management, including hot reloading, interval and timeout management
 func (mgr *Manager) Start(ctx context.Context) {
+	ctx = contextWithTmpDir(ctx, mgr.managerConfig.TempDir)
+
 	for path, rc := range mgr.runners.List() {
 		illog.WithField("file", path).Debug("Starting integrations group.")
-		ctx = contextWithTmpDir(ctx, mgr.managerConfig.TempDir)
 		rc.start(contextWithVerbose(ctx, mgr.managerConfig.Verbose))
 	}
 
@@ -295,6 +296,8 @@ func (mgr *Manager) EnableOHIFromFF(ctx context.Context, featureFlag string) err
 		Name:    featureFlag,
 		Enabled: true,
 	}
+
+	ctx = contextWithTmpDir(ctx, mgr.managerConfig.TempDir)
 
 	mgr.runIntegrationFromPath(ctx, cfgPath, false, &illog, &cmdFF)
 

--- a/pkg/integrations/v4/manager.go
+++ b/pkg/integrations/v4/manager.go
@@ -6,18 +6,17 @@ package v4
 import (
 	"context"
 	"errors"
-	"github.com/newrelic/infrastructure-agent/pkg/entity/host"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 
 	"github.com/newrelic/infrastructure-agent/internal/integrations/v4/constants"
+	"github.com/newrelic/infrastructure-agent/pkg/entity/host"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/cmdrequest"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/configrequest"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/track"
 	v4Config "github.com/newrelic/infrastructure-agent/pkg/integrations/v4/config"
-
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/v4/fs"
 
 	"github.com/fsnotify/fsnotify"
@@ -157,16 +156,19 @@ type ManagerConfig struct {
 	DefinitionFolders []string
 	// Defines verbosity level in v3 legacy integrations
 	Verbose int
+	// Defines TempDir folder in v3 legacy integrations
+	TempDir string
 	// PassthroughEnvironment holds a copy of its homonym in config.Config.
 	PassthroughEnvironment []string
 }
 
-func NewManagerConfig(verbose int, features map[string]bool, passthroughEnvs, configFolders, definitionFolders []string) ManagerConfig {
+func NewManagerConfig(verbose int, tempDir string, features map[string]bool, passthroughEnvs, configFolders, definitionFolders []string) ManagerConfig {
 	return ManagerConfig{
 		ConfigPaths:            configFolders,
 		AgentFeatures:          features,
 		DefinitionFolders:      definitionFolders,
 		Verbose:                verbose,
+		TempDir:                tempDir,
 		PassthroughEnvironment: passthroughEnvs,
 	}
 }

--- a/pkg/integrations/v4/manager_test.go
+++ b/pkg/integrations/v4/manager_test.go
@@ -988,6 +988,68 @@ func TestManager_StartWithVerboseFalse(t *testing.T) {
 	})
 }
 
+func TestManager_StartWithTempDir(t *testing.T) {
+	// GIVEN a configuration file for an OHI with feature in it
+	dir, err := tempFiles(map[string]string{
+		"foo.yaml": getV4VerboseCheckYAML(t),
+	})
+	require.NoError(t, err)
+	defer removeTempFiles(t, dir)
+
+	// AND an integrations manager and with feature enabled within agent config
+	emitter := &testemit.RecordEmitter{}
+	mgr := NewManager(ManagerConfig{
+		ConfigPaths:            []string{dir},
+		PassthroughEnvironment: passthroughEnv,
+	}, config.NewPathLoader(), emitter, integration.ErrLookup, definitionQ, configEntryQ, track.NewTracker(nil), host.IDLookup{})
+
+	// AND the manager starts
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go mgr.Start(ctx)
+
+	d := getEmittedData(t, emitter, "verbose-check")
+	assert.Contains(t, d.DataSet.Metrics, protocol.MetricData{
+		"value":      "true",
+		"event_type": "THIS_IS_A_TEST",
+	})
+	assert.NotContains(t, d.DataSet.Metrics, protocol.MetricData{
+		"event_type": "TEMP_DIR",
+	})
+}
+
+func TestManager_StartWithoutTempDir(t *testing.T) {
+	// GIVEN a configuration file for an OHI with feature in it
+	dir, err := tempFiles(map[string]string{
+		"foo.yaml": getV4VerboseCheckYAML(t),
+	})
+	require.NoError(t, err)
+	defer removeTempFiles(t, dir)
+
+	// AND an integrations manager and with feature enabled within agent config
+	emitter := &testemit.RecordEmitter{}
+	mgr := NewManager(ManagerConfig{
+		ConfigPaths:            []string{dir},
+		PassthroughEnvironment: passthroughEnv,
+		TempDir:                "/my-custom/path",
+	}, config.NewPathLoader(), emitter, integration.ErrLookup, definitionQ, configEntryQ, track.NewTracker(nil), host.IDLookup{})
+
+	// AND the manager starts
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go mgr.Start(ctx)
+
+	d := getEmittedData(t, emitter, "verbose-check")
+	assert.Contains(t, d.DataSet.Metrics, protocol.MetricData{
+		"value":      "true",
+		"event_type": "THIS_IS_A_TEST",
+	})
+	assert.Contains(t, d.DataSet.Metrics, protocol.MetricData{
+		"value":      "/my-custom/path",
+		"event_type": "TEMP_DIR",
+	})
+}
+
 func getV4VerboseCheckYAML(t *testing.T) string {
 	//      GOTMPDIR: %s
 	//      GOCACHE: %s

--- a/test/cfgprotocol/agent/emulator.go
+++ b/test/cfgprotocol/agent/emulator.go
@@ -63,6 +63,7 @@ func New(configsDir, tempBinDir string) *Emulator {
 	cfg := ag.Context.Config()
 	integrationCfg := v4.NewManagerConfig(
 		cfg.Log.VerboseEnabled(),
+		cfg.DefaultIntegrationsTempDir,
 		cfg.Features,
 		cfg.PassthroughEnvironment,
 		[]string{configsDir},
@@ -155,6 +156,7 @@ func newInstancesLookup(cfg v4.ManagerConfig) integration.InstancesLookup {
 	legacyDefinedCommands := v3legacy.NewDefinitionsRepo(v3legacy.LegacyConfig{
 		DefinitionFolders: cfg.DefinitionFolders,
 		Verbose:           cfg.Verbose,
+		TempDir:           cfg.TempDir,
 	})
 	return integration.InstancesLookup{
 		Legacy: legacyDefinedCommands.NewDefinitionCommand,


### PR DESCRIPTION
Propagate TEMP_DIR  environment variable to integrations when DefaultIntegrationsTempDir is set up.
This makes the integrations with the SDK version > 3.8.2 to store the cache files in the provided Directory instead of the default `os.Tempdir() + "/nr-integrations"`