### PR TITLE
Compute the conflict name with a placeholder

### DIFF
--- a/build/goreleaser/linux/al2023_amd64.yml
+++ b/build/goreleaser/linux/al2023_amd64.yml
@@ -88,7 +88,8 @@
     # Required packages. rpm version 4.11.3 does not support weak dependencies
     recommends:
       - fluent-bit
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
-  
+      - newrelic-infra#conflicts-suffix-placeholder#
+
   # end AL2023 adm64

--- a/build/goreleaser/linux/al2023_arm64.yml
+++ b/build/goreleaser/linux/al2023_arm64.yml
@@ -81,7 +81,8 @@
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
     recommends:
       - fluent-bit
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
   
   # end AL2023 arm64

--- a/build/goreleaser/linux/al2_amd64.yml
+++ b/build/goreleaser/linux/al2_amd64.yml
@@ -89,7 +89,8 @@
     dependencies:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
   
   # end AL2 adm64

--- a/build/goreleaser/linux/al2_arm64.yml
+++ b/build/goreleaser/linux/al2_arm64.yml
@@ -82,7 +82,8 @@
     dependencies:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
   
   # end AL2 arm64

--- a/build/goreleaser/linux/centos_7_amd64.yml
+++ b/build/goreleaser/linux/centos_7_amd64.yml
@@ -88,7 +88,8 @@
     dependencies:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
   
   # end CentOS 7 amd64

--- a/build/goreleaser/linux/centos_7_arm64.yml
+++ b/build/goreleaser/linux/centos_7_arm64.yml
@@ -83,7 +83,8 @@
     dependencies:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
   
   # end CentOS 7 arm64

--- a/build/goreleaser/linux/centos_8_amd64.yml
+++ b/build/goreleaser/linux/centos_8_amd64.yml
@@ -89,7 +89,8 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
   
   # end CentOS 8 amd64

--- a/build/goreleaser/linux/centos_8_arm64.yml
+++ b/build/goreleaser/linux/centos_8_arm64.yml
@@ -82,7 +82,8 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
   
   # end CentOS 8 arm64

--- a/build/goreleaser/linux/debian_systemd_amd64.yml
+++ b/build/goreleaser/linux/debian_systemd_amd64.yml
@@ -73,7 +73,8 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
   
   # end Debian systemd amd64

--- a/build/goreleaser/linux/debian_systemd_arm64.yml
+++ b/build/goreleaser/linux/debian_systemd_arm64.yml
@@ -73,7 +73,8 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
   
   # end Debian systemd arm64

--- a/build/goreleaser/linux/debian_upstart_amd64.yml
+++ b/build/goreleaser/linux/debian_upstart_amd64.yml
@@ -69,7 +69,8 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
   
   # end Debian upstart amd64

--- a/build/goreleaser/linux/rhel_9_amd64.yml
+++ b/build/goreleaser/linux/rhel_9_amd64.yml
@@ -88,7 +88,8 @@
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
     recommends:
       - fluent-bit
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
   
   # end RHEL 9 amd64

--- a/build/goreleaser/linux/rhel_9_arm64.yml
+++ b/build/goreleaser/linux/rhel_9_arm64.yml
@@ -81,7 +81,8 @@
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
     recommends:
       - fluent-bit
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
   
   # end RHEL 9 arm64

--- a/build/goreleaser/linux/sles_125_amd64.yml
+++ b/build/goreleaser/linux/sles_125_amd64.yml
@@ -91,7 +91,8 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
   
   # end SLES 12.5 amd64

--- a/build/goreleaser/linux/sles_125_arm64.yml
+++ b/build/goreleaser/linux/sles_125_arm64.yml
@@ -79,8 +79,9 @@
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
 #    recommends:
   # FB not supported yet

--- a/build/goreleaser/linux/sles_152_amd64.yml
+++ b/build/goreleaser/linux/sles_152_amd64.yml
@@ -89,7 +89,7 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
-
+      - newrelic-infra#conflicts-suffix-placeholder#
   # end SLES 15.2 amd64

--- a/build/goreleaser/linux/sles_152_arm64.yml
+++ b/build/goreleaser/linux/sles_152_arm64.yml
@@ -79,8 +79,9 @@
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
 #    recommends:
   # FB not supported yet

--- a/build/goreleaser/linux/sles_153_amd64.yml
+++ b/build/goreleaser/linux/sles_153_amd64.yml
@@ -89,7 +89,8 @@
     recommends:
       - td-agent-bit #To be removed on removal of the ff fluent_bit_19
       - fluent-bit
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
 
   # end SLES 15.3 amd64

--- a/build/goreleaser/linux/sles_153_arm64.yml
+++ b/build/goreleaser/linux/sles_153_arm64.yml
@@ -79,8 +79,9 @@
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
 #    recommends:
   # FB not supported yet

--- a/build/goreleaser/linux/sles_154_amd64.yml
+++ b/build/goreleaser/linux/sles_154_amd64.yml
@@ -88,7 +88,8 @@
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
     recommends:
       - fluent-bit
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
 
   # end SLES 15.4 amd64

