### PR TITLE
(chore): update agent license for packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ INCLUDE_TOOLS_DIR	?= $(PROJECT_WORKSPACE)/tools
 PROJECT_NAME		:= newrelic-infra
 TARGET_DIR			?= $(PROJECT_WORKSPACE)/target
 DIST_DIR			?= $(PROJECT_WORKSPACE)/dist
+CURRENT_YEAR 		:= $(shell date +%Y)
 TARGET_DIR_CENTOS5	= $(TARGET_DIR)/el_5
 UNAME_S				:= $(shell uname -s)
 COVERAGE_FILE       ?= coverage.out

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -101,6 +101,7 @@ ifdef TAG
 			-e PRERELEASE=true \
 			-e GITHUB_TOKEN \
 			-e TAG \
+			-e CURRENT_YEAR \
 			-e GPG_MAIL \
 			-e GPG_PASSPHRASE \
 			-e GPG_PRIVATE_KEY_BASE64 \
@@ -125,6 +126,7 @@ ifdef TAG
 			-v $(CURDIR):/go/src/github.com/newrelic/infrastructure-agent \
             -w /go/src/github.com/newrelic/infrastructure-agent \
 			-e GITHUB_TOKEN \
+			-e CURRENT_YEAR \
 			-e TAG \
 			$(BUILDER_IMG_TAG) make release-publish
 
@@ -140,6 +142,7 @@ dev/release/pkg: ci/deps
 			-v $(CURDIR):/go/src/github.com/newrelic/infrastructure-agent \
             -w /go/src/github.com/newrelic/infrastructure-agent \
 			-e TAG=0.0.0 \
+			-e CURRENT_YEAR \
 			-e SNAPSHOT=true \
 			$(BUILDER_IMG_TAG) make release/pkg-linux
 

--- a/build/goreleaser/linux/al2023_amd64.yml
+++ b/build/goreleaser/linux/al2023_amd64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/al2023_arm.yml
+++ b/build/goreleaser/linux/al2023_arm.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/al2023_arm64.yml
+++ b/build/goreleaser/linux/al2023_arm64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/al2_amd64.yml
+++ b/build/goreleaser/linux/al2_amd64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/al2_arm.yml
+++ b/build/goreleaser/linux/al2_arm.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/al2_arm64.yml
+++ b/build/goreleaser/linux/al2_arm64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/centos_6_amd64.yml
+++ b/build/goreleaser/linux/centos_6_amd64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/centos_7_amd64.yml
+++ b/build/goreleaser/linux/centos_7_amd64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/centos_7_arm.yml
+++ b/build/goreleaser/linux/centos_7_arm.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/centos_7_arm64.yml
+++ b/build/goreleaser/linux/centos_7_arm64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/centos_8_amd64.yml
+++ b/build/goreleaser/linux/centos_8_amd64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/centos_8_arm.yml
+++ b/build/goreleaser/linux/centos_8_arm.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/centos_8_arm64.yml
+++ b/build/goreleaser/linux/centos_8_arm64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/debian_systemd_amd64.yml
+++ b/build/goreleaser/linux/debian_systemd_amd64.yml
@@ -11,7 +11,7 @@
     homepage: "https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes"
     maintainer: "caos-team@newrelic.com"
     description: "New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems."
-    license: "Copyright (c) 2008-2021 New Relic, Inc. All rights reserved."
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - deb
     bindir: /usr/bin

--- a/build/goreleaser/linux/debian_systemd_arm.yml
+++ b/build/goreleaser/linux/debian_systemd_arm.yml
@@ -11,7 +11,7 @@
     homepage: "https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes"
     maintainer: "caos-team@newrelic.com"
     description: "New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems."
-    license: "Copyright (c) 2008-2021 New Relic, Inc. All rights reserved."
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - deb
     bindir: /usr/bin

--- a/build/goreleaser/linux/debian_systemd_arm64.yml
+++ b/build/goreleaser/linux/debian_systemd_arm64.yml
@@ -11,7 +11,7 @@
     homepage: "https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes"
     maintainer: "caos-team@newrelic.com"
     description: "New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems."
-    license: "Copyright (c) 2008-2021 New Relic, Inc. All rights reserved."
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - deb
     bindir: /usr/bin

