### PR TITLE
Add prerelease for FIPS with testing and image creation

### DIFF
--- a/.github/workflows/component_canaries.yml
+++ b/.github/workflows/component_canaries.yml
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-20.04
     if: ${{ inputs.PLATFORM == 'macos' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ASSUME_ROLE }}
           aws-region: us-east-2
@@ -68,10 +68,10 @@ jobs:
     runs-on: ubuntu-20.04
     if: ${{ inputs.PLATFORM == 'linux' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ASSUME_ROLE }}
           aws-region: us-east-2
@@ -130,10 +130,10 @@ jobs:
     runs-on: ubuntu-20.04
     if: ${{ inputs.PLATFORM == 'windows' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ASSUME_ROLE }}
           aws-region: us-east-2

--- a/.github/workflows/component_docker_packaging.yml
+++ b/.github/workflows/component_docker_packaging.yml
@@ -19,6 +19,10 @@ on:
       TAG:
         required: true
         type: string
+      FIPS:
+        required: false
+        type: boolean
+        default: false
 
 env:
   GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -29,6 +33,7 @@ env:
   DOCKER_HUB_ID: ${{ secrets.DOCKER_HUB_ID }}
   DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
   DOCKER_PUBLISH: true
+  FIPS: ${{ inputs.FIPS == true && '-fips' || '' }}
 
 jobs:
   packaging:
@@ -47,7 +52,7 @@ jobs:
           password: ${{ env.DOCKER_HUB_PASSWORD }}
 
       - name: Compiling binaries for linux amd64, arm, arm64
-        run: make ci/prerelease/linux-for-docker
+        run: make ci/prerelease/linux-for-docker${{env.FIPS}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -58,10 +63,10 @@ jobs:
           version: v0.9.1
 
       - name: Build and publish Release Candidate (RC) of base Docker image
-        run: AGENT_VERSION=${{env.TAG}} make -C build/container/ clean publish/multi-arch-base-rc
+        run: AGENT_VERSION=${{env.TAG}} FIPS=${{env.FIPS}} make -C build/container/ clean publish/multi-arch-base-rc
 
       - name: Build and publish Release Candidate (RC) of forwarder Docker image
-        run: AGENT_VERSION=${{env.TAG}} make -C build/container/ clean publish/multi-arch-forwarder-rc
+        run: AGENT_VERSION=${{env.TAG}} FIPS=${{env.FIPS}} make -C build/container/ clean publish/multi-arch-forwarder-rc
 
       - name: Build and publish Release Candidate (RC) of k8s-events-forwarders Docker image
-        run: AGENT_VERSION=${{env.TAG}} make -C build/container/ clean publish/multi-arch-k8s-events-forwarder-rc
+        run: AGENT_VERSION=${{env.TAG}} FIPS=${{env.FIPS}} make -C build/container/ clean publish/multi-arch-k8s-events-forwarder-rc

--- a/.github/workflows/component_docker_publish.yml
+++ b/.github/workflows/component_docker_publish.yml
@@ -54,3 +54,21 @@ jobs:
 
       - name: Publish latest of k8s-events-forwarders Docker image
         run: make -C build/container/ clean publish/multi-arch-k8s-events-forwarder-latest AGENT_VERSION=${{env.TAG}}
+
+      - name: Publish tag of base Docker image FIPS
+        run: make -C build/container/ clean publish/multi-arch-base-tag AGENT_VERSION=${{env.TAG}} FIPS=${{env.FIPS}}
+
+      - name: Publish latest of base Docker image FIPS
+        run: make -C build/container/ clean publish/multi-arch-base-latest AGENT_VERSION=${{env.TAG}} FIPS=${{env.FIPS}}
+
+      - name: Publish tag of forwarder Docker image FIPS
+        run: make -C build/container/ clean publish/multi-arch-forwarder-tag AGENT_VERSION=${{env.TAG}} FIPS=${{env.FIPS}}
+
+      - name: Publish latest of forwarder Docker image FIPS
+        run: make -C build/container/ clean publish/multi-arch-forwarder-latest AGENT_VERSION=${{env.TAG}} FIPS=${{env.FIPS}}
+
+      - name: Publish tag of k8s-events-forwarders Docker image FIPS
+        run: make -C build/container/ clean publish/multi-arch-k8s-events-forwarder-tag AGENT_VERSION=${{env.TAG}} FIPS=${{env.FIPS}}
+
+      - name: Publish latest of k8s-events-forwarders Docker image FIPS
+        run: make -C build/container/ clean publish/multi-arch-k8s-events-forwarder-latest AGENT_VERSION=${{env.TAG}} FIPS=${{env.FIPS}}

--- a/.github/workflows/component_linux_packaging.yml
+++ b/.github/workflows/component_linux_packaging.yml
@@ -22,6 +22,10 @@ on:
       ARCH:
         required: true
         type: string
+      FIPS:
+        required: false
+        type: boolean
+        default: false
 
 env:
   GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -32,6 +36,7 @@ env:
   DOCKER_HUB_ID: ${{ secrets.DOCKER_HUB_ID }}
   DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
   ARCH: ${{ inputs.ARCH }}
+  FIPS: ${{ inputs.FIPS == true && '-fips' || '' }}
 
 jobs:
   packaging:
@@ -49,6 +54,8 @@ jobs:
 
       - name: Preparing linux packages
         run: make ci/prerelease/linux-${{ env.ARCH }}
+        env:
+          FIPS: ${{ env.FIPS }}
 
       - name: Generate checksum files
         uses: ./.github/actions/generate-checksums

--- a/.github/workflows/component_linux_publish.yml
+++ b/.github/workflows/component_linux_publish.yml
@@ -76,6 +76,9 @@ jobs:
           - "targz"
           - "deb"
           - "rpm"
+        suffix:
+          - ""
+          - "-fips"
 
     steps:
       - name: Login to DockerHub
@@ -89,10 +92,10 @@ jobs:
         uses: newrelic/infrastructure-publish-action@v1.3.4
         with:
           tag: ${{env.TAG}}
-          app_name: "newrelic-infra"
+          app_name: "newrelic-infra${{ matrix.suffix }}"
           repo_name: "newrelic/infrastructure-agent"
           schema: "custom"
-          schema_url: "https://raw.githubusercontent.com/newrelic/infrastructure-agent/${{ env.SCHEMA_BRANCH }}/build/upload-schema-linux-${{ matrix.assetsType }}.yml"
+          schema_url: "https://raw.githubusercontent.com/newrelic/infrastructure-agent/${{ env.SCHEMA_BRANCH }}/build/upload-schema-linux-${{ matrix.assetsType }}${{ matrix.suffix }}.yml"
           aws_access_key_id: ${{ env.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           aws_s3_bucket_name: ${{ env.AWS_S3_BUCKET_NAME }}

--- a/.github/workflows/component_molecule_packaging.yml
+++ b/.github/workflows/component_molecule_packaging.yml
@@ -35,5 +35,6 @@ jobs:
           gpg_key: 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg'
           repo_base_url: ${{ inputs.REPO_ENDPOINT }}
           package_name: 'newrelic-infra-fips'
+          exec_name: 'newrelic-infra'
           package_version: ${{ inputs.TAG }}
           platforms: "al2,al2023,debian-bullseye,debian-bookworm,redhat8,redhat9,suse15.3,suse15.4,suse15.5,suse15.6,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204,ubuntu2404"

--- a/.github/workflows/component_molecule_packaging.yml
+++ b/.github/workflows/component_molecule_packaging.yml
@@ -21,10 +21,19 @@ jobs:
     name: Test package installation
     runs-on: ubuntu-latest
     steps:
-      - uses: newrelic/pkg-installation-testing-action@v1
+      - name: Test NON-FIPS package installation
+        uses: newrelic/pkg-installation-testing-action@v1
         with:
           gpg_key: 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg'
           repo_base_url: ${{ inputs.REPO_ENDPOINT }}
           package_name: 'newrelic-infra'
+          package_version: ${{ inputs.TAG }}
+          platforms: "al2,al2023,debian-bullseye,debian-bookworm,redhat8,redhat9,suse15.3,suse15.4,suse15.5,suse15.6,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204,ubuntu2404"
+      - name: Test FIPS package installation
+        uses: newrelic/pkg-installation-testing-action@v1
+        with:
+          gpg_key: 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg'
+          repo_base_url: ${{ inputs.REPO_ENDPOINT }}
+          package_name: 'newrelic-infra-fips'
           package_version: ${{ inputs.TAG }}
           platforms: "al2,al2023,debian-bullseye,debian-bookworm,redhat8,redhat9,suse15.3,suse15.4,suse15.5,suse15.6,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204,ubuntu2404"

--- a/.github/workflows/component_prerelease_testing.yml
+++ b/.github/workflows/component_prerelease_testing.yml
@@ -39,10 +39,10 @@ jobs:
   provision:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ASSUME_ROLE }}
           aws-region: us-east-2
@@ -79,10 +79,10 @@ jobs:
     needs: [ provision ]
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ASSUME_ROLE }}
           aws-region: us-east-2
@@ -120,13 +120,14 @@ jobs:
     needs: [ harvest-tests ]
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ASSUME_ROLE }}
           aws-region: us-east-2
+          role-duration-seconds: 7200
 
       - name: Set branch name
         run: |
@@ -154,10 +155,10 @@ jobs:
     needs: [ harvest-tests ]
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ASSUME_ROLE }}
           aws-region: us-east-2
@@ -188,10 +189,10 @@ jobs:
     needs: [ packaging-tests-linux ]
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ASSUME_ROLE }}
           aws-region: us-east-2
@@ -229,10 +230,10 @@ jobs:
       needs: [ packaging-tests-windows ]
       runs-on: ubuntu-20.04
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v4
 
         - name: Configure AWS Credentials
