### PR TITLE
NR-236049: use relative paths for test/provision and test/canaries

### DIFF
--- a/.github/workflows/component_canaries.yml
+++ b/.github/workflows/component_canaries.yml
@@ -97,7 +97,7 @@ jobs:
         uses: newrelic/fargate-runner-action@main
         with:
           aws_region: us-east-2
-          container_make_target: "test/provision TERRAFORM_STATE_KEY=${{ env.TERRAFORM_STATE }} PREFIX=canary INVENTORY_OUTPUT=${{ env.INVENTORY_OUTPUT }} TAG_OR_UNIQUE_NAME=${{ inputs.TAG }} PLATFORM=${{ inputs.PLATFORM }} CROWDSTRIKE_CLIENT_ID=${{ secrets.CROWDSTRIKE_CLIENT_ID }} CROWDSTRIKE_CLIENT_SECRET=${{ secrets.CROWDSTRIKE_CLIENT_SECRET }} CROWDSTRIKE_CUSTOMER_ID=${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}"
+          container_make_target: "-C test/provision TERRAFORM_STATE_KEY=${{ env.TERRAFORM_STATE }} PREFIX=canary INVENTORY_OUTPUT=${{ env.INVENTORY_OUTPUT }} TAG_OR_UNIQUE_NAME=${{ inputs.TAG }} PLATFORM=${{ inputs.PLATFORM }} CROWDSTRIKE_CLIENT_ID=${{ secrets.CROWDSTRIKE_CLIENT_ID }} CROWDSTRIKE_CLIENT_SECRET=${{ secrets.CROWDSTRIKE_CLIENT_SECRET }} CROWDSTRIKE_CUSTOMER_ID=${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}"
           ecs_cluster_name: caos_infra_agent
           task_definition_name: infra-agent
           cloud_watch_logs_group_name: /ecs/test-prerelease-infra-agent
@@ -160,7 +160,7 @@ jobs:
         uses: newrelic/fargate-runner-action@main
         with:
           aws_region: us-east-2
-          container_make_target: "test/provision TERRAFORM_STATE_KEY=${{ env.TERRAFORM_STATE_PREVIOUS }} PREFIX=canary INVENTORY_OUTPUT=${{ env.INVENTORY_PREVIOUS }} TAG_OR_UNIQUE_NAME=${{ env.PREVIOUS_NR_VERSION }} PLATFORM=${{ inputs.PLATFORM }} CROWDSTRIKE_CLIENT_ID=${{ secrets.CROWDSTRIKE_CLIENT_ID }} CROWDSTRIKE_CLIENT_SECRET=${{ secrets.CROWDSTRIKE_CLIENT_SECRET }} CROWDSTRIKE_CUSTOMER_ID=${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}"
+          container_make_target: "-C test/provision TERRAFORM_STATE_KEY=${{ env.TERRAFORM_STATE_PREVIOUS }} PREFIX=canary INVENTORY_OUTPUT=${{ env.INVENTORY_PREVIOUS }} TAG_OR_UNIQUE_NAME=${{ env.PREVIOUS_NR_VERSION }} PLATFORM=${{ inputs.PLATFORM }} CROWDSTRIKE_CLIENT_ID=${{ secrets.CROWDSTRIKE_CLIENT_ID }} CROWDSTRIKE_CLIENT_SECRET=${{ secrets.CROWDSTRIKE_CLIENT_SECRET }} CROWDSTRIKE_CUSTOMER_ID=${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}"
           ecs_cluster_name: caos_infra_agent
           task_definition_name: infra-agent
           cloud_watch_logs_group_name: /ecs/test-prerelease-infra-agent
@@ -180,7 +180,7 @@ jobs:
         uses: newrelic/fargate-runner-action@main
         with:
           aws_region: us-east-2
