### PR TITLE
chore: fix harvest test workflow

### DIFF
--- a/.github/workflows/component_linux_harvest_test.yml
+++ b/.github/workflows/component_linux_harvest_test.yml
@@ -21,12 +21,11 @@ jobs:
       - name: Setup node
         run: sudo apt install musl-dev
 
-      - name: Fix GOROOT to be run with sudo
+      - name: Run harvest tests
         run: |
-          mkdir -p /home/runner/.config/go
-          echo GOROOT="$( go env GOROOT )" > /home/runner/.config/go/env
-          echo GOTOOLDIR="$( go env GOTOOLDIR )" >> /home/runner/.config/go/env
-          sudo -E go env
+          # Set up installed Go version for root user, to not use the default from the runner
+          # GO_BIN is used by the Makefile
+          export GO_BIN="$( which go)"
 
-      - name: Running Harvest tests
-        run: sudo -E make linux/harvest-tests
+          sudo -E make linux/harvest-tests
+


### PR DESCRIPTION
After Go version from the runner was bump (1.22 -> 1.23), current solution start failed with 
```
[go-get] Done.
go test ./test/harvest -tags="harvest" -v
# internal/unsafeheader
compile: version "go1.22.8" does not match go tool version "go1.23.2"
```

I just changed the approach to use the installed go binary from the action.