### PR TITLE
chore(logging): move container errors to info

### DIFF
--- a/pkg/metrics/containerd_sampler.go
+++ b/pkg/metrics/containerd_sampler.go
@@ -21,7 +21,7 @@ var (
 	cslog = log.WithComponent("ContainerdSampler") //nolint:gochecknoglobals
 
 	errContainerdSampler      = errors.New("containerd sampler")
-	errInitializeContainerd   = errors.New("unable to initialize containerd client, could be not installed on the host")
+	errInitializeContainerd   = errors.New("unable to initialize containerd client, maybe it is not installed on the host")
 	errCannotGetPids          = errors.New("unable to get pids for container")
 	errCannotGetTask          = errors.New("unable to get task for container")
 	errCannotGetContainerInfo = errors.New("unable to get container info")
@@ -71,7 +71,7 @@ func (d *ContainerdSampler) Enabled() bool {
 
 	d.containerdClient, err = initializeContainerdClient()
 	if err != nil {
-		cslog.WithError(err).Warn(errInitializeContainerd.Error())
+		cslog.WithError(err).Info(errInitializeContainerd.Error())
 
 		return false
 	}

--- a/pkg/metrics/docker_sampler.go
+++ b/pkg/metrics/docker_sampler.go
@@ -69,7 +69,7 @@ func (d *DockerSampler) Enabled() bool {
 
 	d.dockerClient, err = initializeDockerClient(d.apiVersion)
 	if err != nil {
-		dslog.WithError(err).Warn("unable to initialize docker client, could be not installed on the host")
+		dslog.WithError(err).Info("unable to initialize docker client, maybe it is not installed on the host")
 
 		return false
 	}


### PR DESCRIPTION
* if the host doesn't have container environment, we should not raise a warning