-          container_make_target: "test/provision TERRAFORM_STATE_KEY=${{ env.TERRAFORM_STATE_CURRENT }} PREFIX=canary INVENTORY_OUTPUT=${{ env.INVENTORY_CURRENT }} TAG_OR_UNIQUE_NAME=${{ env.NR_VERSION }} PLATFORM=${{ inputs.PLATFORM }} CROWDSTRIKE_CLIENT_ID=${{ secrets.CROWDSTRIKE_CLIENT_ID }} CROWDSTRIKE_CLIENT_SECRET=${{ secrets.CROWDSTRIKE_CLIENT_SECRET }} CROWDSTRIKE_CUSTOMER_ID=${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}"
+          container_make_target: "-C test/provision TERRAFORM_STATE_KEY=${{ env.TERRAFORM_STATE_CURRENT }} PREFIX=canary INVENTORY_OUTPUT=${{ env.INVENTORY_CURRENT }} TAG_OR_UNIQUE_NAME=${{ env.NR_VERSION }} PLATFORM=${{ inputs.PLATFORM }} CROWDSTRIKE_CLIENT_ID=${{ secrets.CROWDSTRIKE_CLIENT_ID }} CROWDSTRIKE_CLIENT_SECRET=${{ secrets.CROWDSTRIKE_CLIENT_SECRET }} CROWDSTRIKE_CUSTOMER_ID=${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}"
           ecs_cluster_name: caos_infra_agent
           task_definition_name: infra-agent
           cloud_watch_logs_group_name: /ecs/test-prerelease-infra-agent

--- a/.github/workflows/component_canaries.yml
+++ b/.github/workflows/component_canaries.yml
@@ -55,7 +55,7 @@ jobs:
         uses: newrelic/fargate-runner-action@main
         with:
           aws_region: us-east-2
-          container_make_target: "macos-canaries PLATFORM=${{ inputs.PLATFORM }} ANSIBLE_FORKS=${{ env.ANSIBLE_FORKS }} PREVIOUS_VERSION=${{ env.PREVIOUS_NR_VERSION }} VERSION=${{ inputs.TAG }} CROWDSTRIKE_CLIENT_ID=${{ secrets.CROWDSTRIKE_CLIENT_ID }} CROWDSTRIKE_CLIENT_SECRET=${{ secrets.CROWDSTRIKE_CLIENT_SECRET }} CROWDSTRIKE_CUSTOMER_ID=${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}"
+          container_make_target: "-C test/canaries macos-canaries PLATFORM=${{ inputs.PLATFORM }} ANSIBLE_FORKS=${{ env.ANSIBLE_FORKS }} PREVIOUS_VERSION=${{ env.PREVIOUS_NR_VERSION }} VERSION=${{ inputs.TAG }} CROWDSTRIKE_CLIENT_ID=${{ secrets.CROWDSTRIKE_CLIENT_ID }} CROWDSTRIKE_CLIENT_SECRET=${{ secrets.CROWDSTRIKE_CLIENT_SECRET }} CROWDSTRIKE_CUSTOMER_ID=${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}"
           ecs_cluster_name: caos_infra_agent
           task_definition_name: infra-agent
           cloud_watch_logs_group_name: /ecs/test-prerelease-infra-agent
@@ -117,7 +117,7 @@ jobs:
         uses: newrelic/fargate-runner-action@main
         with:
           aws_region: us-east-2
-          container_make_target: "terraform-canaries ANSIBLE_INVENTORY=${{ env.INVENTORY_OUTPUT }} PLATFORM=${{ inputs.PLATFORM }} ANSIBLE_FORKS=${{ env.ANSIBLE_FORKS }} VERSION=${{ env.NR_VERSION }} PREVIOUS_VERSION=${{ env.PREVIOUS_NR_VERSION }} CROWDSTRIKE_CLIENT_ID=${{ secrets.CROWDSTRIKE_CLIENT_ID }} CROWDSTRIKE_CLIENT_SECRET=${{ secrets.CROWDSTRIKE_CLIENT_SECRET }} CROWDSTRIKE_CUSTOMER_ID=${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}"
+          container_make_target: "-C test/canaries terraform-canaries ANSIBLE_INVENTORY=${{ env.INVENTORY_OUTPUT }} PLATFORM=${{ inputs.PLATFORM }} ANSIBLE_FORKS=${{ env.ANSIBLE_FORKS }} VERSION=${{ env.NR_VERSION }} PREVIOUS_VERSION=${{ env.PREVIOUS_NR_VERSION }} CROWDSTRIKE_CLIENT_ID=${{ secrets.CROWDSTRIKE_CLIENT_ID }} CROWDSTRIKE_CLIENT_SECRET=${{ secrets.CROWDSTRIKE_CLIENT_SECRET }} CROWDSTRIKE_CUSTOMER_ID=${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}"
           ecs_cluster_name: caos_infra_agent
           task_definition_name: infra-agent
           cloud_watch_logs_group_name: /ecs/test-prerelease-infra-agent