-          uses: aws-actions/configure-aws-credentials@v1
+          uses: aws-actions/configure-aws-credentials@v4
           with:
             role-to-assume: ${{ env.AWS_ASSUME_ROLE }}
             aws-region: us-east-2

--- a/.github/workflows/component_trivy.yml
+++ b/.github/workflows/component_trivy.yml
@@ -12,6 +12,13 @@ on:
       severity:
         required: true
         type: string
+      FIPS:
+        required: false
+        type: boolean
+        default: false
+
+env:
+  FIPS: ${{ inputs.FIPS == true && '-fips' || '' }}
 
 jobs:
   trivy_scanner:
@@ -22,7 +29,7 @@ jobs:
       - name: newrelic/infrastructure
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: "docker.io/newrelic/infrastructure:${{ inputs.tag }}"
+          image-ref: "docker.io/newrelic/infrastructure${{ env.FIPS }}:${{ inputs.tag }}"
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true
@@ -35,7 +42,7 @@ jobs:
       - name: newrelic/k8s-events-forwarder
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: "docker.io/newrelic/k8s-events-forwarder:${{ inputs.tag }}"
+          image-ref: "docker.io/newrelic/k8s-events-forwarder${{ env.FIPS }}:${{ inputs.tag }}"
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true
@@ -48,7 +55,7 @@ jobs:
       - name: newrelic/nri-forwarder
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: "docker.io/newrelic/nri-forwarder:${{ inputs.tag }}"
+          image-ref: "docker.io/newrelic/nri-forwarder${{ env.FIPS }}:${{ inputs.tag }}"
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true
@@ -69,7 +76,7 @@ jobs:
       - name: Sarif newrelic/infrastructure
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: "docker.io/newrelic/infrastructure:${{ inputs.tag }}"
+          image-ref: "docker.io/newrelic/infrastructure${{ env.FIPS }}:${{ inputs.tag }}"
           format: 'sarif'
           output: 'trivy-results.sarif'
           vuln-type: 'os,library'

--- a/.github/workflows/prerelease_linux.yml
+++ b/.github/workflows/prerelease_linux.yml
@@ -31,6 +31,21 @@ jobs:
     with:
       TAG:  ${{ github.event.release.tag_name }}
       ARCH: 'amd64'
+  
+  packaging-amd64-fips:
+    needs: [unit-test, proxy-tests]
+    uses: ./.github/workflows/component_linux_packaging.yml
+    secrets:
+      DOCKER_HUB_ID: ${{secrets.OHAI_DOCKER_HUB_ID}}
+      DOCKER_HUB_PASSWORD: ${{secrets.OHAI_DOCKER_HUB_PASSWORD}}
+      GPG_MAIL: 'infrastructure-eng@newrelic.com'
+      GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
+      GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      TAG:  ${{ github.event.release.tag_name }}
+      ARCH: 'amd64'
+      FIPS: true
 
   packaging-arm:
     needs: [unit-test, proxy-tests]
@@ -59,6 +74,21 @@ jobs:
     with:
       TAG:  ${{ github.event.release.tag_name }}
       ARCH: 'arm64'
+
+  packaging-arm64-fips:
+    needs: [unit-test, proxy-tests]
+    uses: ./.github/workflows/component_linux_packaging.yml
+    secrets:
+      DOCKER_HUB_ID: ${{secrets.OHAI_DOCKER_HUB_ID}}
+      DOCKER_HUB_PASSWORD: ${{secrets.OHAI_DOCKER_HUB_PASSWORD}}
+      GPG_MAIL: 'infrastructure-eng@newrelic.com'
+      GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
+      GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      TAG:  ${{ github.event.release.tag_name }}
+      ARCH: 'arm64'
+      FIPS: true
 
   packaging-legacy:
     needs: [unit-test, proxy-tests]
@@ -98,7 +128,7 @@ jobs:
     # point to staging after tests
     name: Publish linux artifacts into s3 staging bucket
     uses: ./.github/workflows/component_linux_publish.yml
-    needs: [packaging-amd64, packaging-arm, packaging-arm64, packaging-legacy]
+    needs: [packaging-amd64, packaging-amd64-fips, packaging-arm, packaging-arm64, packaging-arm64-fips, packaging-legacy]
     secrets:
       DOCKER_HUB_ID: ${{secrets.OHAI_DOCKER_HUB_ID}}
       DOCKER_HUB_PASSWORD: ${{secrets.OHAI_DOCKER_HUB_PASSWORD}}

--- a/.github/workflows/prerelease_linux.yml
+++ b/.github/workflows/prerelease_linux.yml
@@ -124,6 +124,28 @@ jobs:
       tag: "${{ github.event.release.tag_name }}-rc"
       severity: "CRITICAL"
 
+  packaging-docker-fips:
+    needs: [unit-test, proxy-tests]
+    uses: ./.github/workflows/component_docker_packaging.yml
+    secrets:
+      DOCKER_HUB_ID: ${{secrets.OHAI_DOCKER_HUB_ID}}
+      DOCKER_HUB_PASSWORD: ${{secrets.OHAI_DOCKER_HUB_PASSWORD}}
+      GPG_MAIL: 'infrastructure-eng@newrelic.com'
+      GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
+      GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      TAG:  ${{ github.event.release.tag_name }}
+      FIPS: true
+
+  docker-fips-trivy-critical:
+    needs: [packaging-docker-fips]
+    uses: ./.github/workflows/component_trivy.yml
+    with:
+      tag: "${{ github.event.release.tag_name }}-rc"
+      severity: "CRITICAL"
+      FIPS: true
+
   publishing-to-s3:
     # point to staging after tests
     name: Publish linux artifacts into s3 staging bucket

--- a/build/build.mk
+++ b/build/build.mk
@@ -174,6 +174,12 @@ build-harvest-tests: CGO_ENABLED=0
 build-harvest-tests: deps
 	$(GO_BIN) test -c ./test/harvest -tags="harvest" -v
 
+.PHONY: build-harvest-tests-fips
+build-harvest-tests-fips: CGO_ENABLED=1
+build-harvest-tests-fips: GOEXPERIMENT=boringcrypto
+build-harvest-tests-fips: deps
+	$(GO_BIN) test -c ./test/harvest -tags="harvest,fips" -v
+
 
 .PHONY: proxy-test
 proxy-test:

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -84,6 +84,10 @@ ci/prerelease/linux-legacy:
 ci/prerelease/linux-for-docker:
 	TARGET_OS=linux-for-docker $(MAKE) ci/prerelease
 
+.PHONY : ci/prerelease/linux-for-docker-fips
+ci/prerelease/linux-for-docker-fips:
+	TARGET_OS=linux-for-docker-fips $(MAKE) ci/prerelease
+
 
 .PHONY : ci/prerelease/macos
 ci/prerelease/macos:

--- a/build/container/Dockerfile
+++ b/build/container/Dockerfile
@@ -36,8 +36,12 @@ RUN apk add --no-cache --upgrade \
     #   libpthread.so.0 => /lib64/ld-linux-x86-64.so.2 (0x7f2bbbd0f000)
     #   libc.so.6 => /lib64/ld-linux-x86-64.so.2 (0x7f2bbbd0f000)
     # As musl and glibc are compatible, this symlink fixes the missing dependency
+    # The simlink is added both for amd64 and arm64 architectures
     && mkdir /lib64 \
     && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 \
+    && ln -s /lib/libc.musl-aarch64.so.1 /lib64/ld-linux-aarch64.so.1 \
+    # libresolv.so.2 is needed when CGO is enabled so we add the glibc compatibility for Alpine
+    && apk add --no-cache gcompat \
     && apk add --no-cache tini
 
 # Tini is now available at /sbin/tini

--- a/build/container/Makefile
+++ b/build/container/Makefile
@@ -16,6 +16,7 @@ DOCKER_BUILD_TAG_PREFIX	?= build
 DOCKER_TAG_LATEST	?= latest
 USE_BUILDX			?= false
 DOCKER_PUBLISH		?= false
+FIPS                ?=
 
 AGENT_ARCH ?= $(DOCKER_ARCH)
 
@@ -50,12 +51,12 @@ AGENT_VERSION                  ?= 0.0.0
 IMAGE_VERSION                  ?= $(AGENT_VERSION)
 
 NS                             ?= newrelic
-REPO                           ?= infrastructure
+REPO                           ?= infrastructure${FIPS}
 IMAGE_NAME                     ?= ${NS}/${REPO}
 CORE_IMAGE_NAME                ?= ${IMAGE_NAME}-core
 BASE_IMAGE_NAME                ?= ${IMAGE_NAME}
-K8S_FWD_IMAGE_NAME			   ?= ${NS}/k8s-events-forwarder
-FWD_IMAGE_NAME			   	   ?= ${NS}/nri-forwarder
+K8S_FWD_IMAGE_NAME			   ?= ${NS}/k8s-events-forwarder${FIPS}
+FWD_IMAGE_NAME			   	   ?= ${NS}/nri-forwarder${FIPS}
 DOCKER_IMAGE_NAME			   ?= ${BASE_IMAGE_NAME}
 
 AGENT_BIN                      ?= newrelic-infra
@@ -265,19 +266,29 @@ publish/multi-arch-base-manifest :
 	@printf 'Target: publish/base-manifest\n'
 	@printf 'Image: $(DOCKER_IMAGE_NAME):$(IMAGE_VERSION)'
 	@printf '\n================================================================\n'
