### PR TITLE
New health status check and report for the status api

### DIFF
--- a/cmd/newrelic-infra/newrelic-infra.go
+++ b/cmd/newrelic-infra/newrelic-infra.go
@@ -418,7 +418,7 @@ func initializeAgentAndRun(c *config.Config, logFwCfg config.LogForward) error {
 			// This should never happen, as the correct format is checked during NormalizeConfig.
 			aslog.WithError(err).Error("invalid startup_connection_timeout value, cannot run status server")
 		} else {
-			rep := status.NewReporter(agt.Context.Ctx, rlog, c.StatusEndpoints, timeoutD, transport, agt.Context.AgentIdnOrEmpty, agt.Context.EntityKey, c.License, userAgent)
+			rep := status.NewReporter(agt.Context.Ctx, rlog, c.StatusEndpoints, c.HealthEndpoint, timeoutD, transport, agt.Context.AgentIdnOrEmpty, agt.Context.EntityKey, c.License, userAgent)
 
 			apiSrv, err := httpapi.NewServer(rep, integrationEmitter)
 			if c.HTTPServerEnabled {

--- a/internal/agent/status/status_test.go
+++ b/internal/agent/status/status_test.go
@@ -1,5 +1,7 @@
 // Copyright 2021 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+
+//nolint:exhaustruct,noctx
 package status
 
 import (
@@ -9,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	http2 "github.com/newrelic/infrastructure-agent/pkg/backend/http"
+
 	"github.com/newrelic/infrastructure-agent/pkg/entity"
 	"github.com/newrelic/infrastructure-agent/pkg/log"
 	"github.com/stretchr/testify/assert"
@@ -17,45 +21,81 @@ import (
 
 func TestNewReporter_Report(t *testing.T) {
 	serverOk := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
+		w.WriteHeader(http.StatusOK)
 	}))
 	defer serverOk.Close()
+
 	serverTimeout := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(10 * time.Second)
 	}))
 	defer serverTimeout.Close()
 
+	serverUnauthorized := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer serverUnauthorized.Close()
+
 	assert.Eventually(t,
 		func() bool {
 			res, err := serverOk.Client().Get(serverOk.URL)
-			return err == nil && res.StatusCode == 200
+
+			return err == nil && res.StatusCode == http.StatusOK
 		},
 		time.Second, 10*time.Millisecond)
 
 	endpointsOk := []string{serverOk.URL}
+	healthEndpointOK := serverOk.URL
 	endpointsTimeout := []string{serverTimeout.URL}
+	healthEndpointTimeout := serverTimeout.URL
 	endpointsMixed := []string{serverOk.URL, serverTimeout.URL}
+	healthEndpointUnauthorized := serverUnauthorized.URL
 
