### PR TITLE
chore: fix pipeline

### DIFF
--- a/.github/workflows/component_docker_build.yml
+++ b/.github/workflows/component_docker_build.yml
@@ -11,10 +11,14 @@ on:
       TAG:
         required: true
         type: string
+      PUBLISH:
+        default: false
+        required: true
+        type: boolean
 
 env:
   TAG: ${{ inputs.TAG }}
-  DOCKER_PUBLISH: true
+  DOCKER_PUBLISH: ${{ inputs.PUBLISH == true }}
 
 jobs:
   build-container:

--- a/.github/workflows/prerelease_macos.yml
+++ b/.github/workflows/prerelease_macos.yml
@@ -12,7 +12,6 @@ jobs:
     uses: ./.github/workflows/component_macos_unit_test.yml
 
   canaries-macos:
-    needs: [ test-prerelease-macos ]
     uses: ./.github/workflows/component_canaries.yml
     with:
       PLATFORM: "macos"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,7 @@ jobs:
       DOCKER_HUB_PASSWORD: ${{secrets.OHAI_DOCKER_HUB_PASSWORD}}
     with:
       TAG: "0.0.0" # needed for goreleaser test builds
+      PUBLISH: false
 
   test-build:
     uses: ./.github/workflows/component_linux_build.yml

--- a/test/harvest/ansible/roles/run-harvest-tests/tasks/main.yml
+++ b/test/harvest/ansible/roles/run-harvest-tests/tasks/main.yml
@@ -10,6 +10,6 @@
     dest: "{{ ansible_user_dir }}/{{ os_arch_binary_name }}"
     mode: '0755'
 
-- include: "execute-tests-{{ ansible_system }}.yaml"
+- include_tasks: "execute-tests-{{ ansible_system }}.yaml"
 
 ...


### PR DESCRIPTION
- remove missing job of broken workflow
- stop publishing `build-*` images on each push. This was causing race conditions when scanning that image for security. 
- replace deprecated `include:` feature in ansible (updated on the fargate task) fixing:
```
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.
```