### PR TITLE
Make discovered config temp file name be calculated with content's md5

### DIFF
--- a/internal/integrations/v4/integration/definition_test.go
+++ b/internal/integrations/v4/integration/definition_test.go
@@ -345,6 +345,7 @@ func TestRun_RemoveExternalConfig(t *testing.T) {
 		path, err := newTempFile(template)
 		if err == nil {
 			createdConfigs = append(createdConfigs, path)
+			require.Equal(t, getDiscoveredTemplateFileName(template), filepath.Base(path))
 		}
 		return path, err
 	}

--- a/internal/integrations/v4/integration/integration_test.go
+++ b/internal/integrations/v4/integration/integration_test.go
@@ -6,16 +6,18 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
 
-	config2 "github.com/newrelic/infrastructure-agent/pkg/integrations/v4/config"
-
 	"github.com/newrelic/infrastructure-agent/internal/integrations/v4/fixtures"
 	"github.com/newrelic/infrastructure-agent/internal/integrations/v4/testhelp"
+	"github.com/newrelic/infrastructure-agent/internal/testhelpers"
 	"github.com/newrelic/infrastructure-agent/pkg/databind/pkg/data"
 	"github.com/newrelic/infrastructure-agent/pkg/databind/pkg/databind"
+	config2 "github.com/newrelic/infrastructure-agent/pkg/integrations/v4/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
@@ -71,6 +73,19 @@ func TestConfigTemplate(t *testing.T) {
 			i, err := NewDefinition(tc.config, ErrLookup, nil, config)
 			require.NoError(t, err)
 
+			// (spy function to get which files have been created)
+			var createdConfigs []string
+			i.newTempFile = func(template []byte) (string, error) {
+				//nolint: govet
+				path, err := newTempFile(template)
+				if err == nil {
+					createdConfigs = append(createdConfigs, path)
+					require.Equal(t, getDiscoveredTemplateFileName(template), filepath.Base(path))
+				}
+
+				return path, err
+			}
+
 			disc := databind.NewValues(nil,
 				databind.NewDiscovery(data.Map{"discovery.ip": "1.2.3.4"}, data.InterfaceMap{"special": true, "label.important": "one"}, nil),
 				databind.NewDiscovery(data.Map{"discovery.ip": "5.6.7.8"}, data.InterfaceMap{"special": false, "label.important": "two"}, nil),
@@ -95,6 +110,14 @@ func TestConfigTemplate(t *testing.T) {
 				assert.Contains(t, out.ExtraLabels, "special")
 				assert.Contains(t, out.ExtraLabels, "label.important")
 			}
+
+			// THEN the external configuration file has been removed
+			testhelpers.Eventually(t, 5*time.Second, func(t require.TestingT) {
+				for _, path := range createdConfigs {
+					_, err := os.Stat(path)
+					assert.Truef(t, os.IsNotExist(err), "expecting file %q to not exist. Error: %v", path, err)
+				}
+			})
 		})
 	}
 }

--- a/internal/integrations/v4/runner/group_test.go
+++ b/internal/integrations/v4/runner/group_test.go
@@ -258,7 +258,7 @@ func TestGroup_Run_ConfigPathUpdated(t *testing.T) {
 	defer cancel()
 	_ = group.Run(ctx)
 
-	// THEN the emitted config path from discovery is different each time
+	// THEN the emitted config path from discovery is not different each time
 	dataset, err := te.ReceiveFrom("cfgpath")
 	require.NoError(t, err)
 	metrics := dataset.DataSet.Metrics
@@ -278,7 +278,7 @@ func TestGroup_Run_ConfigPathUpdated(t *testing.T) {
 	require.NotEmpty(t, secondValue)
 	require.NotEqual(t, "${config.path}", secondValue)
 
-	assert.NotEqual(t, firstValue, secondValue)
+	assert.Equal(t, firstValue, secondValue)
 }
 
 func interceptGroupErrors(gr *Group) <-chan error {


### PR DESCRIPTION
Make discovered config temp file name be calculated with content's md5 to get always same args and avoid miscalculating the integrationID.