-	expectReportOk := Report{Checks: &ChecksReport{Endpoints: []EndpointReport{{
-		URL:       serverOk.URL,
-		Reachable: true,
-	}}}}
-	expectReportTimeout := Report{Checks: &ChecksReport{Endpoints: []EndpointReport{{
-		URL:       serverTimeout.URL,
-		Reachable: false,
-		Error:     endpointTimeoutMsg, // substring is enough, it'll assert via "string contains"
-	}}}}
-	expectReportMixed := Report{Checks: &ChecksReport{Endpoints: []EndpointReport{
-		{
-			URL:       serverOk.URL,
-			Reachable: true,
+	expectReportOk := Report{Checks: &ChecksReport{
+		Endpoints: []EndpointReport{
+			{
+				URL:       serverOk.URL,
+				Reachable: true,
+				Error:     "",
+			},
 		},
-		{
-			URL:       serverTimeout.URL,
-			Reachable: false,
-			Error:     endpointTimeoutMsg,
+		Health: HealthReport{
+			Healthy: true,
+			Error:   "",
 		},
-	}}}
+	}, Config: nil}
+
+	expectReportTimeout := Report{Checks: &ChecksReport{
+		Endpoints: []EndpointReport{
+			{
+				URL:       serverTimeout.URL,
+				Reachable: false,
+				Error:     endpointTimeoutMsg, // substring is enough, it'll assert via "string contains"
+			},
+		},
+		Health: HealthReport{
+			Healthy: false,
+			Error:   "context deadline exceeded",
+		},
+	}, Config: nil}
+
+	expectReportMixed := Report{Checks: &ChecksReport{
+		Endpoints: []EndpointReport{
+			{
+				URL:       serverOk.URL,
+				Reachable: true,
+				Error:     "",
+			},
+			{
+				URL:       serverTimeout.URL,
+				Reachable: false,
+				Error:     endpointTimeoutMsg,
+			},
+		},
+		Health: HealthReport{
+			Healthy: false,
+			Error:   http2.ErrUnexepectedResponseCode.Error(),
+		},
+	}, Config: nil}
 
 	timeout := 10 * time.Millisecond
 	transport := &http.Transport{}
@@ -66,19 +106,20 @@ func TestNewReporter_Report(t *testing.T) {
 		return ""
 	}
 	tests := []struct {
-		name      string
-		endpoints []string
-		want      Report
-		wantErr   bool
+		name           string
+		endpoints      []string
+		healthEndpoint string
+		want           Report
+		wantErr        bool
 	}{
-		{"connectivity ok", endpointsOk, expectReportOk, false},
-		{"connectivity timedout", endpointsTimeout, expectReportTimeout, false},
-		{"connectivities ok and timeout", endpointsMixed, expectReportMixed, false},
+		{"connectivity ok", endpointsOk, healthEndpointOK, expectReportOk, false},
+		{"connectivity timedout", endpointsTimeout, healthEndpointTimeout, expectReportTimeout, false},
+		{"connectivities ok and timeout and unhealthy", endpointsMixed, healthEndpointUnauthorized, expectReportMixed, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			l := log.WithComponent(tt.name)
-			r := NewReporter(context.Background(), l, tt.endpoints, timeout, transport, emptyIDProvide, emptyEntityKeyProvider, "user-agent", "agent-key")
+			r := NewReporter(context.Background(), l, tt.endpoints, tt.healthEndpoint, timeout, transport, emptyIDProvide, emptyEntityKeyProvider, "user-agent", "agent-key")
 
 			got, err := r.Report()
 
@@ -103,21 +144,25 @@ func TestNewReporter_Report(t *testing.T) {
 				assert.Equal(t, expectedEndpoint.Reachable, gotEndpoint.Reachable)
 				assert.Contains(t, gotEndpoint.Error, expectedEndpoint.Error)
 			}
+			assert.Equal(t, tt.want.Checks.Health.Healthy, got.Checks.Health.Healthy)
+			assert.Contains(t, got.Checks.Health.Error, tt.want.Checks.Health.Error)
 		})
 	}
 }
 
 func TestNewReporter_ReportErrors(t *testing.T) {
 	serverOk := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
+		w.WriteHeader(http.StatusOK)
 	}))
 	defer serverOk.Close()
+
 	serverTimeout := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(10 * time.Second)
 	}))
 	defer serverTimeout.Close()
 
 	endpointsOk := []string{serverOk.URL}
+	healthEndpointOK := serverOk.URL
 	endpointsTimeout := []string{serverTimeout.URL}
 	endpointsMixed := []string{serverOk.URL, serverTimeout.URL}
 
@@ -156,7 +201,7 @@ func TestNewReporter_ReportErrors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			l := log.WithComponent(tt.name)
-			r := NewReporter(context.Background(), l, tt.endpoints, timeout, transport, emptyIDProvide, emptyEntityKeyProvider, "user-agent", "agent-key")
+			r := NewReporter(context.Background(), l, tt.endpoints, healthEndpointOK, timeout, transport, emptyIDProvide, emptyEntityKeyProvider, "user-agent", "agent-key")
 
 			got, err := r.ReportErrors()
 
