### PR TITLE
bump FluentBit version to 2.0.0 - Fix CVE-2024-4323

### DIFF
--- a/build/embed/fluent-bit.version
+++ b/build/embed/fluent-bit.version
@@ -5,5 +5,5 @@
 #
 # OS, newrelic_plugin_version, fluent-bit
 
-linux,1.19.1
-windows,1.19.1,1.9.3
+linux,2.0.0
+windows,2.0.0,1.9.3


### PR DESCRIPTION
bumped FluentBit version to 2.0.0 (which includes fluentbit 3.0.4) to fix CVE-2024-4323

Additional information about the CVE can be found here: https://fluentbit.io/blog/2024/05/21/statement-on-cve-2024-4323-and-its-fix/