### PR TITLE
NR-279356: Add new multiline parser config param to logging config

### DIFF
--- a/pkg/integrations/v4/logs/cfg_template.go
+++ b/pkg/integrations/v4/logs/cfg_template.go
@@ -20,6 +20,9 @@ var fbConfigFormat = `{{- range .Inputs }}
     {{- if .SkipLongLines }}
     Skip_Long_Lines {{ .SkipLongLines }}
     {{- end }}
+    {{- if .MultilineParser }}
+    Multiline.Parser {{ .MultilineParser }}
+    {{- end }}
     {{- if .PathKey }}
     Path_Key {{ .PathKey }}
     {{- end }}


### PR DESCRIPTION
### Description
Adds a new config parameter which is `Multiline.Parser` to the `INPUT` block of fluent-bit config which enables the user to parse multiline logs. And this can be enabled by configuring the `multilineParser` for the log file in the `logging.yml` like below.

```
logging.yml 

 -  name: java.log
    file: /var/log/javalogs.log
    multilineParser: java
    attributes:
      logtype: java_logs
```
```
fluent-bit.conf

[INPUT]
    Name tail
    Path /var/log/javalogs.log
    Buffer_Max_Size 128k
    Mem_Buf_Limit 16384k
    Skip_Long_Lines On
    Multiline.Parser java        
    Path_Key filePath
    Tag  java.log
    DB   /var/db/newrelic-infra/newrelic-integrations/logging/fb.db
```

**Note:** Fluent-Bit already has built-in multiline parsers which are java, go, python, docker and cri. And the above changes will only support fluent-bit built-in multiline parsers.
**FYI:** https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/multiline-parsing#built-in-multiline-parsers 