+ifeq ($(FIPS),)
 	@(docker manifest create \
     $(DOCKER_IMAGE_NAME):$(IMAGE_VERSION) \
     	$(DOCKER_IMAGE_NAME):$(DOCKER_BUILD_TAG_PREFIX)-arm64 \
     	$(DOCKER_IMAGE_NAME):$(DOCKER_BUILD_TAG_PREFIX)-arm \
     	$(DOCKER_IMAGE_NAME):$(DOCKER_BUILD_TAG_PREFIX)-amd64)
+else
+	@(docker manifest create \
+    $(DOCKER_IMAGE_NAME):$(IMAGE_VERSION) \
+    	$(DOCKER_IMAGE_NAME):$(DOCKER_BUILD_TAG_PREFIX)-arm64 \
+    	$(DOCKER_IMAGE_NAME):$(DOCKER_BUILD_TAG_PREFIX)-amd64)
+endif
 	@docker manifest push $(DOCKER_IMAGE_NAME):$(IMAGE_VERSION)
+
 
 # [RC] Shortcut to build all supported multi arch bases and publish as RC
 .PHONY : publish/multi-arch-base-rc
 publish/multi-arch-base-rc : export IMAGE_VERSION=$(AGENT_VERSION)-rc
 publish/multi-arch-base-rc : export DOCKER_BUILD_TAG_PREFIX=$(IMAGE_VERSION)
 publish/multi-arch-base-rc : build/base-arm64
+ifeq ($(FIPS),)
 publish/multi-arch-base-rc : build/base-arm
+endif
 publish/multi-arch-base-rc : build/base-amd64
 publish/multi-arch-base-rc : publish/multi-arch-base-manifest
 
@@ -301,11 +312,18 @@ publish/multi-arch-k8s-events-forwarder-manifest :
 	@printf 'Target: publish/k8s-events-forwarder-manifest\n'
 	@printf 'Image: $(DOCKER_IMAGE_NAME):$(IMAGE_VERSION)'
 	@printf '\n================================================================\n'
+ifeq ($(FIPS),)
 	@(docker manifest create \
     $(DOCKER_IMAGE_NAME):$(IMAGE_VERSION) \
     	$(DOCKER_IMAGE_NAME):$(DOCKER_BUILD_TAG_PREFIX)-arm64 \
     	$(DOCKER_IMAGE_NAME):$(DOCKER_BUILD_TAG_PREFIX)-arm \
     	$(DOCKER_IMAGE_NAME):$(DOCKER_BUILD_TAG_PREFIX)-amd64)
+else
+	@(docker manifest create \
+    $(DOCKER_IMAGE_NAME):$(IMAGE_VERSION) \
+    	$(DOCKER_IMAGE_NAME):$(DOCKER_BUILD_TAG_PREFIX)-arm64 \
+    	$(DOCKER_IMAGE_NAME):$(DOCKER_BUILD_TAG_PREFIX)-amd64)
+endif
 	@docker manifest push $(DOCKER_IMAGE_NAME):$(IMAGE_VERSION)
 
 # [RC] Shortcut to build all supported multi arch k8s-events-forwarders and publish as RC
@@ -313,7 +331,9 @@ publish/multi-arch-k8s-events-forwarder-manifest :
 publish/multi-arch-k8s-events-forwarder-rc : export IMAGE_VERSION=$(AGENT_VERSION)-rc
 publish/multi-arch-k8s-events-forwarder-rc : export DOCKER_BUILD_TAG_PREFIX=$(IMAGE_VERSION)
 publish/multi-arch-k8s-events-forwarder-rc : build/k8s-events-forwarder-arm64
+ifeq ($(FIPS),)
 publish/multi-arch-k8s-events-forwarder-rc : build/k8s-events-forwarder-arm
+endif
 publish/multi-arch-k8s-events-forwarder-rc : build/k8s-events-forwarder-amd64
 publish/multi-arch-k8s-events-forwarder-rc : publish/multi-arch-k8s-events-forwarder-manifest
 
@@ -337,11 +357,18 @@ publish/multi-arch-forwarder-manifest :
 	@printf 'Target: publish/forwarder-manifest\n'
 	@printf 'Image: $(DOCKER_IMAGE_NAME):$(IMAGE_VERSION)'
 	@printf '\n================================================================\n'
+ifeq ($(FIPS),)
 	@(docker manifest create \
     $(DOCKER_IMAGE_NAME):$(IMAGE_VERSION) \
     	$(DOCKER_IMAGE_NAME):$(DOCKER_BUILD_TAG_PREFIX)-arm64 \
     	$(DOCKER_IMAGE_NAME):$(DOCKER_BUILD_TAG_PREFIX)-arm \
     	$(DOCKER_IMAGE_NAME):$(DOCKER_BUILD_TAG_PREFIX)-amd64)
+else
+	@(docker manifest create \
+    $(DOCKER_IMAGE_NAME):$(IMAGE_VERSION) \
+    	$(DOCKER_IMAGE_NAME):$(DOCKER_BUILD_TAG_PREFIX)-arm64 \
+    	$(DOCKER_IMAGE_NAME):$(DOCKER_BUILD_TAG_PREFIX)-amd64)
+endif
 	@docker manifest push $(DOCKER_IMAGE_NAME):$(IMAGE_VERSION)
 
 
@@ -350,7 +377,9 @@ publish/multi-arch-forwarder-manifest :
 publish/multi-arch-forwarder-rc : export IMAGE_VERSION=$(AGENT_VERSION)-rc
 publish/multi-arch-forwarder-rc : export DOCKER_BUILD_TAG_PREFIX=$(IMAGE_VERSION)
 publish/multi-arch-forwarder-rc : build/forwarder-arm64
+ifeq ($(FIPS),)
 publish/multi-arch-forwarder-rc : build/forwarder-arm
+endif
 publish/multi-arch-forwarder-rc : build/forwarder-amd64
 publish/multi-arch-forwarder-rc : publish/multi-arch-forwarder-manifest
 

--- a/build/embed/integrations.mk
+++ b/build/embed/integrations.mk
@@ -12,19 +12,19 @@ OHI_OS   ?= linux
 NRI_DOCKER_VERSION ?= $(call get-nri-version,nri-docker)
 NRI_DOCKER_ARCH    ?= $(OHI_ARCH)
 NRI_DOCKER_OS      ?= $(OHI_OS)
-NRI_DOCKER_URL     ?= https://download.newrelic.com/infrastructure_agent/binaries/$(NRI_DOCKER_OS)/$(NRI_DOCKER_ARCH)/nri-docker_$(NRI_DOCKER_OS)_$(NRI_DOCKER_VERSION)_$(NRI_DOCKER_ARCH).tar.gz
+NRI_DOCKER_URL     ?= https://download.newrelic.com/infrastructure_agent/binaries/$(NRI_DOCKER_OS)/$(NRI_DOCKER_ARCH)/nri-docker$(FIPS)_$(NRI_DOCKER_OS)_$(NRI_DOCKER_VERSION)_$(NRI_DOCKER_ARCH).tar.gz
 
 # flex
 NRI_FLEX_VERSION   ?= $(call get-nri-version,nri-flex)
 NRI_FLEX_ARCH      ?= $(OHI_ARCH)
 NRI_FLEX_OS        ?= $(OHI_OS)
-NRI_FLEX_URL       ?= https://github.com/newrelic/nri-flex/releases/download/v$(NRI_FLEX_VERSION)/nri-flex_$(NRI_FLEX_OS)_$(NRI_FLEX_VERSION)_$(NRI_FLEX_ARCH).tar.gz
+NRI_FLEX_URL       ?= https://github.com/newrelic/nri-flex/releases/download/v$(NRI_FLEX_VERSION)/nri-flex$(FIPS)_$(NRI_FLEX_OS)_$(NRI_FLEX_VERSION)_$(NRI_FLEX_ARCH).tar.gz
 
 # prometheus
 NRI_PROMETHEUS_VERSION   ?= $(call get-nri-version,nri-prometheus)
 NRI_PROMETHEUS_ARCH      ?= $(OHI_ARCH)
 NRI_PROMETHEUS_OS        ?= $(OHI_OS)
-NRI_PROMETHEUS_URL       ?= https://github.com/newrelic/nri-prometheus/releases/download/v$(NRI_PROMETHEUS_VERSION)/nri-prometheus_$(NRI_PROMETHEUS_OS)_$(NRI_PROMETHEUS_VERSION)_$(NRI_PROMETHEUS_ARCH).tar.gz
+NRI_PROMETHEUS_URL       ?= https://github.com/newrelic/nri-prometheus/releases/download/v$(NRI_PROMETHEUS_VERSION)/nri-prometheus$(FIPS)_$(NRI_PROMETHEUS_OS)_$(NRI_PROMETHEUS_VERSION)_$(NRI_PROMETHEUS_ARCH).tar.gz
 
 .PHONY: get-integrations
 get-integrations: get-nri-docker

--- a/build/goreleaser/linux/al2023_amd64.yml
+++ b/build/goreleaser/linux/al2023_amd64.yml
@@ -88,5 +88,7 @@
     # Required packages. rpm version 4.11.3 does not support weak dependencies
     recommends:
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end AL2023 adm64

--- a/build/goreleaser/linux/al2023_arm64.yml
+++ b/build/goreleaser/linux/al2023_arm64.yml
@@ -81,5 +81,7 @@
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
     recommends:
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end AL2023 arm64

--- a/build/goreleaser/linux/al2_amd64.yml
+++ b/build/goreleaser/linux/al2_amd64.yml
@@ -89,5 +89,7 @@
     dependencies:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end AL2 adm64

--- a/build/goreleaser/linux/al2_arm64.yml
+++ b/build/goreleaser/linux/al2_arm64.yml
@@ -82,5 +82,7 @@
     dependencies:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end AL2 arm64

