### PR TITLE
fix: `exclude_matching_metrics` is excluding non-`ProcessSample`s

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -296,7 +296,6 @@ func NewAgent(
 	// all the processes but excluded ones will be sent
 	// * If all the cases where include_metrics_matchers and exclude_metrics_matchers are present,
 	// exclude ones will be ignored
-
 	sampleMatchFn := sampler.NewSampleMatchFn(cfg.EnableProcessMetrics, config.MetricsMap(cfg.IncludeMetricsMatchers), ffRetriever)
 	// by default, do not apply exclude metrics matchers, only if no include ones are present
 	sampleExcludeFn := func(event any) bool {
@@ -1192,7 +1191,7 @@ func (c *context) SendEvent(event sample.Event, entityKey entity.Key) {
 	// check if event should be included
 	// include takes precedence, so the event will be included if
 	// it IS NOT EXCLUDED or if it IS INCLUDED
-	includeSample := c.includeEvent(event)
+	includeSample := c.IncludeEvent(event)
 	if !includeSample {
 		aclog.
 			WithField("entity_key", entityKey.String()).
@@ -1209,7 +1208,7 @@ func (c *context) SendEvent(event sample.Event, entityKey entity.Key) {
 	}
 }
 
-func (c *context) includeEvent(event any) bool {
+func (c *context) IncludeEvent(event any) bool {
 	shouldInclude := c.shouldIncludeEvent(event)
 	shouldExclude := c.shouldExcludeEvent(event)
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -305,7 +305,7 @@ func NewAgent(
 		cfg.EnableProcessMetrics != nil &&
 		*cfg.EnableProcessMetrics &&
 		len(cfg.ExcludeMetricsMatchers) > 0 {
-		sampleExcludeFn = sampler.NewExcludeSampleMatchFn(cfg.EnableProcessMetrics, cfg.ExcludeMetricsMatchers, ffRetriever)
+		sampleExcludeFn = sampler.NewExcludeSampleMatchFn(cfg.ExcludeMetricsMatchers)
 		// if there are not include matchers at all, we remove the matcher to exclude by default
 		sampleMatchFn = func(event any) bool {
 			return false
@@ -1195,7 +1195,7 @@ func (c *context) SendEvent(event sample.Event, entityKey entity.Key) {
 	if !includeSample {
 		aclog.
 			WithField("entity_key", entityKey.String()).
-			WithField("event", fmt.Sprintf("+%v", event)).
+			WithField("event", fmt.Sprintf("%#v", event)).
 			Debug("event excluded by metric matcher")
 		return
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -26,6 +26,7 @@ import (
 	"github.com/newrelic/infrastructure-agent/pkg/entity/host"
 	"github.com/newrelic/infrastructure-agent/pkg/helpers/metric"
 	"github.com/newrelic/infrastructure-agent/pkg/metrics/sampler"
+	process_sample_types "github.com/newrelic/infrastructure-agent/pkg/metrics/types"
 	"github.com/sirupsen/logrus"
 
 	"github.com/newrelic/infrastructure-agent/pkg/ctl"
@@ -159,8 +160,8 @@ type context struct {
 	resolver           hostname.ResolverChangeNotifier
 	EntityMap          entity.KnownIDs
 	idLookup           host.IDLookup
-	shouldIncludeEvent sampler.IncludeSampleMatchFn
-	shouldExcludeEvent sampler.ExcludeSampleMatchFn
+	shouldIncludeEvent sampler.IncludeProcessSampleMatchFn
+	shouldExcludeEvent sampler.ExcludeProcessSampleMatchFn
 }
 
 func (c *context) Context() context2.Context {
@@ -206,8 +207,8 @@ func NewContext(
 	buildVersion string,
 	resolver hostname.ResolverChangeNotifier,
 	lookup host.IDLookup,
-	sampleMatchFn sampler.IncludeSampleMatchFn,
-	sampleExcludeFn sampler.ExcludeSampleMatchFn,
+	sampleMatchFn sampler.IncludeProcessSampleMatchFn,
+	sampleExcludeFn sampler.ExcludeProcessSampleMatchFn,
 ) *context {
 	ctx, cancel := context2.WithCancel(context2.Background())
 
@@ -296,22 +297,22 @@ func NewAgent(
 	// all the processes but excluded ones will be sent
 	// * If all the cases where include_metrics_matchers and exclude_metrics_matchers are present,
 	// exclude ones will be ignored
-	sampleMatchFn := sampler.NewIncludeSampleMatchFn(cfg.EnableProcessMetrics, cfg.IncludeMetricsMatchers, ffRetriever)
+	processSampleMatchFn := sampler.NewIncludeProcessSampleMatchFn(cfg.EnableProcessMetrics, cfg.IncludeMetricsMatchers, ffRetriever)
 	// by default, do not apply exclude metrics matchers, only if no include ones are present
-	sampleExcludeFn := func(event any) bool {
+	processSampleExcludeFn := func(event any) bool {
 		return true
 	}
 	if len(cfg.IncludeMetricsMatchers) == 0 &&
 		cfg.EnableProcessMetrics != nil &&
 		*cfg.EnableProcessMetrics &&
 		len(cfg.ExcludeMetricsMatchers) > 0 {
-		sampleExcludeFn = sampler.NewExcludeSampleMatchFn(cfg.ExcludeMetricsMatchers)
+		processSampleExcludeFn = sampler.NewExcludeProcessSampleMatchFn(cfg.ExcludeMetricsMatchers)
 		// if there are not include matchers at all, we remove the matcher to exclude by default
-		sampleMatchFn = func(event any) bool {
+		processSampleMatchFn = func(event any) bool {
 			return false
 		}
 	}
-	ctx := NewContext(cfg, buildVersion, hostnameResolver, idLookupTable, sampler.IncludeSampleMatchFn(sampleMatchFn), sampleExcludeFn)
+	ctx := NewContext(cfg, buildVersion, hostnameResolver, idLookupTable, sampler.IncludeProcessSampleMatchFn(processSampleMatchFn), processSampleExcludeFn)
 
 	agentKey, err := idLookupTable.AgentKey()
 	if err != nil {
@@ -1210,10 +1211,17 @@ func (c *context) SendEvent(event sample.Event, entityKey entity.Key) {
 
 // Decides wether an event will be included or not.
 func (c *context) IncludeEvent(event any) bool {
-	shouldInclude := c.shouldIncludeEvent(event)
-	shouldExclude := c.shouldExcludeEvent(event)
+	switch event.(type) {
+	// rule is applied to process samples only
+	case *process_sample_types.ProcessSample, *process_sample_types.FlatProcessSample:
+		shouldInclude := c.shouldIncludeEvent(event)
+		shouldExclude := c.shouldExcludeEvent(event)
 
-	return shouldInclude || !shouldExclude
+		return shouldInclude || !shouldExclude
+	default:
+		// other samples are included
+		return true
+	}
 }
 
 func (c *context) Unregister(id ids.PluginID) {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -915,86 +915,6 @@ func Test_ProcessSampling(t *testing.T) {
 	}
 }
 
-func Test_ProcessSamplingExcludes(t *testing.T) {
-	t.Parallel()
-
-	someSample := &types.ProcessSample{
-		ProcessDisplayName: "some-process",
-	}
-
-	boolAsPointer := func(val bool) *bool {
-		return &val
-	}
-
-	type testCase struct {
-		name          string
-		c             *config.Config
-		ff            feature_flags.Retriever
-		expectInclude bool
-	}
-	testCases := []testCase{
-		{
-			name:          "Include not matching must not include",
-			c:             &config.Config{EnableProcessMetrics: boolAsPointer(true), IncludeMetricsMatchers: map[string][]string{"process.name": {"does-not-match"}}, DisableCloudMetadata: true},
-			ff:            test.NewFFRetrieverReturning(false, false),
-			expectInclude: false,
-		},
-		{
-			name:          "Include matching should not exclude",
-			c:             &config.Config{EnableProcessMetrics: boolAsPointer(true), IncludeMetricsMatchers: map[string][]string{"process.name": {"some-process"}}, DisableCloudMetadata: true},
-			ff:            test.NewFFRetrieverReturning(false, false),
-			expectInclude: true,
-		},
-		{
-			name:          "Exclude matching should exclude with process metrics enabled",
-			c:             &config.Config{EnableProcessMetrics: boolAsPointer(true), ExcludeMetricsMatchers: map[string][]string{"process.name": {"some-process"}}, DisableCloudMetadata: true},
-			ff:            test.NewFFRetrieverReturning(false, false),
-			expectInclude: false,
-		},
-		{
-			name:          "Exclude matching should exclude",
-			c:             &config.Config{ExcludeMetricsMatchers: map[string][]string{"process.name": {"some-process"}}, DisableCloudMetadata: true},
-			ff:            test.NewFFRetrieverReturning(false, false),
-			expectInclude: false,
-		},
-		{
-			name:          "Exclude not matching should not exclude with process metrics enabled",
-			c:             &config.Config{EnableProcessMetrics: boolAsPointer(true), ExcludeMetricsMatchers: map[string][]string{"process.name": {"does-not-match"}}, DisableCloudMetadata: true},
-			ff:            test.NewFFRetrieverReturning(false, false),
-			expectInclude: true,
-		},
-		{
-			name:          "Exclude not matching should not exclude",
-			c:             &config.Config{ExcludeMetricsMatchers: map[string][]string{"process.name": {"does-not-match"}}, DisableCloudMetadata: true},
-			ff:            test.NewFFRetrieverReturning(false, false),
-			expectInclude: false,
-		},
-		{
-			name:          "Include matching should include even if exclude is configured with process metrics enabled",
-			c:             &config.Config{EnableProcessMetrics: boolAsPointer(true), IncludeMetricsMatchers: map[string][]string{"process.name": {"some-process"}}, ExcludeMetricsMatchers: map[string][]string{"process.name": {"some-process"}}, DisableCloudMetadata: true},
-			ff:            test.NewFFRetrieverReturning(false, false),
-			expectInclude: true,
-		},
-		{
-			name:          "Include matching should be include even when enable_process_metrics is not defined (nil)",
-			c:             &config.Config{IncludeMetricsMatchers: map[string][]string{"process.name": {"some-process"}}, ExcludeMetricsMatchers: map[string][]string{"process.name": {"some-process"}}, DisableCloudMetadata: true},
-			ff:            test.NewFFRetrieverReturning(false, false),
-			expectInclude: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		testCase := tc
-		a, _ := NewAgent(testCase.c, "test", "userAgent", testCase.ff)
-
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
-			assert.Equal(t, testCase.expectInclude, a.Context.includeEvent(someSample))
-		})
-	}
-}
-
 func Test_ProcessSamplingExcludesAllCases(t *testing.T) {
 	t.Parallel()
 
@@ -1188,7 +1108,7 @@ func Test_ProcessSamplingExcludesAllCases(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			assert.Equal(t, testCase.expectInclude, a.Context.includeEvent(someSample))
+			assert.Equal(t, testCase.expectInclude, a.Context.IncludeEvent(someSample))
 		})
 	}
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -818,24 +818,6 @@ func BenchmarkStorePluginOutput(b *testing.B) {
 	}
 }
 
-func Test_ProcessSampling_FeatureFlagIsEnabled(t *testing.T) {
-	cnf := &config.Config{
-		IncludeMetricsMatchers: map[string][]string{"process.name": {"some-process"}},
-	}
-	someSample := struct {
-		evenType string
-	}{
-		evenType: "ProcessSample",
-	}
-	a, _ := NewAgent(cnf, "test", "userAgent", test.NewFFRetrieverReturning(true, true))
-
-	// when
-	actual := a.Context.shouldIncludeEvent(someSample)
-
-	// then
-	assert.Equal(t, true, actual)
-}
-
 func getBooleanPtr(val bool) *bool {
 	return &val
 }

--- a/pkg/metrics/sampler/matcher.go
+++ b/pkg/metrics/sampler/matcher.go
@@ -300,13 +300,9 @@ func NewSampleMatchFn(enableProcessMetrics *bool, metricsMatchers config.Metrics
 		return matcherForDisabledMetrics()
 	}
 
-	matcherChain := NewMatcherChain(metricsMatchers)
-	if matcherChain.Enabled {
-		mlog.
-			WithField(config.TracesFieldName, config.FeatureTrace).
-			Trace("EnableProcessMetrics is TRUE and rules ARE defined, process metrics will be ENABLED for matching processes")
-
-		return matcherChain.Evaluate
+	matcher := matcherFromMetricsMatchers(metricsMatchers)
+	if matcher != nil {
+		return matcher
 	}
 
 	mlog.

--- a/pkg/metrics/sampler/matcher.go
+++ b/pkg/metrics/sampler/matcher.go
@@ -265,6 +265,7 @@ func (ne constantMatcher) String() string {
 // NewIncludeSampleMatchFn returns a function `func(sample) bool` that determinesif the sample
 // should be included (true) as an event or not (false). Note that this is NOT the negation
 // of `NewExcludeSampleMatchFn`.
+// The include decision logic only applies to ProcessSamples. Other kinds of samples are always included.
 func NewIncludeSampleMatchFn(enableProcessMetrics *bool, metricsMatchers config.IncludeMetricsMap, ffRetriever feature_flags.Retriever) MatcherFn {
 	return func(sample any) bool {
 		// We return early if the sample is not a ProcessSample.
@@ -314,6 +315,7 @@ func NewIncludeSampleMatchFn(enableProcessMetrics *bool, metricsMatchers config.
 // should be excluded (true) as an event or not (false). Note that this is NOT the negation
 // of `NewIncludeSampleMatchFn`. In particular, we don't check here for the `enableProcessMetrics`
 // being unset or disabled because it is checked before calling this function at `agent.NewAgent`.
+// The exclude decision logic only applies to ProcessSamples. Other kinds of samples are never excluded.
 func NewExcludeSampleMatchFn(metricsMatchers config.ExcludeMetricsMap) MatcherFn {
 	return func(sample any) bool {
 		// We return early if the sample is not a ProcessSample.

--- a/pkg/metrics/sampler/matcher_test.go
+++ b/pkg/metrics/sampler/matcher_test.go
@@ -687,7 +687,7 @@ func TestNewSampleMatchFn(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			matchFn := sampler.NewIncludeSampleMatchFn(tt.args.enableProcessMetrics, tt.args.includeMetricsMatchers, tt.args.ffRetriever)
+			matchFn := sampler.NewIncludeProcessSampleMatchFn(tt.args.enableProcessMetrics, tt.args.includeMetricsMatchers, tt.args.ffRetriever)
 			assert.Equal(t, tt.include, matchFn(tt.args.sample))
 		})
 	}

--- a/pkg/metrics/sampler/matcher_test.go
+++ b/pkg/metrics/sampler/matcher_test.go
@@ -755,15 +755,15 @@ func Test_ProcessSamplingExcludes(t *testing.T) {
 	someProcessSample := &types.ProcessSample{
 		ProcessDisplayName: "some-process",
 	}
-	// someNetworkSample := network.NetworkSample{InterfaceName: "eth0"}
-	// someSystemSample := metrics.SystemSample{
-	// 	CPUSample: &metrics.CPUSample{
-	// 		CPUPercent: 50,
-	// 	},
-	// }
-	// someStorageSample := storage.BaseSample{
-	// 	Device: "/dev/sda1",
-	// }
+	someNetworkSample := network.NetworkSample{InterfaceName: "eth0"}
+	someSystemSample := metrics.SystemSample{
+		CPUSample: &metrics.CPUSample{
+			CPUPercent: 50,
+		},
+	}
+	someStorageSample := storage.BaseSample{
+		Device: "/dev/sda1",
+	}
 
 	boolAsPointer := func(val bool) *bool {
 		return &val
@@ -828,16 +828,16 @@ func Test_ProcessSamplingExcludes(t *testing.T) {
 
 	for _, tc := range testCases {
 		testCase := tc
-		a, _ := agent.NewAgent(testCase.c, "test", "userAgent", testCase.ff)
+		agent, _ := agent.NewAgent(testCase.c, "test", "userAgent", testCase.ff)
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			assert.Equal(t, testCase.expectInclude, a.Context.IncludeEvent(someProcessSample))
+			assert.Equal(t, testCase.expectInclude, agent.Context.IncludeEvent(someProcessSample))
 			// In all cases, events that are not ProcessSamples should always be included!
-			// assert.True(t, a.Context.IncludeEvent(someSystemSample))
-			// assert.True(t, a.Context.IncludeEvent(someNetworkSample))
-			// assert.True(t, a.Context.IncludeEvent(someStorageSample))
+			assert.True(t, agent.Context.IncludeEvent(someSystemSample))
+			assert.True(t, agent.Context.IncludeEvent(someNetworkSample))
+			assert.True(t, agent.Context.IncludeEvent(someStorageSample))
 		})
 	}
 }

--- a/pkg/metrics/sampler/matcher_test.go
+++ b/pkg/metrics/sampler/matcher_test.go
@@ -248,61 +248,6 @@ func Test_Evaluator_WithUnMappedFields(t *testing.T) {
 	}
 }
 
-// Test_Evaluator_WithNonProcessSamples tests that other sample types keep working as expected
-func Test_Evaluator_WithNonProcessSamples(t *testing.T) {
-	networkSample := network.NetworkSample{InterfaceName: "eth0"}
-	systemSample := metrics.SystemSample{
-		CPUSample: &metrics.CPUSample{
-			CPUPercent: 50,
-		},
-	}
-	storageSample := storage.BaseSample{
-		Device: "/dev/sda1",
-	}
-
-	type testCase struct {
-		name  string
-		input interface{}
-		rules map[string][]string
-		want  bool
-	}
-
-	cases := []testCase{
-		{
-			name:  "NetworkSample",
-			input: networkSample,
-			rules: map[string][]string{
-				"process.name": {"foobar"},
-			},
-			want: true,
-		},
-		{
-			name:  "SystemSample",
-			input: systemSample,
-			rules: map[string][]string{
-				"process.name": {"foobar"},
-			},
-			want: true,
-		},
-		{
-			name:  "StorageSample",
-			input: storageSample,
-			rules: map[string][]string{
-				"process.name": {"foobar"},
-			},
-			want: true,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			ec := sampler.NewMatcherChain(tc.rules)
-			assert.Len(t, ec.Matchers, len(tc.rules))
-			assert.EqualValues(t, tc.want, ec.Evaluate(tc.input))
-		})
-	}
-}
-
 func Test_EvaluatorChain_WithMultipleRuleAttribute(t *testing.T) {
 
 	type testCase struct {
@@ -742,7 +687,7 @@ func TestNewSampleMatchFn(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			matchFn := sampler.NewSampleMatchFn(tt.args.enableProcessMetrics, config.MetricsMap(tt.args.includeMetricsMatchers), tt.args.ffRetriever)
+			matchFn := sampler.NewIncludeSampleMatchFn(tt.args.enableProcessMetrics, tt.args.includeMetricsMatchers, tt.args.ffRetriever)
 			assert.Equal(t, tt.include, matchFn(tt.args.sample))
 		})
 	}

--- a/pkg/metrics/sampler/matcher_test.go
+++ b/pkg/metrics/sampler/matcher_test.go
@@ -535,16 +535,6 @@ func TestNewSampleMatchFn(t *testing.T) {
 		include bool
 	}{
 		{
-			name: "non process samples are always included",
-			args: args{
-				enableProcessMetrics:   &falseVar,
-				includeMetricsMatchers: emptyMatchers,
-				ffRetriever:            testFF.EmptyFFRetriever,
-				sample:                 &fixture.NetworkSample,
-			},
-			include: true,
-		},
-		{
 			name: "when enableProcessMetrics is FALSE process samples are always excluded",
 			args: args{
 				enableProcessMetrics:   &falseVar,


### PR DESCRIPTION
This fixes [NR-334472](https://new-relic.atlassian.net/browse/NR-334472).

Due to how the logic for the `exclude_matching_metrics` option was implemented for 1.57.2, when this setting is present all samples that are not `ProcessSample`s are filtered out and not sent.

This reworks the matcher logic to cover against this and add relevant unit tests to check for the inclusion or exclusion of non-`ProcessSample` events.

[NR-334472]: https://new-relic.atlassian.net/browse/NR-334472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