--- a/build/goreleaser/linux/sles_154_arm64.yml
+++ b/build/goreleaser/linux/sles_154_arm64.yml
@@ -79,8 +79,9 @@
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
 #    recommends:
 # FB not supported yet

--- a/build/goreleaser/linux/sles_155_amd64.yml
+++ b/build/goreleaser/linux/sles_155_amd64.yml
@@ -88,7 +88,8 @@
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
     recommends:
       - fluent-bit
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
 
   # end SLES 15.5 amd64

--- a/build/goreleaser/linux/sles_155_arm64.yml
+++ b/build/goreleaser/linux/sles_155_arm64.yml
@@ -79,8 +79,9 @@
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
 #    recommends:
 # FB not supported yet

--- a/build/goreleaser/linux/sles_156_amd64.yml
+++ b/build/goreleaser/linux/sles_156_amd64.yml
@@ -88,7 +88,8 @@
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
     recommends:
       - fluent-bit
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
 
   # end SLES 15.6 amd64

--- a/build/goreleaser/linux/sles_156_arm64.yml
+++ b/build/goreleaser/linux/sles_156_arm64.yml
@@ -68,8 +68,9 @@
         posttrans: "build/package/rpm/postinst-systemd.sh"
       summary: "New Relic Infrastructure Agent"
       group: default
+    # conflicts is not "templatable", so we add the conflicts-suffix-placeholder to be replaced later
     conflicts:
-      - newrelic-infra{{ if eq .Env.FIPS "" -}}-fips{{ end }}
+      - newrelic-infra#conflicts-suffix-placeholder#
     # Recommended packages. If they fail to install installation of the agent will not be interrupted.
 #    recommends:
 # FB not supported yet

--- a/build/release.mk
+++ b/build/release.mk
@@ -208,7 +208,8 @@ generate-goreleaser-amd64:
   		$(CURDIR)/build/goreleaser/linux/sles_153_amd64.yml\
   		$(CURDIR)/build/goreleaser/linux/sles_154_amd64.yml\
   		$(CURDIR)/build/goreleaser/linux/sles_155_amd64.yml\
-  		$(CURDIR)/build/goreleaser/linux/sles_156_amd64.yml\
+  		$(CURDIR)/build/goreleaser/linux/sles_156_amd64.yml | \
+  	  sed "s/#conflicts-suffix-placeholder#/$(shell [ -n '$(FIPS)' ] && echo '' || echo '-fips')/g" \
   		 > $(GORELEASER_CONFIG_LINUX)
 
 .PHONY : generate-goreleaser-arm
@@ -258,7 +259,8 @@ generate-goreleaser-arm64:
   		$(CURDIR)/build/goreleaser/linux/sles_153_arm64.yml\
   		$(CURDIR)/build/goreleaser/linux/sles_154_arm64.yml\
   		$(CURDIR)/build/goreleaser/linux/sles_155_arm64.yml\
-  		$(CURDIR)/build/goreleaser/linux/sles_156_arm64.yml\
+  		$(CURDIR)/build/goreleaser/linux/sles_156_arm64.yml | \
+  	 sed "s/#conflicts-suffix-placeholder#/$(shell [ -n '$(FIPS)' ] && echo '' || echo '-fips')/g" \
   		 > $(GORELEASER_CONFIG_LINUX)
 
 .PHONY : generate-goreleaser-legacy
@@ -333,7 +335,8 @@ generate-goreleaser-multiarch:
   		$(CURDIR)/build/goreleaser/linux/sles_155_arm64.yml\
   		$(CURDIR)/build/goreleaser/linux/sles_156_amd64.yml\
   		$(CURDIR)/build/goreleaser/linux/sles_156_arm.yml\
-  		$(CURDIR)/build/goreleaser/linux/sles_156_arm64.yml\
+  		$(CURDIR)/build/goreleaser/linux/sles_156_arm64.yml |\
+  	  sed "s/#conflicts-suffix-placeholder#/-fips/g" \
   		 > $(GORELEASER_CONFIG_LINUX)
 
 .PHONY : generate-goreleaser-multiarch-fips
@@ -369,7 +372,8 @@ generate-goreleaser-multiarch-fips:
   		$(CURDIR)/build/goreleaser/linux/sles_155_amd64.yml\
   		$(CURDIR)/build/goreleaser/linux/sles_155_arm64.yml\
 		$(CURDIR)/build/goreleaser/linux/sles_156_amd64.yml\
-  		$(CURDIR)/build/goreleaser/linux/sles_156_arm64.yml\
+  		$(CURDIR)/build/goreleaser/linux/sles_156_arm64.yml |\
+  	  sed "s/#conflicts-suffix-placeholder#//g" \
   		 > $(GORELEASER_CONFIG_LINUX)
 
 .PHONY : generate-goreleaser-for-docker


### PR DESCRIPTION
Compute the conflict name with a placeholder replaced before rendering, since the conflicts field in goreleaser is not templatable.