### PR TITLE
Bump nri-docker, nri-flex and nri-prometheus to last versions

### DIFF
--- a/build/embed/integrations.version
+++ b/build/embed/integrations.version
@@ -1,5 +1,5 @@
 #ohi-repo-name,version
-nri-docker,v2.1.0
-nri-flex,v1.15.2
+nri-docker,v2.1.2
+nri-flex,v1.16.2
 nri-winservices,v1.0.3
-nri-prometheus,v2.21.6
+nri-prometheus,v2.22.0


### PR DESCRIPTION
- https://github.com/newrelic/nri-prometheus/releases/tag/v2.22.0
- https://github.com/newrelic/nri-docker/releases/tag/v2.1.2
- https://github.com/newrelic/nri-flex/releases/tag/v1.16.2