@@ -200,7 +200,7 @@ jobs:
         uses: newrelic/fargate-runner-action@main
         with:
           aws_region: us-east-2
-          container_make_target: "terraform-canaries ANSIBLE_INVENTORY=${{ env.INVENTORY_PREVIOUS }} PLATFORM=${{ inputs.PLATFORM }} ANSIBLE_FORKS=${{ env.ANSIBLE_FORKS }} VERSION=${{ env.PREVIOUS_NR_VERSION }} PREVIOUS_VERSION='NOT_USED_VALUE' CROWDSTRIKE_CLIENT_ID=${{ secrets.CROWDSTRIKE_CLIENT_ID }} CROWDSTRIKE_CLIENT_SECRET=${{ secrets.CROWDSTRIKE_CLIENT_SECRET }} CROWDSTRIKE_CUSTOMER_ID=${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}"
+          container_make_target: "-C test/canaries terraform-canaries ANSIBLE_INVENTORY=${{ env.INVENTORY_PREVIOUS }} PLATFORM=${{ inputs.PLATFORM }} ANSIBLE_FORKS=${{ env.ANSIBLE_FORKS }} VERSION=${{ env.PREVIOUS_NR_VERSION }} PREVIOUS_VERSION='NOT_USED_VALUE' CROWDSTRIKE_CLIENT_ID=${{ secrets.CROWDSTRIKE_CLIENT_ID }} CROWDSTRIKE_CLIENT_SECRET=${{ secrets.CROWDSTRIKE_CLIENT_SECRET }} CROWDSTRIKE_CUSTOMER_ID=${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}"
           ecs_cluster_name: caos_infra_agent
           task_definition_name: infra-agent
           cloud_watch_logs_group_name: /ecs/test-prerelease-infra-agent
@@ -213,7 +213,7 @@ jobs:
         uses: newrelic/fargate-runner-action@main
         with:
           aws_region: us-east-2
-          container_make_target: "terraform-canaries ANSIBLE_INVENTORY=${{ env.INVENTORY_CURRENT }} PLATFORM=${{ inputs.PLATFORM }} ANSIBLE_FORKS=${{ env.ANSIBLE_FORKS }} VERSION=${{ env.NR_VERSION }} PREVIOUS_VERSION='NOT_USED_VALUE' CROWDSTRIKE_CLIENT_ID=${{ secrets.CROWDSTRIKE_CLIENT_ID }} CROWDSTRIKE_CLIENT_SECRET=${{ secrets.CROWDSTRIKE_CLIENT_SECRET }} CROWDSTRIKE_CUSTOMER_ID=${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}"
+          container_make_target: "-C test/canaries terraform-canaries ANSIBLE_INVENTORY=${{ env.INVENTORY_CURRENT }} PLATFORM=${{ inputs.PLATFORM }} ANSIBLE_FORKS=${{ env.ANSIBLE_FORKS }} VERSION=${{ env.NR_VERSION }} PREVIOUS_VERSION='NOT_USED_VALUE' CROWDSTRIKE_CLIENT_ID=${{ secrets.CROWDSTRIKE_CLIENT_ID }} CROWDSTRIKE_CLIENT_SECRET=${{ secrets.CROWDSTRIKE_CLIENT_SECRET }} CROWDSTRIKE_CUSTOMER_ID=${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}"
           ecs_cluster_name: caos_infra_agent
           task_definition_name: infra-agent
           cloud_watch_logs_group_name: /ecs/test-prerelease-infra-agent

--- a/.github/workflows/component_canaries_prune.yml
+++ b/.github/workflows/component_canaries_prune.yml
@@ -51,7 +51,7 @@ jobs:
         uses: newrelic/fargate-runner-action@main
         with:
           aws_region: us-east-2
