### PR TITLE
chore: remove pre-release macos

### DIFF
--- a/.github/workflows/prerelease_testing.yml
+++ b/.github/workflows/prerelease_testing.yml
@@ -11,11 +11,6 @@ on:
         type: boolean
         default: true
         required: false
-      macos:
-        description: '🍏 Should run tests for MacOS platform?'
-        type: boolean
-        default: true
-        required: false
       windows:
         description: '🪟 Should run tests for Windows platform?'
         type: boolean
@@ -51,17 +46,3 @@ jobs:
       CROWDSTRIKE_CLIENT_ID: ${{secrets.CROWDSTRIKE_CLIENT_ID}}
       CROWDSTRIKE_CLIENT_SECRET: ${{secrets.CROWDSTRIKE_CLIENT_SECRET}}
       CROWDSTRIKE_CUSTOMER_ID: ${{secrets.CROWDSTRIKE_CUSTOMER_ID}}
-
-  test-prerelease-macos:
-    if: ${{ github.event.inputs.macos == 'true' }}
-    uses: ./.github/workflows/component_prerelease_testing.yml
-    with:
-      PLATFORM: "macos"
-      TAG: ${{ github.event.inputs.tag }}
-      TAG_OR_UNIQUE_NAME: "${{ github.event.inputs.tag }}-macos"
-    secrets:
-      AWS_VPC_SUBNET: ${{secrets.AWS_VPC_SUBNET}}
-      CROWDSTRIKE_CLIENT_ID: ${{secrets.CROWDSTRIKE_CLIENT_ID}}
-      CROWDSTRIKE_CLIENT_SECRET: ${{secrets.CROWDSTRIKE_CLIENT_SECRET}}
-      CROWDSTRIKE_CUSTOMER_ID: ${{secrets.CROWDSTRIKE_CUSTOMER_ID}}
-

--- a/test/packaging/ansible/installation-pinned.yml
+++ b/test/packaging/ansible/installation-pinned.yml
@@ -15,7 +15,7 @@
   tasks:
     - name: Installation tests suite
       vars:
-        target_agent_version: "1.47.0" # minimum version for sles 15.5
+        target_agent_version: "1.52.3" # minimum version for ubuntu 24
 
       block:
 


### PR DESCRIPTION
- removes pre-release test on demand for macos which was provisioning machines and trying to run tests that make no sense in the current harness, leaving running machines.
- bumps the min version supported by ubuntu 24 for the pin version test, otherwise it fails for that os since there is no package before it.