### PR TITLE
NR-262015 ci: fix prune previous canaries on pre-release

### DIFF
--- a/.github/workflows/prerelease_linux.yml
+++ b/.github/workflows/prerelease_linux.yml
@@ -150,7 +150,7 @@ jobs:
       CROWDSTRIKE_CUSTOMER_ID: ${{secrets.CROWDSTRIKE_CUSTOMER_ID}}
 
   get_previous_tag:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       previous_tag: ${{ steps.previous_tag_step.outputs.PREVIOUS_TAG }}
     steps:

--- a/.github/workflows/prerelease_linux.yml
+++ b/.github/workflows/prerelease_linux.yml
@@ -149,11 +149,22 @@ jobs:
       CROWDSTRIKE_CLIENT_SECRET: ${{secrets.CROWDSTRIKE_CLIENT_SECRET}}
       CROWDSTRIKE_CUSTOMER_ID: ${{secrets.CROWDSTRIKE_CUSTOMER_ID}}
 
-  prune-canaries-linux:
-    needs: [canaries-linux]
+  get_previous_tag:
+    runs-on: ubuntu-20.04
+    outputs:
+      previous_tag: ${{ steps.previous_tag_step.outputs.PREVIOUS_TAG }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - id: previous_tag_step
+        run: ./.github/workflows/scripts/previous_version.sh ${{ github.event.release.tag_name }} >> "$GITHUB_OUTPUT"
+
+  prune-previous-canaries-linux:
+    needs: [canaries-linux, get_previous_tag]
     uses: ./.github/workflows/component_canaries_prune.yml
     with:
       PLATFORM: "linux"
-      TAG: ${{ github.event.release.tag_name }}
+      TAG: ${{ needs.get_previous_tag.outputs.previous_tag }}
     secrets:
       AWS_VPC_SUBNET: ${{secrets.AWS_VPC_SUBNET}}
+

--- a/.github/workflows/prerelease_windows.yml
+++ b/.github/workflows/prerelease_windows.yml
@@ -134,7 +134,7 @@ jobs:
       CROWDSTRIKE_CUSTOMER_ID: ${{secrets.CROWDSTRIKE_CUSTOMER_ID}}
 
   get_previous_tag:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       previous_tag: ${{ steps.previous_tag_step.outputs.PREVIOUS_TAG }}
     steps:

--- a/.github/workflows/prerelease_windows.yml
+++ b/.github/workflows/prerelease_windows.yml
@@ -133,11 +133,21 @@ jobs:
       CROWDSTRIKE_CLIENT_SECRET: ${{secrets.CROWDSTRIKE_CLIENT_SECRET}}
       CROWDSTRIKE_CUSTOMER_ID: ${{secrets.CROWDSTRIKE_CUSTOMER_ID}}
 
+  get_previous_tag:
+    runs-on: ubuntu-20.04
+    outputs:
+      previous_tag: ${{ steps.previous_tag_step.outputs.PREVIOUS_TAG }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - id: previous_tag_step
+        run: ./.github/workflows/scripts/previous_version.sh ${{ github.event.release.tag_name }} >> "$GITHUB_OUTPUT"
+
   prune-canaries-windows:
-    needs: [canaries-windows]
+    needs: [canaries-windows, get_previous_tag]
     uses: ./.github/workflows/component_canaries_prune.yml
     with:
       PLATFORM: "windows"
-      TAG: ${{ github.event.release.tag_name }}
+      TAG: ${{ needs.get_previous_tag.outputs.previous_tag }}
     secrets:
       AWS_VPC_SUBNET: ${{secrets.AWS_VPC_SUBNET}}


### PR DESCRIPTION
On pre-release, instead of pruning previous canaries we were pruning the recently created ones. This PR fix that
fetching the previous tag and passing it to prune component.