-          container_make_target: "test/provision/clean TERRAFORM_STATE_KEY=${{ env.TERRAFORM_STATE }} PREFIX=canary INVENTORY_OUTPUT=NOT_USED TAG_OR_UNIQUE_NAME=${{ inputs.TAG }} PLATFORM=linux CROWDSTRIKE_CLIENT_ID=${{ secrets.CROWDSTRIKE_CLIENT_ID }} CROWDSTRIKE_CLIENT_SECRET=${{ secrets.CROWDSTRIKE_CLIENT_SECRET }} CROWDSTRIKE_CUSTOMER_ID=${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}"
+          container_make_target: "-C test/provision clean TERRAFORM_STATE_KEY=${{ env.TERRAFORM_STATE }} PREFIX=canary INVENTORY_OUTPUT=NOT_USED TAG_OR_UNIQUE_NAME=${{ inputs.TAG }} PLATFORM=linux CROWDSTRIKE_CLIENT_ID=${{ secrets.CROWDSTRIKE_CLIENT_ID }} CROWDSTRIKE_CLIENT_SECRET=${{ secrets.CROWDSTRIKE_CLIENT_SECRET }} CROWDSTRIKE_CUSTOMER_ID=${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}"
           ecs_cluster_name: caos_infra_agent
           task_definition_name: infra-agent
           cloud_watch_logs_group_name: /ecs/test-prerelease-infra-agent
@@ -100,7 +100,7 @@ jobs:
         uses: newrelic/fargate-runner-action@main
         with:
           aws_region: us-east-2
-          container_make_target: "test/provision/clean TERRAFORM_STATE_KEY=${{ env.PREVIOUS_TERRAFORM_STATE }} PREFIX=canary INVENTORY_OUTPUT=NOT_USED TAG_OR_UNIQUE_NAME=${{ inputs.TAG }} PLATFORM=windows CROWDSTRIKE_CLIENT_ID=${{ secrets.CROWDSTRIKE_CLIENT_ID }} CROWDSTRIKE_CLIENT_SECRET=${{ secrets.CROWDSTRIKE_CLIENT_SECRET }} CROWDSTRIKE_CUSTOMER_ID=${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}"
+          container_make_target: "-C test/provision clean TERRAFORM_STATE_KEY=${{ env.PREVIOUS_TERRAFORM_STATE }} PREFIX=canary INVENTORY_OUTPUT=NOT_USED TAG_OR_UNIQUE_NAME=${{ inputs.TAG }} PLATFORM=windows CROWDSTRIKE_CLIENT_ID=${{ secrets.CROWDSTRIKE_CLIENT_ID }} CROWDSTRIKE_CLIENT_SECRET=${{ secrets.CROWDSTRIKE_CLIENT_SECRET }} CROWDSTRIKE_CUSTOMER_ID=${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}"
           ecs_cluster_name: caos_infra_agent
           task_definition_name: infra-agent
           cloud_watch_logs_group_name: /ecs/test-prerelease-infra-agent
@@ -124,7 +124,7 @@ jobs:
         uses: newrelic/fargate-runner-action@main
         with:
           aws_region: us-east-2
-          container_make_target: "test/provision/clean TERRAFORM_STATE_KEY=${{ env.TERRAFORM_STATE }} PREFIX=canary INVENTORY_OUTPUT=NOT_USED TAG_OR_UNIQUE_NAME=${{ inputs.TAG }} PLATFORM=windows CROWDSTRIKE_CLIENT_ID=${{ secrets.CROWDSTRIKE_CLIENT_ID }} CROWDSTRIKE_CLIENT_SECRET=${{ secrets.CROWDSTRIKE_CLIENT_SECRET }} CROWDSTRIKE_CUSTOMER_ID=${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}"
+          container_make_target: "-C test/provision clean TERRAFORM_STATE_KEY=${{ env.TERRAFORM_STATE }} PREFIX=canary INVENTORY_OUTPUT=NOT_USED TAG_OR_UNIQUE_NAME=${{ inputs.TAG }} PLATFORM=windows CROWDSTRIKE_CLIENT_ID=${{ secrets.CROWDSTRIKE_CLIENT_ID }} CROWDSTRIKE_CLIENT_SECRET=${{ secrets.CROWDSTRIKE_CLIENT_SECRET }} CROWDSTRIKE_CUSTOMER_ID=${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}"
           ecs_cluster_name: caos_infra_agent
           task_definition_name: infra-agent
           cloud_watch_logs_group_name: /ecs/test-prerelease-infra-agent

--- a/.github/workflows/component_canary_alerts.yml
+++ b/.github/workflows/component_canary_alerts.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           aws_region: us-east-2
           container_make_target: >
