### PR TITLE
Nr 116101 - Make TTL not mandatory in secret management command

### DIFF
--- a/pkg/databind/internal/secrets/command.go
+++ b/pkg/databind/internal/secrets/command.go
@@ -36,9 +36,8 @@ var (
 	ErrValidation             = errors.New("validation error")
 	ErrCommandRun             = errors.New("failed to run command")
 	ErrParseCommandResponse   = errors.New("failed to parse command response")
-
-	ErrTTLNotFound = errors.New("TTL value not found")
-	ErrTTLInvalid  = errors.New("TTL value is not valid")
+	ErrTTLNotFound            = errors.New("TTL value not found")
+	ErrTTLInvalid             = errors.New("TTL value is not valid")
 )
 
 func commandExitError(exitErr *exec.ExitError) error {
@@ -87,14 +86,15 @@ func (c *cmdResponse) UnmarshalJSON(data []byte) error {
 func (c *cmdResponse) TTL() (time.Duration, error) {
 
 	if c.CmdTTL == "" {
-		return 0, ErrTTLNotFound
+		return 0, ErrTTLNotFound //nolint:wrapcheck
 	}
 
-	if duration, err := time.ParseDuration(c.CmdTTL); err != nil {
-		return 0, ErrTTLInvalid
-	} else {
-		return duration, nil
+	duration, err := time.ParseDuration(c.CmdTTL)
+	if err != nil {
+		return 0, ErrTTLInvalid //nolint:wrapcheck
 	}
+
+	return duration, nil
 }
 
 func (c *cmdResponse) Data() (map[string]any, error) {

--- a/pkg/databind/internal/secrets/command.go
+++ b/pkg/databind/internal/secrets/command.go
@@ -36,6 +36,9 @@ var (
 	ErrValidation             = errors.New("validation error")
 	ErrCommandRun             = errors.New("failed to run command")
 	ErrParseCommandResponse   = errors.New("failed to parse command response")
+
+	ErrTTLNotFound = errors.New("TTL value not found")
+	ErrTTLInvalid  = errors.New("TTL value is not valid")
 )
 
 func commandExitError(exitErr *exec.ExitError) error {
@@ -82,7 +85,16 @@ func (c *cmdResponse) UnmarshalJSON(data []byte) error {
 }
 
 func (c *cmdResponse) TTL() (time.Duration, error) {
-	return time.ParseDuration(c.CmdTTL)
+
+	if c.CmdTTL == "" {
+		return 0, ErrTTLNotFound
+	}
+
+	if duration, err := time.ParseDuration(c.CmdTTL); err != nil {
+		return 0, ErrTTLInvalid
+	} else {
+		return duration, nil
+	}
 }
 
 func (c *cmdResponse) Data() (map[string]any, error) {

--- a/pkg/databind/internal/secrets/command_test.go
+++ b/pkg/databind/internal/secrets/command_test.go
@@ -92,6 +92,19 @@ func TestCommandGatherer(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "cmdResponseWithDataWithoutTTL",
+			command: &Command{
+				Path:           "echo",
+				Args:           []string{"{\"data\": {\"testKey\": \"testVal\"}}"},
+				PassthroughEnv: nil,
+			},
+			want: &cmdResponse{
+				CmdData: map[string]any{"testKey": "testVal"},
+				CmdTTL:  "",
+			},
+			wantErr: false,
+		},
 	}
 	if runtime.GOOS != "windows" {
 		tests = append(tests, []commandTestCase{

--- a/pkg/databind/pkg/databind/binder.go
+++ b/pkg/databind/pkg/databind/binder.go
@@ -12,8 +12,6 @@ import (
 )
 
 var (
-	ErrTTLNotFound  = errors.New("TTL value not found")
-	ErrTTLInvalid   = errors.New("TTL value is not valid")
 	ErrDataNotFound = errors.New("data value not found")
 	ErrDataInvalid  = errors.New("data must be an map")
 )

--- a/pkg/databind/pkg/databind/binder_test.go
+++ b/pkg/databind/pkg/databind/binder_test.go
@@ -183,7 +183,7 @@ func Test_GathererCacheTtlFromPayload(t *testing.T) {
 			expectedTTLInCache: time.Second * 35,
 		},
 		{
-			name:            "no ttl shoul fallback to default ttl",
+			name:            "no ttl should fallback to default ttl",
 			cacheInitialTTL: time.Second * 35,
 			mockData: dataWithTTL{
 				"data": map[string]interface{}{"some data": "in a map"},

--- a/pkg/databind/pkg/databind/binder_test.go
+++ b/pkg/databind/pkg/databind/binder_test.go
@@ -179,7 +179,8 @@ func Test_GathererCacheTtlFromPayload(t *testing.T) {
 				"ttl":  "invalid duration",
 				"data": map[string]interface{}{"some data": "in a map"},
 			},
-			expectedTTLInCache: defaultVariablesTTL,
+			expectedError:      secrets.ErrTTLInvalid,
+			expectedTTLInCache: time.Second * 35,
 		},
 		{
 			name:            "no ttl shoul fallback to default ttl",

--- a/pkg/databind/pkg/databind/cache.go
+++ b/pkg/databind/pkg/databind/cache.go
@@ -92,7 +92,11 @@ func (d *gatherer) do(now time.Time) (interface{}, error) {
 		if err != nil {
 			if errors.Is(err, secrets.ErrTTLNotFound) {
 				// infra-agent will start even when TTL is not provided
-				log.Warn("Please provide TTL. Using Default TTL")
+				log.Warn(fmt.Printf(
+					"%s. Using Default TTL (%s)",
+					secrets.ErrTTLNotFound,
+					time.Duration(defaultVariablesTTL)*time.Second
+				))
 				d.cache.ttl = defaultVariablesTTL
 			} else {
 				return nil, fmt.Errorf("invalid gathered TTL: %w", err) //nolint:wrapcheck

--- a/pkg/databind/pkg/databind/cache.go
+++ b/pkg/databind/pkg/databind/cache.go
@@ -92,11 +92,7 @@ func (d *gatherer) do(now time.Time) (interface{}, error) {
 		if err != nil {
 			if errors.Is(err, secrets.ErrTTLNotFound) {
 				// infra-agent will start even when TTL is not provided
-				log.Warn(fmt.Printf(
-					"%s. Using Default TTL (%s)",
-					secrets.ErrTTLNotFound,
-					time.Duration(defaultVariablesTTL)*time.Second
-				))
+				log.Warnf("%s. Using Default TTL (%s)", secrets.ErrTTLNotFound, defaultVariablesTTL)
 				d.cache.ttl = defaultVariablesTTL
 			} else {
 				return nil, fmt.Errorf("invalid gathered TTL: %w", err) //nolint:wrapcheck

--- a/pkg/databind/pkg/databind/cache.go
+++ b/pkg/databind/pkg/databind/cache.go
@@ -90,7 +90,7 @@ func (d *gatherer) do(now time.Time) (interface{}, error) {
 	if dataWithTTL, ok := vals.(ValuesWithTTL); ok {
 		ttl, err := dataWithTTL.TTL()
 		if err != nil {
-			if errors.Is(err, secrets.ErrTTLNotFound) || errors.Is(err, secrets.ErrTTLInvalid) {
+			if errors.Is(err, secrets.ErrTTLNotFound) {
 				// infra-agent will start even when TTL is not provided
 				log.Warn("Please provide TTL. Using Default TTL")
 				d.cache.ttl = defaultVariablesTTL

--- a/pkg/databind/pkg/databind/cache.go
+++ b/pkg/databind/pkg/databind/cache.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/newrelic/infrastructure-agent/pkg/databind/internal/discovery"
+	"github.com/newrelic/infrastructure-agent/pkg/databind/internal/secrets"
+	"github.com/newrelic/infrastructure-agent/pkg/log"
 )
 
 // cachedEntry allows storing a value for a given Time-To-Live.
@@ -87,11 +89,15 @@ func (d *gatherer) do(now time.Time) (interface{}, error) {
 
 	if dataWithTTL, ok := vals.(ValuesWithTTL); ok {
 		ttl, err := dataWithTTL.TTL()
-		if err != nil && !errors.Is(err, ErrTTLNotFound) {
-			return nil, fmt.Errorf("invalid gathered TTL: %w", err) //nolint:wrapcheck
-		}
-
-		if err == nil {
+		if err != nil {
+			if errors.Is(err, secrets.ErrTTLNotFound) || errors.Is(err, secrets.ErrTTLInvalid) {
+				// infra-agent will start even when TTL is not provided
+				log.Warn("Please provide TTL. Using Default TTL")
+				d.cache.ttl = defaultVariablesTTL
+			} else {
+				return nil, fmt.Errorf("invalid gathered TTL: %w", err) //nolint:wrapcheck
+			}
+		} else {
 			d.cache.ttl = ttl
 		}
 


### PR DESCRIPTION
Scenarios handled:

If ttl is not present: use default ( DefaultTTL is used and a warning is logged to provide TTL )

If ttl is present and valid: override default ( wask as usual )

If ttl is present and invalid: throw an error ( Invalid TTL value throws error `ErrTTLInvalid` and agent does not start.