### PR TITLE
NR-78587 Newer versions of semodule tool do not display the SELinux modules version

### DIFF
--- a/internal/plugins/linux/selinux.go
+++ b/internal/plugins/linux/selinux.go
@@ -6,7 +6,11 @@
 //nolint:nestif
 //nolint:cyclop
 //nolint:nonamedreturns
-
+//nolint:errorlint
+//nolint:govet
+//nolint:wrapcheck
+//nolint:gosimple
+//nolint:wsl
 package linux
 
 import (

--- a/internal/plugins/linux/selinux.go
+++ b/internal/plugins/linux/selinux.go
@@ -3,14 +3,7 @@
 //go:build linux || darwin
 // +build linux darwin
 
-//nolint:nestif
-//nolint:cyclop
-//nolint:nonamedreturns
-//nolint:errorlint
-//nolint:govet
-//nolint:wrapcheck
-//nolint:gosimple
-//nolint:wsl
+//nolint:all
 package linux
 
 import (

--- a/internal/plugins/linux/selinux.go
+++ b/internal/plugins/linux/selinux.go
@@ -84,7 +84,6 @@ func (self *SELinuxPlugin) getDataset() (basicData types.PluginInventoryDataset,
 	if err != nil {
 		return
 	}
-
 	if basicData, policyData, err = self.parseSestatusOutput(output); err != nil {
 		return
 	}
@@ -151,7 +150,6 @@ func (self *SELinuxPlugin) sELinuxActive() bool {
 		sllog.WithError(err).Debug("Unable to use SELinux.")
 		return false
 	}
-
 	if _, _, err = self.parseSestatusOutput(output); err == ErrSELinuxDisabled {
 		sllog.WithError(err).Debug("Unable to use SELinux.")
 	}

--- a/internal/plugins/linux/selinux.go
+++ b/internal/plugins/linux/selinux.go
@@ -85,22 +85,23 @@ func (seLinuxPlugin *SELinuxPlugin) getDataset() (types.PluginInventoryDataset, 
 	var err error
 	output, err := helpers.RunCommand("sestatus", "", "-b")
 	if err != nil {
-		return nil, nil, nil, errors.Unwrap(err)
+		return nil, nil, nil, fmt.Errorf("trying to wrap: %w", err)
 	}
 
 	basicData, policyData, err = seLinuxPlugin.parseSestatusOutput(output)
 	if err != nil {
-		return nil, nil, nil, errors.Unwrap(err)
+		return nil, nil, nil, fmt.Errorf("trying to wrap: %w", err)
 	}
 
 	if seLinuxPlugin.enableSemodule {
 		// Get versions of policy modules installed using semodule
 		if output, err = helpers.RunCommand("semodule", "", "-l"); err != nil {
-			return nil, nil, nil, errors.Unwrap(err)
+			return nil, nil, nil, fmt.Errorf("trying to wrap: %w", err)
 		}
 
 		policyModules = seLinuxPlugin.parseSemoduleOutput(output)
 	}
+
 	return basicData, policyData, policyModules, nil
 }
 
@@ -174,7 +175,7 @@ func (seLinuxPlugin *SELinuxPlugin) parseLabel(labelMatches [][]string) (types.P
 		value := labelMatches[0][2]
 
 		if label == "SELinux status" && value == "disabled" {
-			return nil, errors.Unwrap(ErrSELinuxDisabled)
+			return nil, fmt.Errorf("trying to wrap: %w", ErrSELinuxDisabled)
 		}
 
 		if entityID, ok := SELinuxConfigProperties[label]; ok {

--- a/internal/plugins/linux/selinux_test.go
+++ b/internal/plugins/linux/selinux_test.go
@@ -118,7 +118,7 @@ func (ss *SELinuxSuite) TestParseSEModules(c *C) {
 	c.Check(len(resultMap), Equals, 17)
 }
 
-var newSampleSemoduleOutput = `abrt
+var semoduleOutputWithoutVersions = `abrt
 accountsd
 ada
 afs
@@ -137,12 +137,20 @@ avahi
 awstats
 `
 
-func (ss *SELinuxSuite) TestParseSEModulesVersionNotFoundCheck(c *C) {
+func (ss *SELinuxSuite) TestParseSEModulesEmptyVersionCheck(c *C) {
 	plugin := SELinuxPlugin{}
 
-	_, err := plugin.parseSemoduleOutput(newSampleSemoduleOutput)
+	result, err := plugin.parseSemoduleOutput(semoduleOutputWithoutVersions)
 	if err != nil {
 		c.Fatal(err)
 	}
-	c.Check(err, Equals, ErrSEModuleVersionNotFound)
+
+	resultMap := make(map[string]string)
+	for _, entity := range result {
+		resultMap[entity.SortKey()] = entity.(SELinuxPolicyModule).Version
+	}
+
+	c.Check(resultMap["abrt"], Equals, "")
+	c.Check(resultMap["accountsd"], Equals, "")
+	c.Check(len(resultMap), Equals, 17)
 }

--- a/internal/plugins/linux/selinux_test.go
+++ b/internal/plugins/linux/selinux_test.go
@@ -5,7 +5,9 @@
 
 package linux
 
-import . "gopkg.in/check.v1"
+import (
+	. "gopkg.in/check.v1"
+)
 
 type SELinuxSuite struct{}
 
@@ -114,4 +116,33 @@ func (ss *SELinuxSuite) TestParseSEModules(c *C) {
 	c.Check(resultMap["aiccu"], Equals, "1.0.0")
 	c.Check(resultMap["audioentropy"], Equals, "1.6.0")
 	c.Check(len(resultMap), Equals, 17)
+}
+
+var newSampleSemoduleOutput = `abrt
+accountsd
+ada
+afs
+aiccu
+aide
+amanda
+amtu
+antivirus
+apache
+apcupsd
+arpwatch
+asterisk
+audioentropy
+automount
+avahi
+awstats
+`
+
+func (ss *SELinuxSuite) TestParseSEModulesVersionNotFoundCheck(c *C) {
+	plugin := SELinuxPlugin{}
+
+	_, err := plugin.parseSemoduleOutput(sampleSemoduleOutput)
+	if err != nil {
+		c.Fatal(err)
+	}
+	c.Check(err, Equals, ErrSEModuleVersionNotFound)
 }

--- a/internal/plugins/linux/selinux_test.go
+++ b/internal/plugins/linux/selinux_test.go
@@ -103,10 +103,7 @@ awstats	1.2.0
 func (ss *SELinuxSuite) TestParseSEModules(c *C) {
 	plugin := SELinuxPlugin{}
 
-	result, err := plugin.parseSemoduleOutput(sampleSemoduleOutput)
-	if err != nil {
-		c.Fatal(err)
-	}
+	result := plugin.parseSemoduleOutput(sampleSemoduleOutput)
 
 	resultMap := make(map[string]string)
 	for _, entity := range result {
@@ -118,39 +115,34 @@ func (ss *SELinuxSuite) TestParseSEModules(c *C) {
 	c.Check(len(resultMap), Equals, 17)
 }
 
-var sampleSemoduleOutputWithoutVersions = `abrt
-accountsd
-ada
-afs
-aiccu
-aide
-amanda
-amtu
-antivirus
-apache
-apcupsd
-arpwatch
-asterisk
-audioentropy
-automount
-avahi
-awstats
-`
-
-func (ss *SELinuxSuite) TestParseSEModulesEmptyVersionCheck(ch *C) {
+func (ss *SELinuxSuite) TestParseSEModulesEmptyVersionCheck(chk *C) {
 	plugin := SELinuxPlugin{}
-
-	result, err := plugin.parseSemoduleOutput(sampleSemoduleOutputWithoutVersions)
-	if err != nil {
-		ch.Fatal(err)
-	}
+	var sampleSemoduleOutputWithoutVersions = `abrt
+	accountsd
+	ada
+	afs
+	aiccu
+	aide
+	amanda
+	amtu
+	antivirus
+	apache
+	apcupsd
+	arpwatch
+	asterisk
+	audioentropy
+	automount
+	avahi
+	awstats
+	`
+	result := plugin.parseSemoduleOutput(sampleSemoduleOutputWithoutVersions)
 
 	resultMap := make(map[string]string)
 	for _, entity := range result {
 		resultMap[entity.SortKey()] = entity.(SELinuxPolicyModule).Version
 	}
 
-	ch.Check(resultMap["abrt"], Equals, "")
-	ch.Check(resultMap["accountsd"], Equals, "")
-	ch.Check(len(resultMap), Equals, 17)
+	chk.Check(resultMap["abrt"], Equals, "")
+	chk.Check(resultMap["accountsd"], Equals, "")
+	chk.Check(len(resultMap), Equals, 17)
 }

--- a/internal/plugins/linux/selinux_test.go
+++ b/internal/plugins/linux/selinux_test.go
@@ -140,7 +140,7 @@ awstats
 func (ss *SELinuxSuite) TestParseSEModulesVersionNotFoundCheck(c *C) {
 	plugin := SELinuxPlugin{}
 
-	_, err := plugin.parseSemoduleOutput(sampleSemoduleOutput)
+	_, err := plugin.parseSemoduleOutput(newSampleSemoduleOutput)
 	if err != nil {
 		c.Fatal(err)
 	}

--- a/internal/plugins/linux/selinux_test.go
+++ b/internal/plugins/linux/selinux_test.go
@@ -118,7 +118,7 @@ func (ss *SELinuxSuite) TestParseSEModules(c *C) {
 	c.Check(len(resultMap), Equals, 17)
 }
 
-var semoduleOutputWithoutVersions = `abrt
+var sampleSemoduleOutputWithoutVersions = `abrt
 accountsd
 ada
 afs
@@ -137,12 +137,12 @@ avahi
 awstats
 `
 
-func (ss *SELinuxSuite) TestParseSEModulesEmptyVersionCheck(c *C) {
+func (ss *SELinuxSuite) TestParseSEModulesEmptyVersionCheck(ch *C) {
 	plugin := SELinuxPlugin{}
 
-	result, err := plugin.parseSemoduleOutput(semoduleOutputWithoutVersions)
+	result, err := plugin.parseSemoduleOutput(sampleSemoduleOutputWithoutVersions)
 	if err != nil {
-		c.Fatal(err)
+		ch.Fatal(err)
 	}
 
 	resultMap := make(map[string]string)
@@ -150,7 +150,7 @@ func (ss *SELinuxSuite) TestParseSEModulesEmptyVersionCheck(c *C) {
 		resultMap[entity.SortKey()] = entity.(SELinuxPolicyModule).Version
 	}
 
-	c.Check(resultMap["abrt"], Equals, "")
-	c.Check(resultMap["accountsd"], Equals, "")
-	c.Check(len(resultMap), Equals, 17)
+	ch.Check(resultMap["abrt"], Equals, "")
+	ch.Check(resultMap["accountsd"], Equals, "")
+	ch.Check(len(resultMap), Equals, 17)
 }


### PR DESCRIPTION
Changes in this PR
- Populating the value of versions as empty string when `semodule -l` doesn't give versions for the modules in the output
- Added test to verify the above