### PR TITLE
chore(deps): update alpine tag to 3.21.1

### DIFF
--- a/build/container/Dockerfile
+++ b/build/container/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_image=alpine:3.21
+ARG base_image=alpine:3.21.1
 
 FROM $base_image AS core
 


### PR DESCRIPTION
Bump alpine from 3.21 to 3.21.1 to fix `CVE-2024-12254` Vulnerability reported in infrastructure bundle.

The alpine [3.21.1](https://www.alpinelinux.org/posts/Alpine-3.21.1-released.html#:~:text=main/python3%3A%20patch%20CVE%2D2024%2D12254) has patch for `CVE-2024-12254`

![image](https://github.com/user-attachments/assets/053d13c9-8d32-499d-988e-ffc5cd8dd9b6)