--- a/build/goreleaser/linux/centos_7_amd64.yml
+++ b/build/goreleaser/linux/centos_7_amd64.yml
@@ -88,5 +88,7 @@
     dependencies:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end CentOS 7 amd64

--- a/build/goreleaser/linux/centos_7_arm64.yml
+++ b/build/goreleaser/linux/centos_7_arm64.yml
@@ -83,5 +83,7 @@
     dependencies:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end CentOS 7 arm64

--- a/build/goreleaser/linux/centos_8_amd64.yml
+++ b/build/goreleaser/linux/centos_8_amd64.yml
@@ -89,5 +89,7 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end CentOS 8 amd64

--- a/build/goreleaser/linux/centos_8_arm64.yml
+++ b/build/goreleaser/linux/centos_8_arm64.yml
@@ -82,5 +82,7 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end CentOS 8 arm64

--- a/build/goreleaser/linux/debian_systemd_amd64.yml
+++ b/build/goreleaser/linux/debian_systemd_amd64.yml
@@ -73,5 +73,7 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end Debian systemd amd64

--- a/build/goreleaser/linux/debian_systemd_arm64.yml
+++ b/build/goreleaser/linux/debian_systemd_arm64.yml
@@ -73,5 +73,7 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end Debian systemd arm64

--- a/build/goreleaser/linux/debian_upstart_amd64.yml
+++ b/build/goreleaser/linux/debian_upstart_amd64.yml
@@ -69,5 +69,7 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end Debian upstart amd64

--- a/build/goreleaser/linux/rhel_9_amd64.yml
+++ b/build/goreleaser/linux/rhel_9_amd64.yml
@@ -88,5 +88,7 @@
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
     recommends:
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end RHEL 9 amd64

--- a/build/goreleaser/linux/rhel_9_arm64.yml
+++ b/build/goreleaser/linux/rhel_9_arm64.yml
@@ -81,5 +81,7 @@
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
     recommends:
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end RHEL 9 arm64

--- a/build/goreleaser/linux/sles_125_amd64.yml
+++ b/build/goreleaser/linux/sles_125_amd64.yml
@@ -91,5 +91,7 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
   
   # end SLES 12.5 amd64

--- a/build/goreleaser/linux/sles_125_arm64.yml
+++ b/build/goreleaser/linux/sles_125_arm64.yml
@@ -79,6 +79,8 @@
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
 #    recommends:
   # FB not supported yet

--- a/build/goreleaser/linux/sles_152_amd64.yml
+++ b/build/goreleaser/linux/sles_152_amd64.yml
@@ -89,5 +89,7 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
 
   # end SLES 15.2 amd64

--- a/build/goreleaser/linux/sles_152_arm64.yml
+++ b/build/goreleaser/linux/sles_152_arm64.yml
@@ -79,6 +79,8 @@
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
 #    recommends:
   # FB not supported yet

--- a/build/goreleaser/linux/sles_153_amd64.yml
+++ b/build/goreleaser/linux/sles_153_amd64.yml
@@ -89,5 +89,7 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
 
   # end SLES 15.3 amd64

--- a/build/goreleaser/linux/sles_153_arm64.yml
+++ b/build/goreleaser/linux/sles_153_arm64.yml
@@ -79,6 +79,8 @@
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
 #    recommends:
   # FB not supported yet

--- a/build/goreleaser/linux/sles_154_amd64.yml
+++ b/build/goreleaser/linux/sles_154_amd64.yml
@@ -88,5 +88,7 @@
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
     recommends:
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
 
   # end SLES 15.4 amd64

--- a/build/goreleaser/linux/sles_154_arm64.yml
+++ b/build/goreleaser/linux/sles_154_arm64.yml
@@ -79,6 +79,8 @@
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
 #    recommends:
 # FB not supported yet

--- a/build/goreleaser/linux/sles_155_amd64.yml
+++ b/build/goreleaser/linux/sles_155_amd64.yml
@@ -88,5 +88,7 @@
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
     recommends:
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
 
   # end SLES 15.5 amd64

--- a/build/goreleaser/linux/sles_155_arm64.yml
+++ b/build/goreleaser/linux/sles_155_arm64.yml
@@ -79,6 +79,8 @@
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
 #    recommends:
 # FB not supported yet

--- a/build/goreleaser/linux/sles_156_amd64.yml
+++ b/build/goreleaser/linux/sles_156_amd64.yml
@@ -88,5 +88,7 @@
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
     recommends:
       - fluent-bit
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
 
   # end SLES 15.6 amd64

--- a/build/goreleaser/linux/sles_156_arm64.yml
+++ b/build/goreleaser/linux/sles_156_arm64.yml
@@ -68,6 +68,8 @@
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    conflicts:
+      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
 #    recommends:
 # FB not supported yet

--- a/build/release.mk
+++ b/build/release.mk
@@ -71,12 +71,10 @@ release/pkg-linux: release/get-fluentbit-linux-arm64
 
 .PHONY : release/pkg-linux-fips
 release/pkg-linux-fips: release/deps release/clean generate-goreleaser-multiarch-fips
-release/pkg-linux-fips: release/get-integrations-amd64 #NO FIPS ASSETS AVAILABLE FOR NOW
-release/pkg-linux-fips: release/get-integrations-arm64 #NO FIPS ASSETS AVAILABLE FOR NOW
-# release/pkg-linux-fips: release/get-integrations-arm #NO FIPS ASSETS AVAILABLE FOR NOW
-release/pkg-linux-fips: release/get-fluentbit-linux-amd64 #NO FIPS ASSETS AVAILABLE FOR NOW
-# #release/pkg-linux: release/get-fluentbit-linux-arm
-release/pkg-linux-fips: release/get-fluentbit-linux-arm64 #NO FIPS ASSETS AVAILABLE FOR NOW
+release/pkg-linux-fips: release/get-integrations-amd64
+release/pkg-linux-fips: release/get-integrations-arm64
+release/pkg-linux-fips: release/get-fluentbit-linux-amd64
+release/pkg-linux-fips: release/get-fluentbit-linux-arm64
 	@echo "=== [release/pkg-linux-fips] PRE-RELEASE compiling all binaries, creating packages, archives"
 	$(GORELEASER_BIN) release --config $(GORELEASER_CONFIG_LINUX) $(PKG_FLAGS)
 
@@ -178,7 +176,7 @@ release-macos: release/pkg-macos release/fix-tarballs-macos
 .PHONY : generate-goreleaser-amd64
 generate-goreleaser-amd64:
 	cat $(CURDIR)/build/goreleaser/linux/header.yml\
-		$(CURDIR)/build/goreleaser/linux/build_amd64.yml\
+		$(CURDIR)/build/goreleaser/linux/build_amd64$(subst -,_,$(FIPS)).yml\
 		$(CURDIR)/build/goreleaser/linux/archives_header.yml\
 		$(CURDIR)/build/goreleaser/linux/archives_amd64.yml\
 		$(CURDIR)/build/goreleaser/linux/nfpms_header.yml\
@@ -232,7 +230,7 @@ generate-goreleaser-amd64:
 .PHONY : generate-goreleaser-arm64
 generate-goreleaser-arm64:
 	cat $(CURDIR)/build/goreleaser/linux/header.yml\
-		$(CURDIR)/build/goreleaser/linux/build_arm64.yml\
+		$(CURDIR)/build/goreleaser/linux/build_arm64$(subst -,_,$(FIPS)).yml\
 		$(CURDIR)/build/goreleaser/linux/archives_header.yml\
 		$(CURDIR)/build/goreleaser/linux/archives_arm64.yml\
 		$(CURDIR)/build/goreleaser/linux/nfpms_header.yml\

--- a/build/release.mk
+++ b/build/release.mk
@@ -110,6 +110,11 @@ release/pkg-linux-for-docker: release/deps release/clean generate-goreleaser-for
 	@echo "=== [release/pkg-linux-for-docker] PRE-RELEASE compiling all binaries"
 	$(GORELEASER_BIN) release --config $(GORELEASER_CONFIG_LINUX) $(PKG_FLAGS)
 
+.PHONY : release/pkg-linux-for-docker-fips
+release/pkg-linux-for-docker-fips: release/deps release/clean generate-goreleaser-for-docker-fips
+	@echo "=== [release/pkg-linux-for-docker-fips] PRE-RELEASE compiling all binaries"
+	$(GORELEASER_BIN) release --config $(GORELEASER_CONFIG_LINUX) $(PKG_FLAGS)
+
 .PHONY : release/pkg-macos
 release/pkg-macos: release/deps release/clean
 #release/pkg-macos: release/get-integrations-amd64-macos NO ASSETS AVAILABLE FOR NOW
@@ -168,6 +173,10 @@ release-linux-arm64: release/pkg-linux-arm64 release/fix-tarballs-linux release/
 .PHONY : release-linux-for-docker
 release-linux-for-docker: release/pkg-linux-for-docker
 	@echo "=== [release-linux-for-docker] compiling assets for docker"
+
+.PHONY : release-linux-for-docker-fips
+release-linux-for-docker-fips: release/pkg-linux-for-docker-fips
+	@echo "=== [release-linux-for-docker-fips] compiling assets for docker - FIPS"
 
 .PHONY : release-macos
 release-macos: release/pkg-macos release/fix-tarballs-macos
@@ -369,6 +378,13 @@ generate-goreleaser-for-docker:
 		$(CURDIR)/build/goreleaser/linux/build_amd64.yml\
 		$(CURDIR)/build/goreleaser/linux/build_arm.yml\
 		$(CURDIR)/build/goreleaser/linux/build_arm64.yml\
