### PR TITLE
Add new integrations_only agent mode.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -390,10 +390,18 @@ type Config struct {
 	// Public: No
 	IsForwardOnly bool `yaml:"is_forward_only" envconfig:"is_forward_only" public:"false"`
 
-	// IsSecureForwardOnly has the same behaviour as `IsForwardOnly` but with some inventory data and a heartbeat
+	// IsSecureForwardOnly has the same behaviour as the default but without sending host metrics.
+	// It creates the host entity, sends inventory data and does a heartbeat to not expire the host entity,
+	// it also sends integrations data.
 	// Default: False
 	// Public: No
 	IsSecureForwardOnly bool `yaml:"is_secure_forward_only" envconfig:"is_secure_forward_only" public:"false"`
+
+	// IsIntegrationsOnly has the same behaviour as the default but without creating the host entity on entity platform and
+	// without sending host metrics, it notifies EP to skip the entity by sending the integrations_only inventory entry.
+	// Default: False
+	// Public: No
+	IsIntegrationsOnly bool `envconfig:"is_integrations_only" public:"false" yaml:"is_integrations_only"`
 
 	// K8sIntegration enables the K8sIntegrationSample, this sample returns the names of the integrations that
 	// the agent has configured.

--- a/pkg/config/config_linux_test.go
+++ b/pkg/config/config_linux_test.go
@@ -39,6 +39,7 @@ is_containerized: false
 	c.Assert(cfg.IsContainerized, Equals, false)
 	c.Assert(cfg.IsForwardOnly, Equals, false)
 	c.Assert(cfg.IsSecureForwardOnly, Equals, false)
+	c.Assert(cfg.IsIntegrationsOnly, Equals, false)
 
 	_ = os.Setenv("NRIA_LICENSE_KEY", "abcd1234")
 	_ = os.Setenv("NRIA_COMPACTION_THRESHOLD", "55")
@@ -55,6 +56,7 @@ is_containerized: false
 	_ = os.Setenv("NRIA_IS_CONTAINERIZED", "true")
 	_ = os.Setenv("NRIA_IS_FORWARD_ONLY", "true")
 	_ = os.Setenv("NRIA_IS_SECURE_FORWARD_ONLY", "true")
+	_ = os.Setenv("NRIA_IS_INTEGRATIONS_ONLY", "true")
 
 	defer func() {
 		_ = os.Unsetenv("NRIA_LICENSE_KEY")
@@ -71,6 +73,7 @@ is_containerized: false
 		_ = os.Unsetenv("NRIA_IS_CONTAINERIZED")
 		_ = os.Unsetenv("NRIA_IS_FORWARD_ONLY")
 		_ = os.Unsetenv("NRIA_IS_SECURE_FORWARD_ONLY")
+		_ = os.Unsetenv("NRIA_IS_INTEGRATIONS_ONLY")
 
 		_ = os.Unsetenv("HOST_SYS")
 		_ = os.Unsetenv("HOST_ETC")
@@ -97,6 +100,7 @@ is_containerized: false
 	c.Assert(cfg.IsContainerized, Equals, true)
 	c.Assert(cfg.IsForwardOnly, Equals, true)
 	c.Assert(cfg.IsSecureForwardOnly, Equals, true)
+	c.Assert(cfg.IsIntegrationsOnly, Equals, true)
 }
 
 func TestDefaultConfig(t *testing.T) {

--- a/pkg/plugins/integrations_only.go
+++ b/pkg/plugins/integrations_only.go
@@ -1,0 +1,42 @@
+// Copyright 2024 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+package plugins
+
+import (
+	"github.com/newrelic/infrastructure-agent/internal/agent"
+	"github.com/newrelic/infrastructure-agent/internal/agent/types"
+	"github.com/newrelic/infrastructure-agent/pkg/entity"
+	"github.com/newrelic/infrastructure-agent/pkg/plugins/ids"
+)
+
+// IntegrationsOnlyPlugin is an inventory plugin that will add an inventory entry notifying the agent is running on
+// this mode. This inventory entry will be read by Infra Platform to not send the Host Entity to Entity Platform.
+type IntegrationsOnlyPlugin struct {
+	agent.PluginCommon
+}
+
+type IntegrationsOnly bool
+
+func (io IntegrationsOnly) SortKey() string {
+	return "integrations_only"
+}
+
+func NewIntegrationsOnlyPlugin(id ids.PluginID, ctx agent.AgentContext) agent.Plugin { //nolint:ireturn
+	return &IntegrationsOnlyPlugin{
+		//nolint:exhaustruct
+		PluginCommon: agent.PluginCommon{
+			ID:      id,
+			Context: ctx,
+		},
+	}
+}
+
+// Run This plugin is pretty simple - it simply returns once with the object notifying that integrations_only is enabled.
+func (iop *IntegrationsOnlyPlugin) Run() {
+	iop.Context.AddReconnecting(iop)
+
+	data := types.PluginInventoryDataset{IntegrationsOnly(true)}
+	entityKey := iop.Context.EntityKey()
+
+	iop.EmitInventory(data, entity.NewFromNameWithoutID(entityKey))
+}

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -1,0 +1,24 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+package plugins
+
+import (
+	"github.com/newrelic/infrastructure-agent/internal/agent"
+	"github.com/newrelic/infrastructure-agent/pkg/config"
+	"github.com/newrelic/infrastructure-agent/pkg/plugins/ids"
+)
+
+func isHeartbeatOnlyMode(cfg *config.Config) bool {
+	return cfg.IsSecureForwardOnly || cfg.IsIntegrationsOnly
+}
+
+func registerIntegrationsOnlyPlugin(agt *agent.Agent) {
+	cfg := agt.GetContext().Config()
+	if cfg.IsSecureForwardOnly {
+		slog.Debug("Both Integrations Only mode and Secure Forward Only are enabled, skipping integrations only mode")
+
+		return
+	}
+
+	agt.RegisterPlugin(NewIntegrationsOnlyPlugin(ids.PluginID{Category: "metadata", Term: "infra_agent"}, agt.Context))
+}

--- a/pkg/plugins/plugins_darwin.go
+++ b/pkg/plugins/plugins_darwin.go
@@ -32,6 +32,19 @@ func RegisterPlugins(a *agent.Agent) error {
 		a.RegisterPlugin(NewConfigFilePlugin(*ids.NewPluginID("files", "config"), a.Context))
 	}
 
+	if config.IsIntegrationsOnly {
+		registerIntegrationsOnlyPlugin(a)
+	}
+
+	if isHeartbeatOnlyMode(config) {
+		sender := metricsSender.NewSender(a.Context)
+		heartBeatSampler := metrics.NewHeartbeatSampler(a.Context)
+		sender.RegisterSampler(heartBeatSampler)
+		a.RegisterMetricsSender(sender)
+
+		return nil
+	}
+
 	sender := metricsSender.NewSender(a.Context)
 	procSampler := process.NewProcessSampler(a.Context)
 	storageSampler := storage.NewSampler(a.Context)

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -1,0 +1,87 @@
+// Copyright 2024 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+package plugins
+
+import (
+	"testing"
+
+	"github.com/newrelic/infrastructure-agent/internal/agent"
+	"github.com/newrelic/infrastructure-agent/pkg/config"
+	"github.com/newrelic/infrastructure-agent/test/infra"
+	ihttp "github.com/newrelic/infrastructure-agent/test/infra/http"
+	"github.com/stretchr/testify/assert"
+)
+
+//nolint:exhaustruct
+func TestIsHeartbeatOnlyMode(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		cfg      *config.Config
+		expected bool
+	}{
+		{
+			"default_config",
+			&config.Config{},
+			false,
+		},
+		{
+			"is_secure_forward_only",
+			&config.Config{
+				IsSecureForwardOnly: true,
+			},
+			true,
+		},
+		{
+			"is_integrations_only",
+			&config.Config{
+				IsIntegrationsOnly: true,
+			},
+			true,
+		},
+	}
+	for _, tc := range testCases {
+		testCase := tc
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, testCase.expected, isHeartbeatOnlyMode(testCase.cfg))
+		})
+	}
+}
+
+func TestRegisterIntegrationsOnlyPlugin(t *testing.T) {
+	t.Parallel()
+
+	testClient := ihttp.NewRequestRecorderClient()
+
+	testCases := []struct {
+		name       string
+		agt        *agent.Agent
+		numPlugins int
+	}{
+		{
+			"is_secure_forward_only_and_is_integrations_only",
+			infra.NewAgent(testClient.Client, func(config *config.Config) {
+				config.IsSecureForwardOnly = true
+				config.IsIntegrationsOnly = true
+			}),
+			0,
+		},
+		{
+			"is_integrations_only",
+			infra.NewAgent(testClient.Client, func(config *config.Config) {
+				config.IsIntegrationsOnly = true
+			}),
+			1,
+		},
+	}
+	for _, tc := range testCases {
+		testCase := tc
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			registerIntegrationsOnlyPlugin(testCase.agt)
+			assert.Len(t, testCase.agt.Plugins(), testCase.numPlugins)
+		})
+	}
+}

