### PR TITLE
Fix pipeline fluentbit legacy windows

### DIFF
--- a/test/automated/ansible/group_vars/localhost/main.yml
+++ b/test/automated/ansible/group_vars/localhost/main.yml
@@ -169,13 +169,6 @@ instances:
   ############################
   # redhat amd64
   ############################
-  - ami: "ami-0680f7cf1ea8cb793"
-    type: "t3a.small"
-    name: "amd64:redhat-7.9"
-    username: "ec2-user"
-    platform: "linux"
-    python_interpreter: "/usr/bin/python"
-    launch_template: "LaunchTemplateId=lt-0b00afb3f5110a0e6,Version=3"
   - ami: "ami-0ba62214afa52bec7"
     type: "t3a.small"
     name: "amd64:redhat-8.4"
@@ -193,13 +186,6 @@ instances:
   ############################
   # redhat arm64
   ############################
-  - ami: "ami-0302c1ecc74930ba5"
-    type: "t4g.small"
-    name: "arm64:redhat-7.6"
-    username: "ec2-user"
-    platform: "linux"
-    python_interpreter: "/usr/bin/python"
-    launch_template: "LaunchTemplateId=lt-0b00afb3f5110a0e6,Version=3"
   - ami: "ami-01089181b0aa3be51"
     type: "t4g.small"
     name: "arm64:redhat-9.0"

--- a/test/packaging/ansible/log-forwarder.yml
+++ b/test/packaging/ansible/log-forwarder.yml
@@ -161,22 +161,13 @@
             log_forwader_supported: true
           when: inventory_hostname is search("windows")
 
-        - name: repo setup
+        - name: install agent
           include_role:
-            name: repo-setup
-          when: log_forwader_supported is defined
-
-        - name: setup config
-          include_role:
-            name: setup-config
+            name: caos.ansible_roles.infra_agent
           vars:
             log_level: 'debug'
             log_forward: 'true'
-          when: log_forwader_supported is defined
-
-        - name: install agent
-          include_role:
-            name: agent-install
+            repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
           when: log_forwader_supported is defined
 
         # Not available for ARM yet

--- a/test/provision/terraform/caos.auto.tfvars.dist
+++ b/test/provision/terraform/caos.auto.tfvars.dist
@@ -2,9 +2,9 @@ ec2_prefix = "PREFIX:TAG_OR_UNIQUE_NAME"
 
 windows_ec2 = ["windows_2012", "windows_2016", "windows_2019", "windows_2022"]
 
-linux_ec2_amd = ["amd64:ubuntu24.04", "amd64:ubuntu22.04", "amd64:ubuntu20.04", "amd64:ubuntu18.04", "amd64:centos-stream", "amd64:sles-12.5", "amd64:sles-15.3",  "amd64:sles-15.4", "amd64:sles-15.5", "amd64:redhat-7.9", "amd64:redhat-8.4", "amd64:redhat-9.0", "amd64:debian-bookworm", "amd64:al-2", "amd64:al-2023"]
+linux_ec2_amd = ["amd64:ubuntu24.04", "amd64:ubuntu22.04", "amd64:ubuntu20.04", "amd64:ubuntu18.04", "amd64:centos-stream", "amd64:sles-12.5", "amd64:sles-15.3",  "amd64:sles-15.4", "amd64:sles-15.5", "amd64:redhat-8.4", "amd64:redhat-9.0", "amd64:debian-bookworm", "amd64:al-2", "amd64:al-2023"]
 
-linux_ec2_arm = ["arm64:ubuntu24.04", "arm64:ubuntu22.04", "arm64:ubuntu20.04", "arm64:ubuntu18.04", "arm64:centos-stream", "arm64:sles-15.3",  "arm64:sles-15.4", "arm64:sles-15.5", "arm64:redhat-7.6", "arm64:redhat-9.0", "arm64:debian-bookworm", "arm64:al-2", "arm64:al-2023"]
+linux_ec2_arm = ["arm64:ubuntu24.04", "arm64:ubuntu22.04", "arm64:ubuntu20.04", "arm64:ubuntu18.04", "arm64:centos-stream", "arm64:sles-15.3",  "arm64:sles-15.4", "arm64:sles-15.5", "arm64:redhat-9.0", "arm64:debian-bookworm", "arm64:al-2", "arm64:al-2023"]
 
 ssh_pub_key      = "AAAAB3NzaC1yc2EAAAADAQABAAABAQDH9C7BS2XrtXGXFFyL0pNku/Hfy84RliqvYKpuslJFeUivf5QY6Ipi8yXfXn6TsRDbdxfGPi6oOR60Fa+4cJmCo6N5g57hBS6f2IdzQBNrZr7i1I/a3cFeK6XOc1G1tQaurx7Pu+qvACfJjLXKG66tHlaVhAHd/1l2FocgFNUDFFuKS3mnzt9hKys7sB4aO3O0OdohN/0NJC4ldV8/OmeXqqfkiPWcgPx3C8bYyXCX7QJNBHKrzbX1jW51Px7SIDWFDV6kxGwpQGGBMJg/k79gjjM+jhn4fg1/VP/Fx37mAnfLqpcTfiOkzSE80ORGefQ1XfGK/Dpa3ITrzRYW8xlR caos-dev-arm"
 pvt_key          = "~/.ssh/caos-dev-arm.cer"


### PR DESCRIPTION
Use caos ansible roles for tests.
Remove RHEL 7  from our canaries since docker is no longer on their yum repos https://download.docker.com/linux/rhel/7/.
They also removed the support from https://docs.docker.com/engine/install/rhel/.