+  		 > $(GORELEASER_CONFIG_LINUX)
+
+.PHONY : generate-goreleaser-for-docker-fips
+generate-goreleaser-for-docker-fips:
+	cat $(CURDIR)/build/goreleaser/linux/header.yml\
+		$(CURDIR)/build/goreleaser/linux/build_amd64_fips.yml\
+		$(CURDIR)/build/goreleaser/linux/build_arm64_fips.yml\
   		 > $(GORELEASER_CONFIG_LINUX)
 
 ifndef SNAPSHOT

--- a/test/automated/ansible/group_vars/localhost/main.yml
+++ b/test/automated/ansible/group_vars/localhost/main.yml
@@ -271,12 +271,32 @@ instances:
     platform: "linux"
     python_interpreter: "/usr/bin/python3"
     launch_template: "LaunchTemplateId=lt-0b00afb3f5110a0e6,Version=3"
+  #################################
+  # amazon linux 2023 amd64 FIPS
+  #################################
+  - ami: "ami-085fa628e46dcb929"
+    type: "t3a.small"
+    name: "amd64:al-2023-fips"
+    username: "ec2-user"
+    platform: "linux"
+    python_interpreter: "/usr/bin/python3"
+    launch_template: "LaunchTemplateId=lt-0b00afb3f5110a0e6,Version=3"
   ############################
   # amazon linux 2023 arm64
   ############################
   - ami: "ami-07d16074c2fdf3a19"
     type: "t4g.small"
     name: "arm64:al-2023"
+    username: "ec2-user"
+    platform: "linux"
+    python_interpreter: "/usr/bin/python3"
+    launch_template: "LaunchTemplateId=lt-0b00afb3f5110a0e6,Version=3"
+  #################################
+  # amazon linux 2023 arm64 FIPS
+  #################################
+  - ami: "ami-06014e12b8efb52e2"
+    type: "t4g.small"
+    name: "arm64:al-2023-fips"
     username: "ec2-user"
     platform: "linux"
     python_interpreter: "/usr/bin/python3"

--- a/test/canaries/deploy_canaries.yml
+++ b/test/canaries/deploy_canaries.yml
@@ -19,27 +19,31 @@
       block:
 
         - name: install latest agent on host
-          include_role:
+          ansible.builtin.include_role:
             name: caos.ansible_roles.infra_agent
           vars:
-            target_version: "{{ current_version }}"
             repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
+            fips_enabled: "{{ '-fips' in inventory_hostname }}"
 
         - name: install latest agent in container
-          include_role:
+          ansible.builtin.include_role:
             name: caos.ansible_roles.infra_agent
           vars:
             is_containerized: true
             target_version: "{{ current_version }}-rc"
             display_name: "{{ inventory_hostname }}-current"
+            fips_enabled: "{{ '-fips' in inventory_hostname }}"
 
         - name: install previous agent in container
-          include_role:
+          # Remove the "when" condition after second release https://new-relic.atlassian.net/browse/NR-355851
+          when: "'-fips' not in inventory_hostname"
+          ansible.builtin.include_role:
             name: caos.ansible_roles.infra_agent
           vars:
             is_containerized: true
             target_version: "{{ previous_version }}"
             display_name: "{{ inventory_hostname }}-previous"
+            fips_enabled: "{{ '-fips' in inventory_hostname }}"
 
 # Windows
 - name: installation-agent-no-clean

--- a/test/harvest/ansible/README.md
+++ b/test/harvest/ansible/README.md
@@ -10,7 +10,8 @@ localhost ansible_connection=local
 
 [testing_hosts]
 amd64:debian-buster ansible_host=192.168.1.12 ansible_user=admin ansible_python_interpreter=/usr/bin/python3 
-amd64:centos7 ansible_host=192.168.1.13 ansible_user=centos ansible_python_interpreter=/usr/bin/python 
+amd64:centos7 ansible_host=192.168.1.13 ansible_user=centos ansible_python_interpreter=/usr/bin/python
+amd64:al-2023-fips ansible_host=192.168.1.14 ansible_user=ec2-user ansible_python_interpreter=/usr/bin/python3 ansible_ssh_common_args='-o Ciphers=aes256-ctr,aes192-ctr,aes128-ctr -o KexAlgorithms=ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521 -o MACs=hmac-sha2-256,hmac-sha2-512'
 ```
 
 ## Playbooks

--- a/test/harvest/ansible/roles/build-harvest-tests/tasks/main.yml
+++ b/test/harvest/ansible/roles/build-harvest-tests/tasks/main.yml
@@ -1,21 +1,41 @@
 ---
 
-- name: build harvest tests for every os/arch combination
-  ansible.builtin.shell: "CGO_ENABLED=0 GOOS=linux GOARCH={{item}} make build-harvest-tests && mv {{ default_binary_name }} {{ os_arch_binary_name_tpl | replace('%GOOS%', 'linux') | replace('%GOARCH%', item) }}"
+- name: Build harvest tests for Linux arch combination
+  ansible.builtin.shell: >
+    CGO_ENABLED=0 GOOS=linux GOARCH={{ item }} make build-harvest-tests &&
+    mv {{ default_binary_name }} {{ os_arch_binary_name_tpl | replace('%GOOS%', 'linux') | replace('%GOARCH%', item) }}
   args:
     chdir: "{{ agent_root_dir }}"
+    creates: "{{ os_arch_binary_name_tpl | replace('%GOOS%', 'linux') | replace('%GOARCH%', item) }}"
   loop: "{{ goos_arch.linux }}"
 
-- name: build harvest tests for every os/arch combination
-  ansible.builtin.shell: "GOOS=darwin GOARCH={{item}} make build-harvest-tests && mv {{ default_binary_name }} {{ os_arch_binary_name_tpl | replace('%GOOS%', 'darwin') | replace('%GOARCH%', item) }}"
+- name: Build harvest tests for Linux arch combination - FIPS
+  ansible.builtin.shell: >
+    CGO_ENABLED=1 GOEXPERIMENT=boringcrypto GOOS=linux GOARCH={{ item }}
+    {% if item == 'arm64' %}CC=aarch64-linux-gnu-gcc{% endif %}
+    make build-harvest-tests-fips &&
+    mv {{ default_binary_name }} {{ os_arch_binary_name_tpl_fips | replace('%GOOS%', 'linux') | replace('%GOARCH%', item) }}
   args:
     chdir: "{{ agent_root_dir }}"
+    creates: "{{ os_arch_binary_name_tpl_fips | replace('%GOOS%', 'linux') | replace('%GOARCH%', item) }}"
+  loop: "{{ goos_arch.linux_fips }}"
+
+- name: Build harvest tests for Darwin arch combination
+  ansible.builtin.shell: >
+    GOOS=darwin GOARCH={{ item }} make build-harvest-tests &&
+    mv {{ default_binary_name }} {{ os_arch_binary_name_tpl | replace('%GOOS%', 'darwin') | replace('%GOARCH%', item) }}
+  args:
+    chdir: "{{ agent_root_dir }}"
+    creates: "{{ os_arch_binary_name_tpl | replace('%GOOS%', 'darwin') | replace('%GOARCH%', item) }}"
   loop: "{{ goos_arch.darwin }}"
 
-- name: build harvest tests for every os/arch combination
-  ansible.builtin.shell: "GOOS=windows GOARCH={{item}} make build-harvest-tests && mv {{ default_binary_name }}.exe {{ os_arch_binary_name_tpl | replace('%GOOS%', 'win32nt') | replace('%GOARCH%', item) }}.exe"
+- name: Build harvest tests for Windows arch combination
+  ansible.builtin.shell: >
+    GOOS=windows GOARCH={{ item }} make build-harvest-tests &&
+    mv {{ default_binary_name }}.exe {{ os_arch_binary_name_tpl | replace('%GOOS%', 'win32nt') | replace('%GOARCH%', item) }}.exe
   args:
     chdir: "{{ agent_root_dir }}"
+    creates: "{{ os_arch_binary_name_tpl | replace('%GOOS%', 'win32nt') | replace('%GOARCH%', item) }}.exe"
   loop: "{{ goos_arch.windows }}"
 
 

--- a/test/harvest/ansible/roles/build-harvest-tests/vars/main.yml
+++ b/test/harvest/ansible/roles/build-harvest-tests/vars/main.yml
@@ -3,10 +3,14 @@
 agent_root_dir: ""
 default_binary_name: "harvest.test"
 os_arch_binary_name_tpl: "harvest_%GOOS%_%GOARCH%.test"
+os_arch_binary_name_tpl_fips: "harvest_%GOOS%-fips_%GOARCH%.test"
 goos_arch:
   linux:
     - "amd64"
     - "arm"
+    - "arm64"
+  linux_fips:
+    - "amd64"
     - "arm64"
   darwin:
     - "amd64"

--- a/test/harvest/ansible/roles/run-harvest-tests/tasks/main.yml
+++ b/test/harvest/ansible/roles/run-harvest-tests/tasks/main.yml
@@ -1,15 +1,26 @@
 ---
 
-- name: register os/arch specific binary name
-  set_fact:
-    os_arch_binary_name: "{{ os_arch_binary_name_tpl | replace('%GOOS%',ansible_system|lower) | replace('%GOARCH%',architecture_map[ansible_architecture]) }}"
+- name: Register os/arch specific binary name
+  ansible.builtin.set_fact:
+    os_arch_binary_name: "{{ os_arch_binary_name_tpl
+      | replace('%GOOS%', ansible_system | lower)
+      | replace('%GOARCH%', architecture_map[ansible_architecture]) }}"
+  when: "'-fips' not in inventory_hostname"
 
-- name: copy binary
+- name: Register os/arch specific binary name - FIPS
+  ansible.builtin.set_fact:
+    os_arch_binary_name: "{{ os_arch_binary_name_tpl_fips
+      | replace('%GOOS%', ansible_system | lower)
+      | replace('%GOARCH%', architecture_map[ansible_architecture]) }}"
+  when: "'-fips' in inventory_hostname"
+
+- name: Copy binary
   ansible.builtin.copy:
     src: "{{ agent_root_dir }}/{{ os_arch_binary_name }}"
     dest: "{{ ansible_user_dir }}/{{ os_arch_binary_name }}"
     mode: '0755'
 
-- include_tasks: "execute-tests-{{ ansible_system }}.yaml"
+- name: Include OS-specific test tasks
+  ansible.builtin.include_tasks: "execute-tests-{{ ansible_system }}.yaml"
 
 ...

--- a/test/harvest/ansible/roles/run-harvest-tests/vars/main.yml
+++ b/test/harvest/ansible/roles/run-harvest-tests/vars/main.yml
@@ -6,4 +6,5 @@ architecture_map:
   64-bit: "amd64"
 
 os_arch_binary_name_tpl: "harvest_%GOOS%_%GOARCH%.test{{ '.exe' if ansible_system == 'Win32NT' else '' }}"
+os_arch_binary_name_tpl_fips: "harvest_%GOOS%-fips_%GOARCH%.test{{ '.exe' if ansible_system == 'Win32NT' else '' }}"
 tests_to_run_regex: ".*"

--- a/test/harvest/ansible/test.yml
+++ b/test/harvest/ansible/test.yml
@@ -4,22 +4,24 @@
 # It will build the harvest tests binaries for specified architectures/os combinations
 # and copy and run them in the testing_hosts hosts
 
-- hosts: localhost
+- name: Build harvest tests on localhost
+  hosts: localhost
   become: false
-  gather_facts: no
+  gather_facts: false
 
   tasks:
-    - name: build harvest tests
-      include_role:
+    - name: Build harvest tests
+      ansible.builtin.include_role:
         name: build-harvest-tests
 
 
-- hosts: testing_hosts
-  gather_facts: yes
+- name: Copy and run harvest tests on testing hosts
+  hosts: testing_hosts
+  gather_facts: true
 
   tasks:
-    - name: copy and run harvest tests
-      include_role:
+    - name: Copy and run harvest tests
+      ansible.builtin.include_role:
         name: run-harvest-tests
 
 ...

--- a/test/packaging/ansible/README.md
+++ b/test/packaging/ansible/README.md
@@ -9,7 +9,8 @@ localhost ansible_connection=local
 
 [testing_hosts]
 amd64:debian-buster ansible_host=192.168.1.12 ansible_user=admin ansible_python_interpreter=/usr/bin/python3 
-amd64:centos7 ansible_host=192.168.1.13 ansible_user=centos ansible_python_interpreter=/usr/bin/python 
+amd64:centos7 ansible_host=192.168.1.13 ansible_user=centos ansible_python_interpreter=/usr/bin/python
+amd64:al-2023-fips ansible_host=192.168.1.14 ansible_user=ec2-user ansible_python_interpreter=/usr/bin/python3 ansible_ssh_common_args='-o Ciphers=aes256-ctr,aes192-ctr,aes128-ctr -o KexAlgorithms=ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521 -o MACs=hmac-sha2-256,hmac-sha2-512'
 ```
 
 ## Playbooks

