### PR TITLE
Goreleaser conflict fips

### DIFF
--- a/.github/workflows/component_molecule_packaging.yml
+++ b/.github/workflows/component_molecule_packaging.yml
@@ -35,5 +35,6 @@ jobs:
           gpg_key: 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg'
           repo_base_url: ${{ inputs.REPO_ENDPOINT }}
           package_name: 'newrelic-infra-fips'
+          exec_name: 'newrelic-infra'
           package_version: ${{ inputs.TAG }}
           platforms: "al2,al2023,debian-bullseye,debian-bookworm,redhat8,redhat9,suse15.3,suse15.4,suse15.5,suse15.6,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204,ubuntu2404"

--- a/build/goreleaser/linux/al2023_amd64.yml
+++ b/build/goreleaser/linux/al2023_amd64.yml
@@ -88,5 +88,7 @@
     # Required packages. rpm version 4.11.3 does not support weak dependencies
     recommends:
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end AL2023 adm64

--- a/build/goreleaser/linux/al2023_arm64.yml
+++ b/build/goreleaser/linux/al2023_arm64.yml
@@ -81,5 +81,7 @@
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
     recommends:
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end AL2023 arm64

--- a/build/goreleaser/linux/al2_amd64.yml
+++ b/build/goreleaser/linux/al2_amd64.yml
@@ -89,5 +89,7 @@
     dependencies:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end AL2 adm64

--- a/build/goreleaser/linux/al2_arm64.yml
+++ b/build/goreleaser/linux/al2_arm64.yml
@@ -82,5 +82,7 @@
     dependencies:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end AL2 arm64

--- a/build/goreleaser/linux/centos_7_amd64.yml
+++ b/build/goreleaser/linux/centos_7_amd64.yml
@@ -88,5 +88,7 @@
     dependencies:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end CentOS 7 amd64

--- a/build/goreleaser/linux/centos_7_arm64.yml
+++ b/build/goreleaser/linux/centos_7_arm64.yml
@@ -83,5 +83,7 @@
     dependencies:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end CentOS 7 arm64

--- a/build/goreleaser/linux/centos_8_amd64.yml
+++ b/build/goreleaser/linux/centos_8_amd64.yml
@@ -89,5 +89,7 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end CentOS 8 amd64

--- a/build/goreleaser/linux/centos_8_arm64.yml
+++ b/build/goreleaser/linux/centos_8_arm64.yml
@@ -82,5 +82,7 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end CentOS 8 arm64

--- a/build/goreleaser/linux/debian_systemd_amd64.yml
+++ b/build/goreleaser/linux/debian_systemd_amd64.yml
@@ -73,5 +73,7 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end Debian systemd amd64

--- a/build/goreleaser/linux/debian_systemd_arm64.yml
+++ b/build/goreleaser/linux/debian_systemd_arm64.yml
@@ -73,5 +73,7 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end Debian systemd arm64

--- a/build/goreleaser/linux/debian_upstart_amd64.yml
+++ b/build/goreleaser/linux/debian_upstart_amd64.yml
@@ -69,5 +69,7 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end Debian upstart amd64

--- a/build/goreleaser/linux/rhel_9_amd64.yml
+++ b/build/goreleaser/linux/rhel_9_amd64.yml
@@ -88,5 +88,7 @@
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
     recommends:
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end RHEL 9 amd64

--- a/build/goreleaser/linux/rhel_9_arm64.yml
+++ b/build/goreleaser/linux/rhel_9_arm64.yml
@@ -81,5 +81,7 @@
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
     recommends:
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end RHEL 9 arm64

--- a/build/goreleaser/linux/sles_125_amd64.yml
+++ b/build/goreleaser/linux/sles_125_amd64.yml
@@ -91,5 +91,7 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end SLES 12.5 amd64

--- a/build/goreleaser/linux/sles_125_arm64.yml
+++ b/build/goreleaser/linux/sles_125_arm64.yml
@@ -79,6 +79,8 @@
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
 #    recommends:
   # FB not supported yet

--- a/build/goreleaser/linux/sles_152_amd64.yml
+++ b/build/goreleaser/linux/sles_152_amd64.yml
@@ -89,5 +89,7 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
 
   # end SLES 15.2 amd64

--- a/build/goreleaser/linux/sles_152_arm64.yml
+++ b/build/goreleaser/linux/sles_152_arm64.yml
@@ -79,6 +79,8 @@
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
 #    recommends:
   # FB not supported yet

--- a/build/goreleaser/linux/sles_153_amd64.yml
+++ b/build/goreleaser/linux/sles_153_amd64.yml
@@ -89,5 +89,7 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
 
   # end SLES 15.3 amd64

--- a/build/goreleaser/linux/sles_153_arm64.yml
+++ b/build/goreleaser/linux/sles_153_arm64.yml
@@ -79,6 +79,8 @@
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
 #    recommends:
   # FB not supported yet

--- a/build/goreleaser/linux/sles_154_amd64.yml
+++ b/build/goreleaser/linux/sles_154_amd64.yml
@@ -88,5 +88,7 @@
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
     recommends:
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
 
   # end SLES 15.4 amd64

--- a/build/goreleaser/linux/sles_154_arm64.yml
+++ b/build/goreleaser/linux/sles_154_arm64.yml
@@ -79,6 +79,8 @@
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
 #    recommends:
 # FB not supported yet

--- a/build/goreleaser/linux/sles_155_amd64.yml
+++ b/build/goreleaser/linux/sles_155_amd64.yml
@@ -88,5 +88,7 @@
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
     recommends:
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
 
   # end SLES 15.5 amd64

--- a/build/goreleaser/linux/sles_155_arm64.yml
+++ b/build/goreleaser/linux/sles_155_arm64.yml
@@ -79,6 +79,8 @@
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
 #    recommends:
 # FB not supported yet

--- a/build/goreleaser/linux/sles_156_amd64.yml
+++ b/build/goreleaser/linux/sles_156_amd64.yml
@@ -88,5 +88,7 @@
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
     recommends:
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
 
   # end SLES 15.6 amd64

--- a/build/goreleaser/linux/sles_156_arm64.yml
+++ b/build/goreleaser/linux/sles_156_arm64.yml
@@ -68,6 +68,8 @@
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
 #    recommends:
 # FB not supported yet


### PR DESCRIPTION
Add conflict metadata between newrelic-infra and newrelic-infra-fips and set the right exec path for molecule fips tests.