### PR TITLE
Enable FB for al2023_arm64.yml

### DIFF
--- a/build/goreleaser/linux/al2023_arm64.yml
+++ b/build/goreleaser/linux/al2023_arm64.yml
@@ -73,7 +73,7 @@
       summary: "New Relic Infrastructure Agent"
       group: default
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
-#    recommends:
-#      - fluent-bit
+    recommends:
+      - fluent-bit
   
   # end AL2023 arm64


### PR DESCRIPTION
fluent-bit supports amzn 2023 arm64 and we'd like to release packages for it too