--- a/build/goreleaser/linux/debian_upstart_amd64.yml
+++ b/build/goreleaser/linux/debian_upstart_amd64.yml
@@ -11,7 +11,7 @@
     homepage: "https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes"
     maintainer: "caos-team@newrelic.com"
     description: "New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems."
-    license: "Copyright (c) 2008-2021 New Relic, Inc. All rights reserved."
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - deb
     bindir: /usr/bin

--- a/build/goreleaser/linux/rhel_9_amd64.yml
+++ b/build/goreleaser/linux/rhel_9_amd64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/rhel_9_arm.yml
+++ b/build/goreleaser/linux/rhel_9_arm.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/rhel_9_arm64.yml
+++ b/build/goreleaser/linux/rhel_9_arm64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_114_amd64.yml
+++ b/build/goreleaser/linux/sles_114_amd64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_121_amd64.yml
+++ b/build/goreleaser/linux/sles_121_amd64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_122_amd64.yml
+++ b/build/goreleaser/linux/sles_122_amd64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_122_arm.yml
+++ b/build/goreleaser/linux/sles_122_arm.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_122_arm64.yml
+++ b/build/goreleaser/linux/sles_122_arm64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_123_amd64.yml
+++ b/build/goreleaser/linux/sles_123_amd64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_123_arm.yml
+++ b/build/goreleaser/linux/sles_123_arm.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_123_arm64.yml
+++ b/build/goreleaser/linux/sles_123_arm64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_124_amd64.yml
+++ b/build/goreleaser/linux/sles_124_amd64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_124_arm.yml
+++ b/build/goreleaser/linux/sles_124_arm.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_124_arm64.yml
+++ b/build/goreleaser/linux/sles_124_arm64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_125_amd64.yml
+++ b/build/goreleaser/linux/sles_125_amd64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_125_arm.yml
+++ b/build/goreleaser/linux/sles_125_arm.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_125_arm64.yml
+++ b/build/goreleaser/linux/sles_125_arm64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_151_amd64.yml
+++ b/build/goreleaser/linux/sles_151_amd64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_151_arm.yml
+++ b/build/goreleaser/linux/sles_151_arm.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_151_arm64.yml
+++ b/build/goreleaser/linux/sles_151_arm64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_152_amd64.yml
+++ b/build/goreleaser/linux/sles_152_amd64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_152_arm.yml
+++ b/build/goreleaser/linux/sles_152_arm.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_152_arm64.yml
+++ b/build/goreleaser/linux/sles_152_arm64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_153_amd64.yml
+++ b/build/goreleaser/linux/sles_153_amd64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_153_arm.yml
+++ b/build/goreleaser/linux/sles_153_arm.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_153_arm64.yml
+++ b/build/goreleaser/linux/sles_153_arm64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_154_amd64.yml
+++ b/build/goreleaser/linux/sles_154_amd64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_154_arm.yml
+++ b/build/goreleaser/linux/sles_154_arm.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_154_arm64.yml
+++ b/build/goreleaser/linux/sles_154_arm64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_155_amd64.yml
+++ b/build/goreleaser/linux/sles_155_amd64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_155_arm.yml
+++ b/build/goreleaser/linux/sles_155_arm.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_155_arm64.yml
+++ b/build/goreleaser/linux/sles_155_arm64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_156_amd64.yml
+++ b/build/goreleaser/linux/sles_156_amd64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2024 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_156_arm.yml
+++ b/build/goreleaser/linux/sles_156_arm.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2021 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin

--- a/build/goreleaser/linux/sles_156_arm64.yml
+++ b/build/goreleaser/linux/sles_156_arm64.yml
@@ -11,7 +11,7 @@
     homepage: 'https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes'
     maintainer: 'caos-team@newrelic.com'
     description: 'New Relic Infrastructure provides flexible, dynamic server monitoring. With real-time data collection and a UI that scales from a handful of hosts to thousands, Infrastructure is designed for modern Operations teams with fast-changing systems.'
-    license: 'Copyright (c) 2008-2024 New Relic, Inc. All rights reserved.'
+    license: "Copyright (c) 2008-{{ .Env.CURRENT_YEAR }} New Relic, Inc. All rights reserved."
     formats:
       - rpm
     bindir: /usr/bin


### PR DESCRIPTION
## Summary
License packaged with infra-agent packages was referring to `2008-2021` which is clearly outdated. Therefore, introduced `CURRENT_YEAR` and embed that as part of the license.