### PR TITLE
chore: bump nri-winservices to v1.0.2

### DIFF
--- a/build/embed/integrations.version
+++ b/build/embed/integrations.version
@@ -1,5 +1,5 @@
 #ohi-repo-name,version
 nri-docker,v2.0.6
 nri-flex,v1.15.1
-nri-winservices,v1.0.1
+nri-winservices,v1.0.2
 nri-prometheus,v2.21.4


### PR DESCRIPTION
bump to latest version of integration