### PR TITLE
Nr 337529 infra agent flaky test

### DIFF
--- a/internal/agent/status/status_test.go
+++ b/internal/agent/status/status_test.go
@@ -145,10 +145,7 @@ func TestNewReporter_Report(t *testing.T) {
 				assert.Contains(t, gotEndpoint.Error, expectedEndpoint.Error)
 			}
 			assert.Equal(t, tt.want.Checks.Health.Healthy, got.Checks.Health.Healthy)
-			// Allows retries if server responds with incorrect error
-			assert.Eventually(t, func() bool {
-				return assert.Contains(t, got.Checks.Health.Error, tt.want.Checks.Health.Error)
-			}, timeout, 10*time.Millisecond)
+			assert.Contains(t, got.Checks.Health.Error, tt.want.Checks.Health.Error)
 		})
 	}
 }


### PR DESCRIPTION
Timeout was increased to `500 * time.Millisecond` allow enough time to set things up correctly.
The flakiness was due to the test expecting this specific error `http2.ErrUnexepectedResponseCode.Error()` but instead might get `"context deadline exceeded"` as the error sometimes.
By increasing timeout, there is more time for the right response to be received from the server.

Another way would be to expect that the server might timeout sometimes and check for `"context deadline exceeded."` .