### PR TITLE
fix(logging): don't pollute logs with event when truncating event

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1183,9 +1183,15 @@ func (c *context) SendEvent(event sample.Event, entityKey entity.Key) {
 			aclog.
 				WithField("entity_key", entityKey.String()).
 				WithField("length", len(origValue)).
+				Warn("event truncated to NRDB limit")
+			// Log the actual event as a debug, to not pollute the non-verbose logs
+			// with potentially large messages.
+			aclog.
+				WithField("entity_key", entityKey.String()).
+				WithField("length", len(origValue)).
 				WithField("original", origValue).
 				WithField("truncated", fmt.Sprintf("+%v", event)).
-				Warn("event truncated to NRDB limit")
+				Debug("event truncated to NRDB limit debug")
 		}
 	}
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo"
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/cloud"
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/hostname"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1113,7 +1114,7 @@ func TestContext_SendEvent_LogTruncatedEvent(t *testing.T) {
 	// Capture the logs
 	var output bytes.Buffer
 	log.SetOutput(&output)
-	log.EnableSmartVerboseMode(1000)
+	log.SetLevel(logrus.DebugLevel)
 
 	cfg := config.Config{TruncTextValues: true}
 	c := NewContext(


### PR DESCRIPTION
Closes #866 