-            provision-alerts-terraform
+            -C test/canaries/alerts provision-alerts-terraform
             TF_VAR_api_key=${{ secrets.CANARIES_NR_API_KEY }}
             TF_VAR_account_id=${{ secrets.NR_ACCOUNT_ID }}
             TF_VAR_region=Staging

--- a/.github/workflows/component_canary_alerts_delete.yml
+++ b/.github/workflows/component_canary_alerts_delete.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           aws_region: us-east-2
           container_make_target: >
-            alerts-clean
+            -C test/canaries/alerts alerts-clean
             TF_VAR_api_key=${{ secrets.CANARIES_NR_API_KEY }}
             TF_VAR_account_id=${{ secrets.NR_ACCOUNT_ID }}
             TF_VAR_region=Staging

--- a/.github/workflows/component_prerelease_testing.yml
+++ b/.github/workflows/component_prerelease_testing.yml
@@ -59,7 +59,7 @@ jobs:
         uses: newrelic/fargate-runner-action@main
         with:
           aws_region: us-east-2
-          container_make_target: "test/provision TERRAFORM_STATE_KEY=${{ inputs.TAG_OR_UNIQUE_NAME }} PREFIX=pkg-tests INVENTORY_OUTPUT=/srv/runner/inventory/${{ inputs.TAG_OR_UNIQUE_NAME }}-inventory.ec2 TAG_OR_UNIQUE_NAME=${{ inputs.TAG_OR_UNIQUE_NAME }} PLATFORM=${{ inputs.PLATFORM }} CROWDSTRIKE_CLIENT_ID=${{ secrets.CROWDSTRIKE_CLIENT_ID }} CROWDSTRIKE_CLIENT_SECRET=${{ secrets.CROWDSTRIKE_CLIENT_SECRET }} CROWDSTRIKE_CUSTOMER_ID=${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}"
+          container_make_target: "-C test/provision TERRAFORM_STATE_KEY=${{ inputs.TAG_OR_UNIQUE_NAME }} PREFIX=pkg-tests INVENTORY_OUTPUT=/srv/runner/inventory/${{ inputs.TAG_OR_UNIQUE_NAME }}-inventory.ec2 TAG_OR_UNIQUE_NAME=${{ inputs.TAG_OR_UNIQUE_NAME }} PLATFORM=${{ inputs.PLATFORM }} CROWDSTRIKE_CLIENT_ID=${{ secrets.CROWDSTRIKE_CLIENT_ID }} CROWDSTRIKE_CLIENT_SECRET=${{ secrets.CROWDSTRIKE_CLIENT_SECRET }} CROWDSTRIKE_CUSTOMER_ID=${{ secrets.CROWDSTRIKE_CUSTOMER_ID }}"
           ecs_cluster_name: caos_infra_agent
           task_definition_name: infra-agent
           cloud_watch_logs_group_name: /ecs/test-prerelease-infra-agent
@@ -208,7 +208,7 @@ jobs:
         uses: newrelic/fargate-runner-action@main
         with:
           aws_region: us-east-2
-          container_make_target: "test/provision/clean TERRAFORM_STATE_KEY=${{ inputs.TAG_OR_UNIQUE_NAME }}  TAG_OR_UNIQUE_NAME=${{ inputs.TAG_OR_UNIQUE_NAME }}"
+          container_make_target: "-C test/provision clean TERRAFORM_STATE_KEY=${{ inputs.TAG_OR_UNIQUE_NAME }}  TAG_OR_UNIQUE_NAME=${{ inputs.TAG_OR_UNIQUE_NAME }}"
           ecs_cluster_name: caos_infra_agent
           task_definition_name: infra-agent
           cloud_watch_logs_group_name: /ecs/test-prerelease-infra-agent
@@ -249,7 +249,7 @@ jobs:
           uses: newrelic/fargate-runner-action@main
           with:
             aws_region: us-east-2
-            container_make_target: "test/provision/clean TERRAFORM_STATE_KEY=${{ inputs.TAG_OR_UNIQUE_NAME }} TAG_OR_UNIQUE_NAME=${{ inputs.TAG_OR_UNIQUE_NAME }}"
+            container_make_target: "-C test/provision clean TERRAFORM_STATE_KEY=${{ inputs.TAG_OR_UNIQUE_NAME }} TAG_OR_UNIQUE_NAME=${{ inputs.TAG_OR_UNIQUE_NAME }}"
             ecs_cluster_name: caos_infra_agent
             task_definition_name: infra-agent
             cloud_watch_logs_group_name: /ecs/test-prerelease-infra-agent

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,6 @@ include $(INCLUDE_BUILD_DIR)/release.mk
 # test
 include $(INCLUDE_TEST_DIR)/test.mk
 
