### PR TITLE
ci: limit S3 recovery to 7 days in the past

### DIFF
--- a/.github/workflows/recover_s3_repository.yml
+++ b/.github/workflows/recover_s3_repository.yml
@@ -23,7 +23,7 @@ on:
       path:
         description: 'Path under infrastructure_agent folder to recover (w/o leading nor trailing slash)'
         type: string
-        required: true
+        required: false
       environment:
         type: choice
         required: true
@@ -65,6 +65,14 @@ jobs:
             exit 1
           fi
           echo "datetime is not in the future"
+          
+          echo "Validating that datetime is max 7 days in the past"
+          python3 -c "from datetime import datetime, timezone, timedelta; import sys; sys.exit(0) if datetime.strptime('$datetime', '%m-%d-%Y %H:%M:%S %z') >= datetime.now(timezone.utc) - timedelta(days=7) else sys.exit(1)"
+          exit_code=$?          
+          if [ $exit_code -ne 0 ]; then
+            exit 1
+          fi
+          echo "datetime cannot be more than 7 days in the past"
           
           echo "DATE_TIME=$datetime" >> $GITHUB_ENV
 


### PR DESCRIPTION
Limit the S3 Recovery action to max 7 days in the past