### PR TITLE
feat: bump minimal agent version for agent upgrade scenarios

### DIFF
--- a/test/packaging/ansible/agent-upgrade.yml
+++ b/test/packaging/ansible/agent-upgrade.yml
@@ -15,7 +15,7 @@
   tasks:
     - name: agent upgrade tests suite
       vars:
-        target_agent_version: "1.52.3"
+        target_agent_version: "1.57.2"
 
       block:
 

--- a/test/packaging/ansible/installation-pinned.yml
+++ b/test/packaging/ansible/installation-pinned.yml
@@ -15,7 +15,7 @@
   tasks:
     - name: Installation tests suite
       vars:
-        target_agent_version: "1.52.3" # minimum version for ubuntu 24
+        target_agent_version: "1.57.2"
 
       block:
 


### PR DESCRIPTION
The new minimum version is supported by SUSE 15.6, else the pipelines will fail on the agent upgrade scenario.