### PR TITLE
support Cyberark on Windows

### DIFF
--- a/pkg/databind/internal/secrets/cyberarkcli.go
+++ b/pkg/databind/internal/secrets/cyberarkcli.go
@@ -41,7 +41,7 @@ func CyberArkCLIGatherer(cyberArkCLI *CyberArkCLI) func() (interface{}, error) {
 }
 
 func (g *cyberArkCLIGatherer) get() (data.InterfaceMap, error) {
-	cmd := cyberArkExecCommand(g.cfg.CLI, "GetPassword", "-p", "AppDescs.AppID="+g.cfg.AppID, "-p", "Query=Safe="+g.cfg.Safe+";Folder="+g.cfg.Folder+";Object="+g.cfg.Object, "-o", "Password")
+	cmd := g.cyberArkExecCommand()
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out

--- a/pkg/databind/internal/secrets/cyberarkcli_exec_unix.go
+++ b/pkg/databind/internal/secrets/cyberarkcli_exec_unix.go
@@ -1,0 +1,11 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//go:build unix
+
+package secrets
+
+import "os/exec"
+
+func (g *cyberArkCLIGatherer) cyberArkExecCommand() *exec.Cmd {
+	return cyberArkExecCommand(g.cfg.CLI, "GetPassword", "-p", "AppDescs.AppID="+g.cfg.AppID, "-p", "Query=Safe="+g.cfg.Safe+";Folder="+g.cfg.Folder+";Object="+g.cfg.Object, "-o", "Password")
+}

--- a/pkg/databind/internal/secrets/cyberarkcli_exec_unix_test.go
+++ b/pkg/databind/internal/secrets/cyberarkcli_exec_unix_test.go
@@ -1,0 +1,26 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//go:build unix
+
+package secrets
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_cyberArkExecCommand(t *testing.T) {
+	t.Parallel()
+	cliStruct := CyberArkCLI{
+		CLI:    "/opt/some/path/cli",
+		AppID:  "appid",
+		Safe:   "safe",
+		Folder: "folder",
+		Object: "object",
+	}
+
+	gatherer := cyberArkCLIGatherer{cfg: &cliStruct}
+	cmd := gatherer.cyberArkExecCommand()
+	assert.Equal(t, "/opt/some/path/cli GetPassword -p AppDescs.AppID=appid -p Query=Safe=safe;Folder=folder;Object=object -o Password", cmd.String())
+}

--- a/pkg/databind/internal/secrets/cyberarkcli_exec_windows.go
+++ b/pkg/databind/internal/secrets/cyberarkcli_exec_windows.go
@@ -1,0 +1,11 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//go:build windows
+
+package secrets
+
+import "os/exec"
+
+func (g *cyberArkCLIGatherer) cyberArkExecCommand() *exec.Cmd {
+	return cyberArkExecCommand(g.cfg.CLI, "GetPassword", "/p", "AppDescs.AppID="+g.cfg.AppID, "/p", "Query=Safe="+g.cfg.Safe+";Folder="+g.cfg.Folder+";Object="+g.cfg.Object, "/o", "Password")
+}

--- a/pkg/databind/internal/secrets/cyberarkcli_exec_windows_test.go
+++ b/pkg/databind/internal/secrets/cyberarkcli_exec_windows_test.go
@@ -1,0 +1,26 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//go:build windows
+
+package secrets
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_cyberArkExecCommand(t *testing.T) {
+	t.Parallel()
+	cliStruct := CyberArkCLI{
+		CLI:    `C:\Program Files (x86)\CyberArk\ApplicationPasswordSdk\CLIPasswordSDK.exe`,
+		AppID:  "appid",
+		Safe:   "safe",
+		Folder: "folder",
+		Object: "object",
+	}
+
+	gatherer := cyberArkCLIGatherer{cfg: &cliStruct}
+	cmd := gatherer.cyberArkExecCommand()
+	assert.Equal(t, `C:\Program Files (x86)\CyberArk\ApplicationPasswordSdk\CLIPasswordSDK.exe GetPassword /p AppDescs.AppID=appid /p Query=Safe=safe;Folder=folder;Object=object /o Password`, cmd.String())
+}


### PR DESCRIPTION
CyberArk CLI on Windows is not currently supported. This PR adds support for it.

```
CLIPasswordSDK.exe GetPassword /p AppDescs.AppID=AppBilling /p Query="Safe=PasswordSafe;Folder=Root;Object=Application1" /o Password 
```

https://docs.cyberark.com/credential-providers/Latest/en/Content/CP%20and%20ASCP/CLI-Application-Password-SDK-EgsSyntax.htm#Examples