--- a/pkg/plugins/plugins_windows.go
+++ b/pkg/plugins/plugins_windows.go
@@ -34,12 +34,16 @@ func RegisterPlugins(a *agent.Agent) error {
 
 	a.RegisterPlugin(NewCustomAttrsPlugin(a.Context))
 
-	if config.IsSecureForwardOnly {
-		// We need heartbeat samples.
+	if config.IsIntegrationsOnly {
+		registerIntegrationsOnlyPlugin(a)
+	}
+
+	if isHeartbeatOnlyMode(config) {
 		sender := metricsSender.NewSender(a.Context)
 		heartBeatSampler := metrics.NewHeartbeatSampler(a.Context)
 		sender.RegisterSampler(heartBeatSampler)
 		a.RegisterMetricsSender(sender)
+
 		return nil
 	}
 

--- a/test/harvest/integrations_only_test.go
+++ b/test/harvest/integrations_only_test.go
@@ -1,0 +1,63 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//go:build harvest
+// +build harvest
+
+package harvest
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/newrelic/infrastructure-agent/pkg/backend/inventoryapi"
+	"github.com/newrelic/infrastructure-agent/pkg/config"
+	"github.com/newrelic/infrastructure-agent/pkg/entity"
+	"github.com/newrelic/infrastructure-agent/pkg/plugins"
+	fixture "github.com/newrelic/infrastructure-agent/test/fixture/inventory"
+	"github.com/newrelic/infrastructure-agent/test/infra"
+	ihttp "github.com/newrelic/infrastructure-agent/test/infra/http"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIntegrationsOnlyMode(t *testing.T) {
+	t.Parallel()
+
+	const timeout = 5 * time.Second
+
+	testClient := ihttp.NewRequestRecorderClient()
+	agt := infra.NewAgent(testClient.Client, func(config *config.Config) {
+		config.DisplayName = "my_display_name"
+		config.IsIntegrationsOnly = true
+		config.HeartBeatSampleRate = 1
+	})
+	agt.Context.SetAgentIdentity(entity.Identity{ID: 10, GUID: "abcdef"})
+
+	if err := plugins.RegisterPlugins(agt); err != nil {
+		assert.FailNow(t, "fatal error while registering plugins")
+	}
+	go func() {
+		_ = agt.Run()
+	}()
+
+	var req http.Request
+	select {
+	case req = <-testClient.RequestCh:
+		agt.Terminate()
+	case <-time.After(timeout):
+		agt.Terminate()
+		assert.FailNow(t, "timeout while waiting for a response")
+	}
+
+	fixture.AssertRequestContainsInventoryDeltas(t, req, []*inventoryapi.RawDelta{
+		{
+			Source:   "metadata/infra_agent",
+			ID:       1,
+			FullDiff: true,
+			// Checking some common services that should exist in any linux host
+			Diff: map[string]interface{}{
+				"integrations_only": bool(true),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Adds a new mode to the Infra Agent to cover the scenario where the customer wants Integration Entities, and Host decoration but not Host Entity created by the Infra agent.

New Mode: integrations_only

The Infra Agent will send the running mode as a new inventory entry.

source: metadata/infra_agent

with this format: "metadata/infra_agent" : {"integrations_only": ""}

Infra Platform will read the running mode inventory entry when Integrations Only it will not send the Host Entity to Entity Platform