--- a/test/packaging/ansible/agent-upgrade.yml
+++ b/test/packaging/ansible/agent-upgrade.yml
@@ -14,6 +14,8 @@
 
   tasks:
     - name: agent upgrade tests suite
+      # TODO: https://new-relic.atlassian.net/browse/NR-355851 Update when two releases with FIPS are done
+      # Also add FIPS tests
       vars:
         target_agent_version: "1.57.1"
 

--- a/test/packaging/ansible/installation-pinned.yml
+++ b/test/packaging/ansible/installation-pinned.yml
@@ -18,22 +18,12 @@
 
       block:
         - name: Install agent
-          # when: "'-fips' not in inventory_hostname"
           ansible.builtin.include_role:
             name: caos.ansible_roles.infra_agent
           vars:
             target_version: "{{ target_agent_version }}"
             repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
-
-        # TODO: https://new-relic.atlassian.net/browse/NR-355845 Uncomment when FIPS version is available for the minimum version
-        # - name: Install agent - FIPS
-        #   when: "'-fips' in inventory_hostname"
-        #   ansible.builtin.include_role:
-        #     name: caos.ansible_roles.infra_agent
-        #   vars:
-        #     target_version: "{{ target_agent_version }}"
-        #     repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
-        #     fips_enabled: true
+            fips_enabled: "{{ '-fips' in inventory_hostname }}"
 
         - name: Assert version
           ansible.builtin.include_role:

--- a/test/packaging/ansible/installation-pinned.yml
+++ b/test/packaging/ansible/installation-pinned.yml
@@ -1,13 +1,12 @@
 ---
-
-- name: installation-pinned
+- name: Installation-pinned
   hosts: testing_hosts_linux
   become: true
-  gather_facts: yes
+  gather_facts: true
 
   pre_tasks:
     - name: Initial cleanup
-      include_role:
+      ansible.builtin.include_role:
         name: caos.ansible_roles.infra_agent
       vars:
         uninstall: true
@@ -18,16 +17,26 @@
         target_agent_version: "1.57.1" # minimum version for ubuntu sles 15.6
 
       block:
-
-        - name: install agent
-          include_role:
+        - name: Install agent
+          # when: "'-fips' not in inventory_hostname"
+          ansible.builtin.include_role:
             name: caos.ansible_roles.infra_agent
           vars:
             target_version: "{{ target_agent_version }}"
             repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
 
+        # TODO: https://new-relic.atlassian.net/browse/NR-355845 Uncomment when FIPS version is available for the minimum version
+        # - name: Install agent - FIPS
+        #   when: "'-fips' in inventory_hostname"
+        #   ansible.builtin.include_role:
+        #     name: caos.ansible_roles.infra_agent
+        #   vars:
+        #     target_version: "{{ target_agent_version }}"
+        #     repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
+        #     fips_enabled: true
+
         - name: Assert version
-          include_role:
+          ansible.builtin.include_role:
             name: caos.ansible_roles.assert_version
           vars:
             target_versions:

--- a/test/packaging/ansible/installation-privileged.yml
+++ b/test/packaging/ansible/installation-privileged.yml
@@ -21,19 +21,11 @@
 
       block:
         - name: Install agent
-          when: "'-fips' not in inventory_hostname"
           ansible.builtin.include_role:
             name: caos.ansible_roles.infra_agent
           vars:
             repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
-
-        - name: Install agent - FIPS
-          when: "'-fips' in inventory_hostname"
-          ansible.builtin.include_role:
-            name: caos.ansible_roles.infra_agent
-          vars:
-            repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
-            fips_enabled: true
+            fips_enabled: "{{ '-fips' in inventory_hostname }}"
 
         - name: Assert privileged caps
           ansible.builtin.include_role:

--- a/test/packaging/ansible/installation-privileged.yml
+++ b/test/packaging/ansible/installation-privileged.yml
@@ -1,13 +1,12 @@
 ---
-
-- name: installation-privileged
+- name: Installation-privileged
   hosts: testing_hosts_linux
   become: true
-  gather_facts: yes
+  gather_facts: true
 
   pre_tasks:
     - name: Initial cleanup
-      include_role:
+      ansible.builtin.include_role:
         name: caos.ansible_roles.infra_agent
       vars:
         uninstall: true
@@ -21,30 +20,38 @@
           NRIA_MODE: PRIVILEGED
 
       block:
+        - name: Install agent
+          when: "'-fips' not in inventory_hostname"
+          ansible.builtin.include_role:
+            name: caos.ansible_roles.infra_agent
+          vars:
+            repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
 
-      - name: install agent
-        include_role:
-          name: caos.ansible_roles.infra_agent
-        vars:
-          repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
+        - name: Install agent - FIPS
+          when: "'-fips' in inventory_hostname"
+          ansible.builtin.include_role:
+            name: caos.ansible_roles.infra_agent
+          vars:
+            repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
+            fips_enabled: true
 
-      - name: assert privileged caps
-        include_role:
-          name: caos.ansible_roles.assert_privileged_caps
-        vars:
-          executable: "/usr/bin/newrelic-infra"
-          caps:
-            - cap_dac_read_search
-            - cap_sys_ptrace.ep
+        - name: Assert privileged caps
+          ansible.builtin.include_role:
+            name: caos.ansible_roles.assert_privileged_caps
+          vars:
+            executable: "/usr/bin/newrelic-infra"
+            caps:
+              - cap_dac_read_search
+              - cap_sys_ptrace.ep
 
-      - name: Assert rootless
-        include_role:
-          name: caos.ansible_roles.assert_files
-        vars:
-          processes:
-            - name: newrelic-infra-service
-              owner: "{{ agent_user }}"
-          files:
-            - name: /usr/bin/newrelic-infra
-              permissions: "{{ bin_mode }}"
+        - name: Assert rootless
+          ansible.builtin.include_role:
+            name: caos.ansible_roles.assert_files
+          vars:
+            processes:
+              - name: newrelic-infra-service
+                owner: "{{ agent_user }}"
+            files:
+              - name: /usr/bin/newrelic-infra
+                permissions: "{{ bin_mode }}"
 ...

--- a/test/packaging/ansible/installation-root.yml
+++ b/test/packaging/ansible/installation-root.yml
@@ -1,13 +1,13 @@
 ---
 
-- name: installation-root
+- name: Installation-root
   hosts: testing_hosts_linux
   become: true
-  gather_facts: yes
+  gather_facts: true
 
   pre_tasks:
     - name: Initial cleanup
