### PR TITLE
fix local action checksum path

### DIFF
--- a/.github/workflows/prerelease_windows_on_demand.yml
+++ b/.github/workflows/prerelease_windows_on_demand.yml
@@ -78,7 +78,7 @@ jobs:
         run: build\windows\package_zip.ps1 -arch ${{ matrix.goarch }} -version ${{env.FAKE_TAG}}
 
       - name: Generate checksum files
-        uses: ./src/github.com/newrelic/infrastructure-agent/.github/actions/generate-checksums
+        uses: ./.github/actions/generate-checksums
         with:
           files_regex: '.*zip\|.*msi'
           files_path: './${{ env.REPO_WORKDIR }}/dist'


### PR DESCRIPTION
Checkout action v2 and v3 have different behavior regarding checkout path and checksum action is not found.

v2:
```
"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\infrastructure-agent\infrastructure-agent\src\github.com\newrelic\infrastructure-agent
```

v3:
```
"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\infrastructure-agent\infrastructure-agent
```

This PR adjusts the path to v3