@@ -205,6 +250,7 @@ func TestNewReporter_ReportEntity(t *testing.T) {
 		{"foo guid", "foo", "", ReportEntity{GUID: "foo"}, false},
 		{"foo guid bar key", "foo", "bar", ReportEntity{GUID: "foo", Key: "bar"}, false},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			idProvide := func() entity.Identity {
@@ -216,7 +262,7 @@ func TestNewReporter_ReportEntity(t *testing.T) {
 			entityKeyProvider := func() string {
 				return tt.entityKey
 			}
-			r := NewReporter(context.Background(), l, []string{}, timeout, transport, idProvide, entityKeyProvider, "user-agent", "agent-key")
+			r := NewReporter(context.Background(), l, []string{}, "", timeout, transport, idProvide, entityKeyProvider, "user-agent", "agent-key")
 
 			got, err := r.ReportEntity()
 
@@ -227,6 +273,84 @@ func TestNewReporter_ReportEntity(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.guid, got.GUID)
+		})
+	}
+}
+
+//nolint:paralleltest
+func TestNewReporter_ReportHealth(t *testing.T) {
+	serverOk := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer serverOk.Close()
+
+	serverTimeout := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+	}))
+	defer serverTimeout.Close()
+
+	serverUnauthorized := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer serverUnauthorized.Close()
+
+	assert.Eventually(t,
+		func() bool {
+			res, err := serverOk.Client().Get(serverOk.URL)
+			defer func() {
+				_ = res.Body.Close()
+			}()
+
+			return err == nil && res.StatusCode == 200
+		},
+		time.Second, 10*time.Millisecond)
+
+	healthEndpointOK := serverOk.URL
+	healthEndpointTimeout := serverTimeout.URL
+	healthEndpointUnauthorized := serverUnauthorized.URL
+
+	expectReportOk := HealthReport{
+		Healthy: true,
+		Error:   "",
+	}
+
+	expectReportTimeout := HealthReport{
+		Healthy: false,
+		Error:   "context deadline exceeded",
+	}
+
+	expectReportUnauthorized := HealthReport{
+		Healthy: false,
+		Error:   http2.ErrUnexepectedResponseCode.Error(),
+	}
+
+	timeout := 10 * time.Millisecond
+	transport := &http.Transport{}
+	emptyIDProvide := func() entity.Identity {
+		return entity.EmptyIdentity
+	}
+	emptyEntityKeyProvider := func() string {
+		return ""
+	}
+	tests := []struct {
+		name           string
+		healthEndpoint string
+		want           HealthReport
+	}{
+		{"connectivity ok", healthEndpointOK, expectReportOk},
+		{"connectivity timedout", healthEndpointTimeout, expectReportTimeout},
+		{"unhealthy", healthEndpointUnauthorized, expectReportUnauthorized},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			l := log.WithComponent(testCase.name)
+			r := NewReporter(context.Background(), l, nil, testCase.healthEndpoint, timeout, transport, emptyIDProvide, emptyEntityKeyProvider, "user-agent", "agent-key")
+
+			got := r.ReportHealth()
+
+			assert.Equal(t, testCase.want.Healthy, got.Healthy)
+			assert.Contains(t, got.Error, testCase.want.Error)
 		})
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -979,10 +979,15 @@ type Config struct {
 	// Public: Yes
 	StatusServerPort int `yaml:"status_server_port" envconfig:"status_server_port"`
 
-	// StatusServerPort Set the port for status server.
+	// StatusEndpoints Status endpoints to check reachability.
 	// Default: IdentityURL, CommandChannelURL, MetricsIngestURL, InventoryIngestURL
 	// Public: Yes
 	StatusEndpoints []string `yaml:"status_endpoints" envconfig:"status_endpoints"`
+
+	// HealthEndpoint to check backend connection healthiness.
+	// Default: CommandChannelURL
+	// Public: Yes
+	HealthEndpoint string `envconfig:"health_endpoint" yaml:"health_endpoint"`
 
 	// AppDataDir This option is only for Windows. It defines the path to store data in a different path than the
 	// program files directory.
@@ -2164,6 +2169,10 @@ func NormalizeConfig(cfg *Config, cfgMetadata config_loader.YAMLMetadata) (err e
 			// cfg.DMIngestURL(), // dimensional metrics without shimming not available yet
 			// no endpoint value to checking log ingest reachability
 		}
+	}
+
+	if cfg.HealthEndpoint == "" {
+		cfg.HealthEndpoint = cfg.CommandChannelURL + cfg.CommandChannelEndpoint
 	}
 
 	// MetricsIngestEndpoint default value defined in NewConfig


### PR DESCRIPTION
New health status check and report for the status api, it detects if the CommandApi is not returning a 200. For example if License Key is incorrect.