-      include_role:
+      ansible.builtin.include_role:
         name: caos.ansible_roles.infra_agent
       vars:
         uninstall: true
@@ -20,14 +20,23 @@
 
       block:
 
-        - name: install agent
-          include_role:
+        - name: Install agent
+          when: "'-fips' not in inventory_hostname"
+          ansible.builtin.include_role:
             name: caos.ansible_roles.infra_agent
           vars:
             repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
 
+        - name: Install agent - FIPS
+          when: "'-fips' in inventory_hostname"
+          ansible.builtin.include_role:
+            name: caos.ansible_roles.infra_agent
+          vars:
+            repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
+            fips_enabled: true
+
         - name: Assert root
-          include_role:
+          ansible.builtin.include_role:
             name: caos.ansible_roles.assert_files
           vars:
             processes:

--- a/test/packaging/ansible/installation-root.yml
+++ b/test/packaging/ansible/installation-root.yml
@@ -21,19 +21,11 @@
       block:
 
         - name: Install agent
-          when: "'-fips' not in inventory_hostname"
           ansible.builtin.include_role:
             name: caos.ansible_roles.infra_agent
           vars:
             repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
-
-        - name: Install agent - FIPS
-          when: "'-fips' in inventory_hostname"
-          ansible.builtin.include_role:
-            name: caos.ansible_roles.infra_agent
-          vars:
-            repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
-            fips_enabled: true
+            fips_enabled: "{{ '-fips' in inventory_hostname }}"
 
         - name: Assert root
           ansible.builtin.include_role:

--- a/test/packaging/ansible/installation-unprivileged.yml
+++ b/test/packaging/ansible/installation-unprivileged.yml
@@ -1,13 +1,12 @@
 ---
-
-- name: installation-unprivileged
+- name: Installation-unprivileged
   hosts: testing_hosts_linux
   become: true
-  gather_facts: yes
+  gather_facts: true
 
   pre_tasks:
     - name: Initial cleanup
-      include_role:
+      ansible.builtin.include_role:
         name: caos.ansible_roles.infra_agent
       vars:
         uninstall: true
@@ -21,28 +20,36 @@
           NRIA_MODE: UNPRIVILEGED
 
       block:
+        - name: Install agent
+          when: "'-fips' not in inventory_hostname"
+          ansible.builtin.include_role:
+            name: caos.ansible_roles.infra_agent
+          vars:
+            repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
 
-      - name: install agent
-        include_role:
-          name: caos.ansible_roles.infra_agent
-        vars:
-          repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
+        - name: Install agent - FIPS
+          when: "'-fips' in inventory_hostname"
+          ansible.builtin.include_role:
+            name: caos.ansible_roles.infra_agent
+          vars:
+            repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
+            fips_enabled: true
 
-      - name: assert no privileged caps
-        include_role:
-          name: caos.ansible_roles.assert_privileged_caps
-        vars:
-          executable: "/usr/bin/newrelic-infra"
-          caps: []
+        - name: Assert no privileged caps
+          ansible.builtin.include_role:
+            name: caos.ansible_roles.assert_privileged_caps
+          vars:
+            executable: "/usr/bin/newrelic-infra"
+            caps: []
 
-      - name: Assert rootless
-        include_role:
-          name: caos.ansible_roles.assert_files
-        vars:
-          processes:
-            - name: newrelic-infra-service
-              owner: "{{ agent_user }}"
-          files:
-            - name: /usr/bin/newrelic-infra
-              permissions: "{{ bin_mode }}"
+        - name: Assert rootless
+          ansible.builtin.include_role:
+            name: caos.ansible_roles.assert_files
+          vars:
+            processes:
+              - name: newrelic-infra-service
+                owner: "{{ agent_user }}"
+            files:
+              - name: /usr/bin/newrelic-infra
+                permissions: "{{ bin_mode }}"
 ...

--- a/test/packaging/ansible/installation-unprivileged.yml
+++ b/test/packaging/ansible/installation-unprivileged.yml
@@ -26,14 +26,7 @@
             name: caos.ansible_roles.infra_agent
           vars:
             repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
-
-        - name: Install agent - FIPS
-          when: "'-fips' in inventory_hostname"
-          ansible.builtin.include_role:
-            name: caos.ansible_roles.infra_agent
-          vars:
-            repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
-            fips_enabled: true
+            fips_enabled: "{{ '-fips' in inventory_hostname }}"
 
         - name: Assert no privileged caps
           ansible.builtin.include_role:

--- a/test/packaging/ansible/shutdown-and-terminate.yml
+++ b/test/packaging/ansible/shutdown-and-terminate.yml
@@ -16,21 +16,12 @@
 
   tasks:
     - name: Install agent
-      when: "'-fips' not in inventory_hostname"
       ansible.builtin.include_role:
         name: caos.ansible_roles.infra_agent
       vars:
         display_name: "{{ iid }}:{{ inventory_hostname }}"
         repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
-
-    - name: Install agent - FIPS
-      when: "'-fips' in inventory_hostname"
-      ansible.builtin.include_role:
-        name: caos.ansible_roles.infra_agent
-      vars:
-        display_name: "{{ iid }}:{{ inventory_hostname }}"
-        repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
-        fips_enabled: true
+        fips_enabled: "{{ '-fips' in inventory_hostname }}"
 
 - name: Install agent windows  (HNR)
   hosts: testing_hosts_windows

--- a/test/packaging/ansible/shutdown-and-terminate.yml
+++ b/test/packaging/ansible/shutdown-and-terminate.yml
@@ -1,47 +1,57 @@
 ---
 
-- name: install agent linux (HNR)
+- name: Install agent linux (HNR)
   hosts: testing_hosts_linux
-  gather_facts: yes
+  gather_facts: true
   become: true
   vars:
     agent_user: root
 
   pre_tasks:
     - name: Initial cleanup
-      include_role:
+      ansible.builtin.include_role:
         name: caos.ansible_roles.infra_agent
       vars:
         uninstall: true
 
   tasks:
-    - name: install agent
-      include_role:
+    - name: Install agent
+      when: "'-fips' not in inventory_hostname"
+      ansible.builtin.include_role:
         name: caos.ansible_roles.infra_agent
       vars:
         display_name: "{{ iid }}:{{ inventory_hostname }}"
         repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
 
-- name: install agent windows  (HNR)
+    - name: Install agent - FIPS
+      when: "'-fips' in inventory_hostname"
+      ansible.builtin.include_role:
+        name: caos.ansible_roles.infra_agent
+      vars:
+        display_name: "{{ iid }}:{{ inventory_hostname }}"
+        repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
+        fips_enabled: true
+
+- name: Install agent windows  (HNR)
   hosts: testing_hosts_windows
-  gather_facts: yes
+  gather_facts: true
 
   pre_tasks:
     - name: Initial cleanup
-      include_role:
+      ansible.builtin.include_role:
         name: caos.ansible_roles.infra_agent
       vars:
         uninstall: true
 
   tasks:
-    - name: install agent
-      include_role:
+    - name: Install agent
+      ansible.builtin.include_role:
         name: caos.ansible_roles.infra_agent
       vars:
         display_name: "{{ iid }}:{{ inventory_hostname }}"
 
 
-- name: test agent behaviour on host shutdown
+- name: Test agent behaviour on host shutdown
   hosts: testing_hosts
   vars:
     # Add here hosts of the instances that doesn't support Smart HNR (shutdown detection) e.g. - "amd64:ubuntu14.04"
@@ -56,80 +66,80 @@
       }}
 
   tasks:
-    - name: pause a bit to let the agent send some data
-      pause:
+    - name: Pause a bit to let the agent send some data
+      ansible.builtin.pause:
         minutes: 1
 
-    - name: restart the agent
-      include_role:
+    - name: Restart the agent
+      ansible.builtin.include_role:
         name: caos.ansible_roles.service_status
       vars:
         service_name: "newrelic-infra"
         action: "restart"
 
-    - name: pause for a bit to let the agent initialize
-      pause:
+    - name: Pause for a bit to let the agent initialize
+      ansible.builtin.pause:
         seconds: 30
 
     - name: Get entity id
-      include_role:
+      ansible.builtin.include_role:
         name: caos.ansible_roles.infra_agent_get_entity_id
 
-    - name: assert agent restart don't trigger shutdown event
-      include_role:
+    - name: Assert agent restart don't trigger shutdown event
+      ansible.builtin.include_role:
         name: caos.ansible_roles.assert_host_status_event
       vars:
         host_status: "shutdown"
         expect_change_event: false
         since_sec_ago: 30
 
-    - name: stop instances
-      include_role:
+    - name: Stop instances
+      ansible.builtin.include_role:
         name: caos.ansible_roles.ec2_instance
       vars:
         action: stop
         instance_id: "{{ iid }}"
 
-    - name: pause for a bit to let the event fire
-      pause:
+    - name: Pause for a bit to let the event fire
+      ansible.builtin.pause:
         seconds: 30
 
-    - name: assert that the agent detecteded host shutdown and disconnected from the backend (only on hosts that support shutdown detection)
-      include_role:
+    - name: Assert that the agent detecteded host shutdown and disconnected from the backend (only on hosts that support shutdown detection)
+      ansible.builtin.include_role:
         name: caos.ansible_roles.assert_host_status_event
       vars:
         host_status: "shutdown"
         expect_change_event: "{{ host_supports_shutdown_detection }}"
         timestamp_ref: "{{ ec2_stop_time_sec | int }}"
 
-    - name: start instances
-      include_role:
+    - name: Start instances
+      ansible.builtin.include_role:
         name: caos.ansible_roles.ec2_instance
       vars:
         action: start
         instance_id: "{{ iid }}"
 
