### PR TITLE
chore: remove eol os testing (NR-291541)

### DIFF
--- a/.github/workflows/component_molecule_packaging.yml
+++ b/.github/workflows/component_molecule_packaging.yml
@@ -27,4 +27,4 @@ jobs:
           repo_base_url: ${{ inputs.REPO_ENDPOINT }}
           package_name: 'newrelic-infra'
           package_version: ${{ inputs.TAG }}
-          platforms: "al2,al2023,centos7,centos8,debian-bullseye,debian-bookworm,redhat8,redhat9,suse15.3,suse15.4,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204,ubuntu2404"
+          platforms: "al2,al2023,debian-bullseye,debian-bookworm,redhat8,redhat9,suse15.3,suse15.4,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204,ubuntu2404"

--- a/test/automated/ansible/group_vars/localhost/main.yml
+++ b/test/automated/ansible/group_vars/localhost/main.yml
@@ -270,12 +270,6 @@ instances:
   ############################
   # windows amd64
   ############################
-  - ami: "ami-0c5d73971003d1ab0"
-    type: "t3a.small"
-    name: "amd64:windows_2012"
-    username: "ansible"
-    platform: "windows"
-    launch_template: "LaunchTemplateId=lt-005e12ef728c179bf,Version=3"
   - ami: "ami-03d46abfa414238dd"
     type: "t3a.small"
     name: "amd64:windows_2016"

--- a/test/provision/terraform/caos.auto.tfvars.dist
+++ b/test/provision/terraform/caos.auto.tfvars.dist
@@ -1,10 +1,10 @@
 ec2_prefix = "PREFIX:TAG_OR_UNIQUE_NAME"
 
-windows_ec2 = ["windows_2012", "windows_2016", "windows_2019", "windows_2022"]
+windows_ec2 = ["windows_2016", "windows_2019", "windows_2022"]
 
-linux_ec2_amd = ["amd64:ubuntu24.04", "amd64:ubuntu22.04", "amd64:ubuntu20.04", "amd64:ubuntu18.04", "amd64:centos-stream", "amd64:sles-12.5", "amd64:sles-15.3",  "amd64:sles-15.4", "amd64:sles-15.5", "amd64:redhat-8.4", "amd64:redhat-9.0", "amd64:debian-bookworm", "amd64:al-2", "amd64:al-2023"]
+linux_ec2_amd = ["amd64:ubuntu24.04", "amd64:ubuntu22.04", "amd64:ubuntu20.04", "amd64:ubuntu18.04", "amd64:ubuntu16.04", "amd64:centos-stream", "amd64:sles-12.5", "amd64:sles-15.3",  "amd64:sles-15.4", "amd64:sles-15.5", "amd64:redhat-8.4", "amd64:redhat-9.0", "amd64:debian-bookworm", "amd64:al-2", "amd64:al-2023"]
 
-linux_ec2_arm = ["arm64:ubuntu24.04", "arm64:ubuntu22.04", "arm64:ubuntu20.04", "arm64:ubuntu18.04", "arm64:centos-stream", "arm64:sles-15.3",  "arm64:sles-15.4", "arm64:sles-15.5", "arm64:redhat-9.0", "arm64:debian-bookworm", "arm64:al-2", "arm64:al-2023"]
+linux_ec2_arm = ["arm64:ubuntu24.04", "arm64:ubuntu22.04", "arm64:ubuntu20.04", "arm64:ubuntu18.04", "arm64:ubuntu16.04", "arm64:centos-stream", "arm64:sles-15.3",  "arm64:sles-15.4", "arm64:sles-15.5", "arm64:redhat-9.0", "arm64:debian-bookworm", "arm64:al-2", "arm64:al-2023"]
 
 ssh_pub_key      = "AAAAB3NzaC1yc2EAAAADAQABAAABAQDH9C7BS2XrtXGXFFyL0pNku/Hfy84RliqvYKpuslJFeUivf5QY6Ipi8yXfXn6TsRDbdxfGPi6oOR60Fa+4cJmCo6N5g57hBS6f2IdzQBNrZr7i1I/a3cFeK6XOc1G1tQaurx7Pu+qvACfJjLXKG66tHlaVhAHd/1l2FocgFNUDFFuKS3mnzt9hKys7sB4aO3O0OdohN/0NJC4ldV8/OmeXqqfkiPWcgPx3C8bYyXCX7QJNBHKrzbX1jW51Px7SIDWFDV6kxGwpQGGBMJg/k79gjjM+jhn4fg1/VP/Fx37mAnfLqpcTfiOkzSE80ORGefQ1XfGK/Dpa3ITrzRYW8xlR caos-dev-arm"
 pvt_key          = "~/.ssh/caos-dev-arm.cer"


### PR DESCRIPTION
removed testing for eol OS out of [support](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent/) 