### PR TITLE
add host.id to System Sample

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,8 @@ linters-settings:
   wrapcheck:
     ignoreSigs:
       - multierr.Append
+      - errors.Join
+
 
 
 linters:
@@ -52,6 +54,7 @@ linters:
     - testpackage
     - gci
     - tagliatelle
+    - depguard #disabled until configure properly
 
 issues:
   new-from-rev: "HEAD~"

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -16,6 +16,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/hostid"
+
 	"github.com/newrelic/infrastructure-agent/internal/agent/instrumentation"
 	"github.com/newrelic/infrastructure-agent/internal/agent/inventory"
 	"github.com/newrelic/infrastructure-agent/internal/agent/types"
@@ -340,7 +342,7 @@ func NewAgent(
 		return nil, err
 	}
 
-	connectMetadataHarvester := identityapi.NewMetadataHarvesterDefault()
+	connectMetadataHarvester := identityapi.NewMetadataHarvesterDefault(hostid.NewProviderEnv())
 
 	connectSrv := NewIdentityConnectService(connectClient, fpHarvester, connectMetadataHarvester)
 

--- a/pkg/backend/identityapi/metadata_test.go
+++ b/pkg/backend/identityapi/metadata_test.go
@@ -37,7 +37,7 @@ func TestMetadataHarvesterDefaultErrorOnHostId(t *testing.T) {
 
 	//nolint:goerr113
 	providerErr := errors.New("some error")
-	hostIDProvider.ShouldNotProvide(providerErr)
+	hostIDProvider.ShouldReturnErr(providerErr)
 
 	metadata, err := harvester.Harvest()
 	require.ErrorAs(t, err, &providerErr)

--- a/pkg/metrics/system_sampler_test.go
+++ b/pkg/metrics/system_sampler_test.go
@@ -1,21 +1,37 @@
 // Copyright 2020 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+//
+//nolint:exhaustruct
 package metrics
 
 import (
+	"encoding/json"
+	"errors"
+	"regexp"
 	"testing"
+
+	"github.com/newrelic/infrastructure-agent/pkg/log"
+
+	logHelper "github.com/newrelic/infrastructure-agent/test/log"
 
 	"github.com/newrelic/infrastructure-agent/internal/agent/mocks"
 	"github.com/newrelic/infrastructure-agent/pkg/config"
 	"github.com/newrelic/infrastructure-agent/pkg/metrics/storage"
+	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/hostid"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewSystemSampler(t *testing.T) {
 	ctx := new(mocks.AgentContext)
 	ctx.On("Config").Return(&config.Config{})
 
-	m := NewSystemSampler(ctx, nil, nil)
+	hostIDProvider := &hostid.ProviderMock{} //nolint:exhaustruct
+	defer hostIDProvider.AssertExpectations(t)
+
+	m := NewSystemSampler(ctx, nil, nil, hostIDProvider)
 
 	assert.NotNil(t, m)
 }
@@ -24,8 +40,13 @@ func TestSystemSample(t *testing.T) {
 	ctx := new(mocks.AgentContext)
 	ctx.On("Config").Return(&config.Config{})
 
+	hostIDProvider := &hostid.ProviderMock{} //nolint:exhaustruct
+	defer hostIDProvider.AssertExpectations(t)
+
+	hostIDProvider.ShouldProvide("")
+
 	storage := storage.NewSampler(ctx)
-	m := NewSystemSampler(ctx, storage, nil)
+	m := NewSystemSampler(ctx, storage, nil, hostIDProvider)
 
 	result, err := m.Sample()
 
@@ -33,12 +54,94 @@ func TestSystemSample(t *testing.T) {
 	assert.Len(t, result, 1)
 }
 
+func TestSystemSample_HostIDMarshalling(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name         string
+		sample       SystemSample
+		expectedJSON string
+	}{
+		{
+			name:         "this is the first case",
+			sample:       SystemSample{HostID: "a host id"}, //nolint:exhaustruct
+			expectedJSON: `{"eventType":"","timestamp":0,"entityKey":"","host.id":"a host id"}`,
+		},
+		{
+			name:         "this is the first case",
+			sample:       SystemSample{HostID: ""}, //nolint:exhaustruct
+			expectedJSON: `{"eventType":"","timestamp":0,"entityKey":""}`,
+		},
+	}
+
+	for i := range testCases {
+		testCase := testCases[i]
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			res, err := json.Marshal(testCase.sample)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectedJSON, string(res))
+		})
+	}
+}
+
+func TestSystemSample_HostID(t *testing.T) {
+	t.Parallel()
+	ctx := new(mocks.AgentContext)
+	ctx.On("Config").Return(&config.Config{})
+
+	hostIDProvider := &hostid.ProviderMock{}
+	defer hostIDProvider.AssertExpectations(t)
+
+	hostIDProvider.ShouldProvide("this-is-a-host-id")
+
+	storage := storage.NewSampler(ctx)
+	m := NewSystemSampler(ctx, storage, nil, hostIDProvider)
+
+	result, err := m.Sample()
+
+	require.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "this-is-a-host-id", result[0].(*SystemSample).HostID) //nolint:forcetypeassert
+}
+
+func TestSystemSample_HostIDErrorShouldBeLogged(t *testing.T) {
+	t.Parallel()
+	ctx := new(mocks.AgentContext)
+	ctx.On("Config").Return(&config.Config{})
+
+	hostIDProvider := &hostid.ProviderMock{}
+	defer hostIDProvider.AssertExpectations(t)
+
+	hook := logHelper.NewInMemoryEntriesHook([]logrus.Level{logrus.ErrorLevel})
+	log.AddHook(hook)
+
+	//nolint:goerr113
+	providerErr := errors.New("some error")
+	hostIDProvider.ShouldNotProvide(providerErr)
+
+	storage := storage.NewSampler(ctx)
+	m := NewSystemSampler(ctx, storage, nil, hostIDProvider)
+
+	result, err := m.Sample()
+
+	require.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "", result[0].(*SystemSample).HostID) //nolint:forcetypeassert
+	assert.True(t, hook.EntryWithMessageExists(regexp.MustCompile(`cannot retrieve host_id`)))
+	assert.True(t, hook.EntryWithErrorExists(providerErr))
+}
+
 func BenchmarkSystem(b *testing.B) {
 	ctx := new(mocks.AgentContext)
 	ctx.On("Config").Return(&config.Config{})
 
+	hostIDProvider := &hostid.ProviderMock{}
+	defer hostIDProvider.AssertExpectations(b)
+
+	hostIDProvider.ShouldProvide("")
+
 	storage := storage.NewSampler(ctx)
-	m := NewSystemSampler(ctx, storage, nil)
+	m := NewSystemSampler(ctx, storage, nil, hostIDProvider)
 	for n := 0; n < b.N; n++ {
 		m.Sample()
 	}

--- a/pkg/metrics/system_sampler_test.go
+++ b/pkg/metrics/system_sampler_test.go
@@ -117,7 +117,7 @@ func TestSystemSample_HostIDErrorShouldBeLogged(t *testing.T) {
 
 	//nolint:goerr113
 	providerErr := errors.New("some error")
-	hostIDProvider.ShouldNotProvide(providerErr)
+	hostIDProvider.ShouldReturnErr(providerErr)
 
 	storage := storage.NewSampler(ctx)
 	m := NewSystemSampler(ctx, storage, nil, hostIDProvider)

--- a/pkg/plugins/plugins_darwin.go
+++ b/pkg/plugins/plugins_darwin.go
@@ -13,6 +13,7 @@ import (
 	"github.com/newrelic/infrastructure-agent/pkg/metrics/storage"
 	"github.com/newrelic/infrastructure-agent/pkg/plugins/ids"
 	"github.com/newrelic/infrastructure-agent/pkg/plugins/proxy"
+	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/hostid"
 )
 
 func RegisterPlugins(a *agent.Agent) error {
@@ -41,7 +42,7 @@ func RegisterPlugins(a *agent.Agent) error {
 	if config.NtpMetrics.Enabled {
 		ntpMonitor = metrics.NewNtp(config.NtpMetrics.Pool, config.NtpMetrics.Timeout, config.NtpMetrics.Interval)
 	}
-	systemSampler := metrics.NewSystemSampler(a.Context, storageSampler, ntpMonitor)
+	systemSampler := metrics.NewSystemSampler(a.Context, storageSampler, ntpMonitor, hostid.NewProviderEnv())
 
 	sender.RegisterSampler(systemSampler)
 	sender.RegisterSampler(storageSampler)

--- a/pkg/plugins/plugins_linux.go
+++ b/pkg/plugins/plugins_linux.go
@@ -17,6 +17,7 @@ import (
 	"github.com/newrelic/infrastructure-agent/pkg/plugins/ids"
 	"github.com/newrelic/infrastructure-agent/pkg/plugins/proxy"
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/cloud"
+	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/hostid"
 )
 
 func registerForwarderHeartbeat(a *agnt.Agent) {
@@ -122,7 +123,7 @@ func RegisterPlugins(agent *agnt.Agent) error {
 	if config.NtpMetrics.Enabled {
 		ntpMonitor = metrics.NewNtp(config.NtpMetrics.Pool, config.NtpMetrics.Timeout, config.NtpMetrics.Interval)
 	}
-	systemSampler := metrics.NewSystemSampler(agent.Context, storageSampler, ntpMonitor)
+	systemSampler := metrics.NewSystemSampler(agent.Context, storageSampler, ntpMonitor, hostid.NewProviderEnv())
 
 	// Prime Storage Sampler, ignoring results
 	if !storageSampler.Disabled() {

--- a/pkg/plugins/plugins_windows.go
+++ b/pkg/plugins/plugins_windows.go
@@ -9,6 +9,7 @@ import (
 	"github.com/newrelic/infrastructure-agent/pkg/metrics/storage"
 	"github.com/newrelic/infrastructure-agent/pkg/plugins/ids"
 	"github.com/newrelic/infrastructure-agent/pkg/plugins/proxy"
+	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/hostid"
 
 	"github.com/newrelic/infrastructure-agent/internal/agent"
 	pluginsWindows "github.com/newrelic/infrastructure-agent/internal/plugins/windows"
@@ -72,7 +73,7 @@ func RegisterPlugins(a *agent.Agent) error {
 	if config.NtpMetrics.Enabled {
 		ntpMonitor = metrics.NewNtp(config.NtpMetrics.Pool, config.NtpMetrics.Timeout, config.NtpMetrics.Interval)
 	}
-	systemSampler := metrics.NewSystemSampler(a.Context, storageSampler, ntpMonitor)
+	systemSampler := metrics.NewSystemSampler(a.Context, storageSampler, ntpMonitor, hostid.NewProviderEnv())
 	sender.RegisterSampler(systemSampler)
 	sender.RegisterSampler(storageSampler)
 	sender.RegisterSampler(networkSampler)

--- a/pkg/sysinfo/hostid/provider.go
+++ b/pkg/sysinfo/hostid/provider.go
@@ -1,0 +1,25 @@
+// Copyright New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package hostid
+
+import "os"
+
+const hostIDEnv = "NR_HOST_ID"
+
+type Provider interface {
+	Provide() (string, error)
+}
+
+type ProviderEnv struct{}
+
+func NewProviderEnv() *ProviderEnv {
+	return &ProviderEnv{}
+}
+
+func (p *ProviderEnv) Provide() (string, error) {
+	// get host.it from env var
+	hostID, _ := os.LookupEnv(hostIDEnv)
+
+	return hostID, nil
+}

--- a/pkg/sysinfo/hostid/provider_mock.go
+++ b/pkg/sysinfo/hostid/provider_mock.go
@@ -1,0 +1,24 @@
+// Copyright New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package hostid
+
+import "github.com/stretchr/testify/mock"
+
+type ProviderMock struct {
+	mock.Mock
+}
+
+func (m *ProviderMock) Provide() (string, error) {
+	args := m.Called()
+
+	return args.String(0), args.Error(1)
+}
+
+func (m *ProviderMock) ShouldProvide(hostID string) {
+	m.On("Provide").Once().Return(hostID, nil)
+}
+
+func (m *ProviderMock) ShouldNotProvide(err error) {
+	m.On("Provide").Once().Return("", err)
+}

--- a/pkg/sysinfo/hostid/provider_mock.go
+++ b/pkg/sysinfo/hostid/provider_mock.go
@@ -19,6 +19,6 @@ func (m *ProviderMock) ShouldProvide(hostID string) {
 	m.On("Provide").Once().Return(hostID, nil)
 }
 
-func (m *ProviderMock) ShouldNotProvide(err error) {
+func (m *ProviderMock) ShouldReturnErr(err error) {
 	m.On("Provide").Once().Return("", err)
 }

--- a/pkg/sysinfo/hostid/provider_test.go
+++ b/pkg/sysinfo/hostid/provider_test.go
@@ -1,0 +1,61 @@
+// Copyright New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package hostid
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:paralleltest
+func TestMetadataHarvesterDefault(t *testing.T) {
+	testCases := []struct {
+		name           string
+		envVars        map[string]string
+		expectedHostID string
+	}{
+		{
+			name:           "no env vars empty string",
+			expectedHostID: "",
+			envVars:        map[string]string{},
+		},
+		{
+			name:           "no host id expects empty metadata",
+			envVars:        map[string]string{"one_env_var": "some value"},
+			expectedHostID: "",
+		},
+		{
+			name:           "NR_HOST_ID expects the host_id",
+			envVars:        map[string]string{"one_env_var": "some value", "NR_HOST_ID": "the host id"},
+			expectedHostID: "the host id",
+		},
+	}
+
+	//nolint:paralleltest
+	for i := range testCases {
+		testCase := testCases[i]
+		t.Run(testCase.name, func(t *testing.T) {
+			// Set environment variables
+			for envVarKey, envVar := range testCase.envVars {
+				err := os.Setenv(envVarKey, envVar)
+				require.NoError(t, err)
+			}
+
+			provider := ProviderEnv{}
+			actualHostID, err := provider.Provide()
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectedHostID, actualHostID)
+
+			// Unset environment variables
+			for envVarKey := range testCase.envVars {
+				err := os.Unsetenv(envVarKey)
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/test/harvest/hostmetrics_linux_test.go
+++ b/test/harvest/hostmetrics_linux_test.go
@@ -14,15 +14,16 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/shirou/gopsutil/v3/disk"
-
 	"github.com/newrelic/infrastructure-agent/internal/agent/mocks"
 	"github.com/newrelic/infrastructure-agent/internal/testhelpers"
 	"github.com/newrelic/infrastructure-agent/pkg/config"
 	"github.com/newrelic/infrastructure-agent/pkg/metrics"
 	"github.com/newrelic/infrastructure-agent/pkg/metrics/storage"
+	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/hostid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/shirou/gopsutil/v3/disk"
 )
 
 func TestHostSharedMemory(t *testing.T) {
@@ -32,7 +33,10 @@ func TestHostSharedMemory(t *testing.T) {
 	})
 	storageSampler := storage.NewSampler(ctx)
 
-	systemSampler := metrics.NewSystemSampler(ctx, storageSampler, nil)
+	hostIDProvider := &hostid.ProviderMock{}
+	hostIDProvider.On("Provide").Return("some-host-id", nil)
+
+	systemSampler := metrics.NewSystemSampler(ctx, storageSampler, nil, hostid.NewProviderEnv())
 
 	sampleB, _ := systemSampler.Sample()
 	beforeSample := sampleB[0].(*metrics.SystemSample)
@@ -67,7 +71,10 @@ func TestHostCachedMemory(t *testing.T) {
 	})
 	storageSampler := storage.NewSampler(ctx)
 
-	systemSampler := metrics.NewSystemSampler(ctx, storageSampler, nil)
+	hostIDProvider := &hostid.ProviderMock{}
+	hostIDProvider.On("Provide").Return("some-host-id", nil)
+
+	systemSampler := metrics.NewSystemSampler(ctx, storageSampler, nil, hostIDProvider)
 
 	sampleB, _ := systemSampler.Sample()
 	beforeSample := sampleB[0].(*metrics.SystemSample)
@@ -144,7 +151,10 @@ func TestHostSlabMemory(t *testing.T) {
 	})
 	storageSampler := storage.NewSampler(ctx)
 
-	systemSampler := metrics.NewSystemSampler(ctx, storageSampler, nil)
+	hostIDProvider := &hostid.ProviderMock{}
+	hostIDProvider.On("Provide").Return("some-host-id", nil)
+
+	systemSampler := metrics.NewSystemSampler(ctx, storageSampler, nil, hostIDProvider)
 
 	sampleB, _ := systemSampler.Sample()
 	beforeSample := sampleB[0].(*metrics.SystemSample)
@@ -175,7 +185,11 @@ func TestHostBuffersMemory(t *testing.T) {
 		MetricsNetworkSampleRate: 1,
 	})
 	storageSampler := storage.NewSampler(ctx)
-	systemSampler := metrics.NewSystemSampler(ctx, storageSampler, nil)
+
+	hostIDProvider := &hostid.ProviderMock{}
+	hostIDProvider.On("Provide").Return("some-host-id", nil)
+
+	systemSampler := metrics.NewSystemSampler(ctx, storageSampler, nil, hostIDProvider)
 
 	// clear cache
 	err := ioutil.WriteFile("/proc/sys/vm/drop_caches", []byte("3"), 0o200)

--- a/test/harvest/hostmetrics_test.go
+++ b/test/harvest/hostmetrics_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/hostid"
+
 	"github.com/newrelic/infrastructure-agent/internal/agent/mocks"
 	"github.com/newrelic/infrastructure-agent/pkg/config"
 	"github.com/newrelic/infrastructure-agent/pkg/metrics"
@@ -22,7 +24,11 @@ func TestUptime(t *testing.T) {
 		MetricsNetworkSampleRate: 1,
 	})
 	storageSampler := storage.NewSampler(ctx)
-	systemSampler := metrics.NewSystemSampler(ctx, storageSampler, nil)
+
+	hostIDProvider := &hostid.ProviderMock{}
+	hostIDProvider.On("Provide").Return("some-host-id", nil)
+
+	systemSampler := metrics.NewSystemSampler(ctx, storageSampler, nil, hostIDProvider)
 
 	sampleB1, _ := systemSampler.Sample()
 	sample1 := sampleB1[0].(*metrics.SystemSample)

--- a/test/harvest/hostmetrics_unix_test.go
+++ b/test/harvest/hostmetrics_unix_test.go
@@ -8,18 +8,20 @@ package harvest
 
 import (
 	"fmt"
-	"github.com/shirou/gopsutil/v3/cpu"
 	"os"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/shirou/gopsutil/v3/cpu"
+
 	"github.com/newrelic/infrastructure-agent/internal/agent/mocks"
 	"github.com/newrelic/infrastructure-agent/internal/testhelpers"
 	"github.com/newrelic/infrastructure-agent/pkg/config"
 	"github.com/newrelic/infrastructure-agent/pkg/metrics"
 	"github.com/newrelic/infrastructure-agent/pkg/metrics/storage"
+	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/hostid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,7 +34,11 @@ func TestHostCPU(t *testing.T) {
 		MetricsNetworkSampleRate: 1,
 	})
 	storageSampler := storage.NewSampler(ctx)
-	systemSampler := metrics.NewSystemSampler(ctx, storageSampler, nil)
+
+	hostIDProvider := &hostid.ProviderMock{}
+	hostIDProvider.On("Provide").Return("some-host-id", nil)
+
+	systemSampler := metrics.NewSystemSampler(ctx, storageSampler, nil, hostIDProvider)
 
 	// Hacky method to skip this test when CGO (required by gopsutils.cpu.Times() on darwin impl) is not available for tests build.
 	// Context: harvest tests are build in container before pushed to the runner machine for execution.
@@ -81,7 +87,10 @@ func TestHostMemory(t *testing.T) {
 	})
 	storageSampler := storage.NewSampler(ctx)
 
-	systemSampler := metrics.NewSystemSampler(ctx, storageSampler, nil)
+	hostIDProvider := &hostid.ProviderMock{}
+	hostIDProvider.On("Provide").Return("some-host-id", nil)
+
+	systemSampler := metrics.NewSystemSampler(ctx, storageSampler, nil, hostIDProvider)
 
 	sampleB, _ := systemSampler.Sample()
 	beforeSample := sampleB[0].(*metrics.SystemSample)
@@ -125,7 +134,10 @@ func TestHostSwap(t *testing.T) {
 	})
 	storageSampler := storage.NewSampler(ctx)
 
-	systemSampler := metrics.NewSystemSampler(ctx, storageSampler, nil)
+	hostIDProvider := &hostid.ProviderMock{}
+	hostIDProvider.On("Provide").Return("some-host-id", nil)
+
+	systemSampler := metrics.NewSystemSampler(ctx, storageSampler, nil, hostIDProvider)
 
 	sampleB, _ := systemSampler.Sample()
 	sample := sampleB[0].(*metrics.SystemSample)

--- a/test/infra/agent.go
+++ b/test/infra/agent.go
@@ -12,8 +12,8 @@ import (
 	infra "github.com/newrelic/infrastructure-agent/test/infra/http" //nolint:depguard
 
 	"github.com/newrelic/infrastructure-agent/pkg/ctl"
-
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/cloud"
+	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/hostid" //nolint:depguard
 
 	"github.com/newrelic/infrastructure-agent/internal/agent"
 	"github.com/newrelic/infrastructure-agent/internal/agent/delta"
@@ -93,7 +93,7 @@ func NewAgentWithConnectClientAndConfig(connectClient *http.Client, dataClient b
 		panic(err)
 	}
 
-	connectMetadataHarvester := identityapi.NewMetadataHarvesterDefault()
+	connectMetadataHarvester := identityapi.NewMetadataHarvesterDefault(hostid.NewProviderEnv())
 
 	connectSrv := agent.NewIdentityConnectService(connectC, fingerprintHarvester, connectMetadataHarvester)
 

--- a/test/log/log_helper.go
+++ b/test/log/log_helper.go
@@ -4,6 +4,7 @@
 package log
 
 import (
+	"errors"
 	"regexp"
 	"sync"
 
@@ -35,6 +36,17 @@ func (h *InMemoryEntriesHook) GetEntries() []logrus.Entry {
 func (h *InMemoryEntriesHook) EntryWithMessageExists(entry *regexp.Regexp) bool {
 	for _, e := range h.GetEntries() {
 		if entry.MatchString(e.Message) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (h *InMemoryEntriesHook) EntryWithErrorExists(err error) bool {
+	for _, e := range h.GetEntries() {
+		//nolint:forcetypeassert
+		if errors.Is(err, e.Data["error"].(error)) {
 			return true
 		}
 	}


### PR DESCRIPTION
This PR extracts the HostID Provider functionality from the Metadata Provider and it injects into this and the System Sampler.