-    - name: assert the agent performed connect to the backend (only on hosts that support shutdown detection)
-      include_role:
+    - name: Assert the agent performed connect to the backend (only on hosts that support shutdown detection)
+      ansible.builtin.include_role:
         name: caos.ansible_roles.assert_host_status_event
       vars:
         host_status: "running"
         expect_change_event: "{{ host_supports_shutdown_detection }}"
         timestamp_ref: "{{ ec2_start_time_sec | int }}"
 
-    - name: terminate instances
-      include_role:
+    - name: Terminate instances
+      ansible.builtin.include_role:
         name: caos.ansible_roles.ec2_instance
       vars:
         action: terminate
         instance_id: "{{ iid }}"
 
-    - name: pause for a bit to let the event fire
-      pause:
+    - name: Pause for a bit to let the event fire
+      ansible.builtin.pause:
         seconds: 30
 
-    - name: assert that the agent detecteded host termination and disconnected from the backend (only on hosts that support shutdown detection)
-      include_role:
+    - name: Assert that the agent detecteded host termination and disconnected from the backend (only on hosts that support shutdown detection)
+      ansible.builtin.include_role:
         name: caos.ansible_roles.assert_host_status_event
       vars:
         host_status: "shutdown"

--- a/test/packaging/ansible/test.yml
+++ b/test/packaging/ansible/test.yml
@@ -1,30 +1,35 @@
 ---
 
-- name: pinned version agent installation
+- name: Pinned version agent installation
   import_playbook: installation-pinned.yml
+  when: "'-fips' not in inventory_hostname" # TODO: https://new-relic.atlassian.net/browse/NR-355841
 
-- name: agent installation as root
+- name: Agent installation as root
   import_playbook: installation-root.yml
 
-- name: privileged mode agent installation
+- name: Privileged mode agent installation
   import_playbook: installation-privileged.yml
 
-- name: unprivileged mode agent installation
+- name: Unprivileged mode agent installation
   import_playbook: installation-unprivileged.yml
 
-- name: agent installation via newrelic-cli
+- name: Agent installation via newrelic-cli
   import_playbook: installation-newrelic-cli.yml
+  when: "'-fips' not in inventory_hostname" # FIPS not supported via newrelic-cli in initial release
 
-- name: installation windows
+- name: Installation windows
   import_playbook: installation-windows.yml
 
-- name: log forwarder
+- name: Log forwarder
   import_playbook: log-forwarder.yml
+  when: "'-fips' not in inventory_hostname" # We only have AL-2023 images for FIPS for now
 
-- name: agent upgrade
+- name: Agent upgrade
   import_playbook: agent-upgrade.yml
+  when: "'-fips' not in inventory_hostname" # TODO: https://new-relic.atlassian.net/browse/NR-355851
 
-- name: shutdown , terminate and HNR alerts
+- name: Shutdown , terminate and HNR alerts
   import_playbook: shutdown-and-terminate.yml
+  when: "'al-2023' not in inventory_hostname" # TODO: https://new-relic.atlassian.net/browse/NR-282854 AL-2023 fails this test 80% of the time
 
 ...

--- a/test/packaging/ansible/test.yml
+++ b/test/packaging/ansible/test.yml
@@ -2,7 +2,7 @@
 
 - name: Pinned version agent installation
   import_playbook: installation-pinned.yml
-  when: "'-fips' not in inventory_hostname" # TODO: https://new-relic.atlassian.net/browse/NR-355841
+  when: "'-fips' not in inventory_hostname" # TODO: https://new-relic.atlassian.net/browse/NR-355845
 
 - name: Agent installation as root
   import_playbook: installation-root.yml

--- a/test/provision/terraform/caos.auto.tfvars.dist
+++ b/test/provision/terraform/caos.auto.tfvars.dist
@@ -2,9 +2,9 @@ ec2_prefix = "PREFIX:TAG_OR_UNIQUE_NAME"
 
 windows_ec2 = ["windows_2016", "windows_2019", "windows_2022"]
 
-linux_ec2_amd = ["amd64:ubuntu24.04", "amd64:ubuntu22.04", "amd64:ubuntu20.04", "amd64:ubuntu18.04", "amd64:ubuntu16.04", "amd64:centos-stream", "amd64:sles-12.5", "amd64:sles-15.3",  "amd64:sles-15.4", "amd64:sles-15.5", "amd64:sles-15.6", "amd64:redhat-8.4", "amd64:redhat-9.0", "amd64:debian-bookworm", "amd64:al-2", "amd64:al-2023"]
+linux_ec2_amd = ["amd64:ubuntu24.04", "amd64:ubuntu22.04", "amd64:ubuntu20.04", "amd64:ubuntu18.04", "amd64:ubuntu16.04", "amd64:centos-stream", "amd64:sles-12.5", "amd64:sles-15.3",  "amd64:sles-15.4", "amd64:sles-15.5", "amd64:sles-15.6", "amd64:redhat-8.4", "amd64:redhat-9.0", "amd64:debian-bookworm", "amd64:al-2", "amd64:al-2023", "amd64:al-2023-fips"]
 
-linux_ec2_arm = ["arm64:ubuntu24.04", "arm64:ubuntu22.04", "arm64:ubuntu20.04", "arm64:ubuntu18.04", "arm64:ubuntu16.04", "arm64:centos-stream", "arm64:sles-15.3",  "arm64:sles-15.4", "arm64:sles-15.5", "arm64:sles-15.6", "arm64:redhat-9.0", "arm64:debian-bookworm", "arm64:al-2", "arm64:al-2023"]
+linux_ec2_arm = ["arm64:ubuntu24.04", "arm64:ubuntu22.04", "arm64:ubuntu20.04", "arm64:ubuntu18.04", "arm64:ubuntu16.04", "arm64:centos-stream", "arm64:sles-15.3",  "arm64:sles-15.4", "arm64:sles-15.5", "arm64:sles-15.6", "arm64:redhat-9.0", "arm64:debian-bookworm", "arm64:al-2", "arm64:al-2023", "arm64:al-2023-fips"]
 
 ssh_pub_key      = "AAAAB3NzaC1yc2EAAAADAQABAAABAQDH9C7BS2XrtXGXFFyL0pNku/Hfy84RliqvYKpuslJFeUivf5QY6Ipi8yXfXn6TsRDbdxfGPi6oOR60Fa+4cJmCo6N5g57hBS6f2IdzQBNrZr7i1I/a3cFeK6XOc1G1tQaurx7Pu+qvACfJjLXKG66tHlaVhAHd/1l2FocgFNUDFFuKS3mnzt9hKys7sB4aO3O0OdohN/0NJC4ldV8/OmeXqqfkiPWcgPx3C8bYyXCX7QJNBHKrzbX1jW51Px7SIDWFDV6kxGwpQGGBMJg/k79gjjM+jhn4fg1/VP/Fx37mAnfLqpcTfiOkzSE80ORGefQ1XfGK/Dpa3ITrzRYW8xlR caos-dev-arm"
 pvt_key          = "~/.ssh/caos-dev-arm.cer"

--- a/test/provision/terraform/inventory.tmpl
+++ b/test/provision/terraform/inventory.tmpl
@@ -15,12 +15,12 @@ windows_amd64
 
 [linux_amd64]
 %{ for index, vms in agent-ids ~}
-%{ if platform[index] == "linux" && strcontains(vms, "amd64") }${vms} ansible_user=${agent-user[index]} ansible_host=${agent-private-ip[index]} ansible_python_interpreter=${agent-python[index]} iid=${instance-id[index]}%{ endif }
+%{ if platform[index] == "linux" && strcontains(vms, "amd64") }${vms} ansible_user=${agent-user[index]} ansible_host=${agent-private-ip[index]} ansible_python_interpreter=${agent-python[index]} iid=${instance-id[index]} ansible_ssh_common_args='-o StrictHostKeyChecking=no%{ if strcontains(vms, "fips") } -o Ciphers=aes256-ctr,aes192-ctr,aes128-ctr -o KexAlgorithms=ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521 -o MACs=hmac-sha2-256,hmac-sha2-512%{ endif }'%{ endif }
 %{ endfor ~}
 
 [linux_arm64]
 %{ for index, vms in agent-ids ~}
-%{ if platform[index] == "linux" && strcontains(vms, "arm64") }${vms} ansible_user=${agent-user[index]} ansible_host=${agent-private-ip[index]} ansible_python_interpreter=${agent-python[index]} iid=${instance-id[index]}%{ endif }
+%{ if platform[index] == "linux" && strcontains(vms, "arm64") }${vms} ansible_user=${agent-user[index]} ansible_host=${agent-private-ip[index]} ansible_python_interpreter=${agent-python[index]} iid=${instance-id[index]} ansible_ssh_common_args='-o StrictHostKeyChecking=no%{ if strcontains(vms, "fips") } -o Ciphers=aes256-ctr,aes192-ctr,aes128-ctr -o KexAlgorithms=ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521 -o MACs=hmac-sha2-256,hmac-sha2-512%{ endif }'%{ endif }
 %{ endfor ~}
 
 [windows_amd64]
@@ -30,7 +30,6 @@ windows_amd64
 
 [testing_hosts_linux:vars]
 ansible_ssh_private_key_file=~/.ssh/caos-dev-arm.cer
-ansible_ssh_common_args='-o StrictHostKeyChecking=no'
 
 [windows_amd64:vars]
 ansible_winrm_transport=basic


### PR DESCRIPTION
- Add fips integrations when building fips infra-agent
- Linux prerelease fips
- Create new docker FIPS images
- Update tests to run for fips packages
- Add conflicts to the newrelic-infra packages to not allow having both fips and non fips installed at the same time
- Add fips canaries