### PR TITLE
fix: override hostname from infra-agent config for win-services

### DIFF
--- a/pkg/entity/register/worker.go
+++ b/pkg/entity/register/worker.go
@@ -30,6 +30,7 @@ type WorkerConfig struct {
 	MaxBatchDuration  time.Duration
 	MaxRetryBo        time.Duration
 	VerboseLogLevel   int
+	OverrideHostname  string
 }
 
 type worker struct {
@@ -90,6 +91,11 @@ func (w *worker) Run(ctx context.Context) {
 			}
 			// TODO update when entity key retrieval is fixed
 			eKey := entity.Key(req.Data.Entity.Name)
+			overrideHostname := w.config.OverrideHostname
+			// Only update hostname for windows services
+			if overrideHostname != "" && req.Data.Entity.Type == "WIN_SERVICE" {
+				req.Data.Entity.Metadata["hostname"] = overrideHostname
+			}
 			batch[eKey] = req
 			batchSizeBytes += entitySizeBytes
 

--- a/pkg/integrations/v4/dm/emitter.go
+++ b/pkg/integrations/v4/dm/emitter.go
@@ -111,6 +111,9 @@ func (e *emitter) lazyLoadProcessor() {
 	if e.isProcessing.IsNotSet() {
 		e.isProcessing.Set()
 		ctx := e.agentContext.Context()
+		agentResolver := e.agentContext.HostnameResolver()
+		fullHostname, shortHostname, _ := agentResolver.Query()
+		elog.WithField("overridehostname", fullHostname).WithField("overridehostname", shortHostname).Warn("emitter.go overridehostname config")
 
 		go e.runFwReqConsumer(ctx)
 		go e.runReqsRegisteredConsumer(ctx)
@@ -121,6 +124,7 @@ func (e *emitter) lazyLoadProcessor() {
 				MaxBatchDuration:  e.registerMaxBatchTime,
 				MaxRetryBo:        e.maxRetryBo,
 				VerboseLogLevel:   e.verboseLogLevel,
+				OverrideHostname:  shortHostname,
 			}
 			regWorker := register.NewWorker(
 				e.agentContext.Identity,


### PR DESCRIPTION
`override_hostname_short` overrides the hostname value for winservices  