-# provisioning
-include $(INCLUDE_TEST_DIR)/provision/Makefile
-
 # canaries
 include $(INCLUDE_TEST_DIR)/canaries/Makefile
 include $(INCLUDE_TEST_DIR)/canaries/alerts/Makefile

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,6 @@ include $(INCLUDE_BUILD_DIR)/release.mk
 # test
 include $(INCLUDE_TEST_DIR)/test.mk
 
-# canaries
-include $(INCLUDE_TEST_DIR)/canaries/Makefile
-include $(INCLUDE_TEST_DIR)/canaries/alerts/Makefile
-
 # tools
 include $(INCLUDE_TOOLS_DIR)/tools.mk
 

--- a/test/canaries/Makefile
+++ b/test/canaries/Makefile
@@ -1,7 +1,7 @@
 # Include Ansible dependencies common installation strategy
-include $(CURDIR)/test/ansible/Ansible.common
+include ../ansible/Ansible.common
 
-ANSIBLE_FOLDER := $(CURDIR)/test/canaries
+ANSIBLE_FOLDER := $(CURDIR)
 ANSIBLE_FORKS ?= 20
 
 .DEFAULT_GOAL := canaries

--- a/test/canaries/alerts/Makefile
+++ b/test/canaries/alerts/Makefile
@@ -1,8 +1,7 @@
 # Include AWS common features
-include $(CURDIR)/test/ansible/Ansible.common
+include ../../ansible/Ansible.common
 
-# FIXME: Makefile should be able to be run from its relative path
-PROVISION_ALERTS_TERRAFORM_WORKSPACE	?= $(CURDIR)/test/canaries/alerts
+PROVISION_ALERTS_TERRAFORM_WORKSPACE	?= $(CURDIR)
 
 .DEFAULT_GOAL := provision-alerts-terraform
 

--- a/test/provision/Makefile
+++ b/test/provision/Makefile
@@ -1,8 +1,8 @@
 # Include Ansible dependencies common installation strategy
-include $(CURDIR)/test/ansible/Ansible.common
+include ../ansible/Ansible.common
 
-TERRAFORM_DIR := $(CURDIR)/test/provision/terraform
-ANSIBLE_FOLDER := $(CURDIR)/test/provision/terraform
+TERRAFORM_DIR := ./terraform
+ANSIBLE_FOLDER := ./terraform
 
 .DEFAULT_GOAL := provision
 
@@ -19,8 +19,8 @@ endif
 	sed -i -e "s/PREFIX/$(PREFIX)/g" "$(TERRAFORM_DIR)/caos.auto.tfvars"
 	sed -i -e "s/TAG_OR_UNIQUE_NAME/$(TAG_OR_UNIQUE_NAME)/g" "$(TERRAFORM_DIR)/caos.auto.tfvars"
 
-.PHONY: test/provision
-test/provision: terraform/backend
+.PHONY: provision
+provision: terraform/backend
 ifndef PLATFORM
 	$(error PLATFORM is undefined)
 endif
@@ -45,8 +45,8 @@ endif
 	TF_VAR_inventory_output="$(INVENTORY_OUTPUT)" \
 	terraform -chdir=$(TERRAFORM_DIR) apply -auto-approve
 
-.PHONY: test/provision/clean
-test/provision/clean: terraform/backend ansible/clean
+.PHONY: clean
+clean: terraform/backend ansible/clean
 	terraform -chdir=$(TERRAFORM_DIR) init -reconfigure && \
 	TF_VAR_nr_license_key="$(NR_LICENSE_KEY)" \
 	TF_VAR_platform="$(PLATFORM)" \

--- a/test/provision/README.md
+++ b/test/provision/README.md
@@ -21,5 +21,5 @@ In the background, it automates the deployment of the [Otel-ec2](https://github.
 Destroy the provisioned instances:
 ```shell
 // You must have valid AWS credentials at this point
-make test/provision/clean
+make -C test/provision
 ```


### PR DESCRIPTION
Use makefile relative paths to the current directory