### PR TITLE
ci: fail if purge CDN fails

### DIFF
--- a/tools/cdn-purge/fastly-purge.go
+++ b/tools/cdn-purge/fastly-purge.go
@@ -107,6 +107,7 @@ func main() {
 
 	if err := purgeCDN(ctx); err != nil {
 		logInfo("cannot purge CDN, error: %v", err)
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
Fail the purge CDN action if the API call to Fastly fails.