### PR TITLE
NR-403516: Move all pipelines from ubuntu-20 runners to ubuntu-latest

### DIFF
--- a/.github/workflows/component_canaries.yml
+++ b/.github/workflows/component_canaries.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   canaries_macos:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ inputs.PLATFORM == 'macos' }}
     steps:
       - uses: actions/checkout@v4
@@ -65,7 +65,7 @@ jobs:
           ref: "${{ env.GIT_BRANCH }}"
 
   canaries_linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ inputs.PLATFORM == 'linux' }}
     steps:
       - uses: actions/checkout@v4
@@ -127,7 +127,7 @@ jobs:
           ref: "${{ env.GIT_BRANCH }}"
 
   canaries_windows:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ inputs.PLATFORM == 'windows' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/component_canaries_prune.yml
+++ b/.github/workflows/component_canaries_prune.yml
@@ -25,7 +25,7 @@ jobs:
 
   canaries-prune-linux:
     if: ${{ inputs.PLATFORM == 'linux' || inputs.PLATFORM == 'all' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
@@ -69,7 +69,7 @@ jobs:
 
   canaries-prune-windows:
     if: ${{ inputs.PLATFORM == 'windows' || inputs.PLATFORM == 'all' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/component_canary_alerts.yml
+++ b/.github/workflows/component_canary_alerts.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   provision:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/component_canary_alerts_delete.yml
+++ b/.github/workflows/component_canary_alerts_delete.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   provision:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/component_docker_packaging.yml
+++ b/.github/workflows/component_docker_packaging.yml
@@ -38,7 +38,7 @@ env:
 jobs:
   packaging:
     name: Build and upload docker images as RC
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/component_docker_publish.yml
+++ b/.github/workflows/component_docker_publish.yml
@@ -26,7 +26,7 @@ jobs:
   publish-docker-images:
     if: ${{ inputs.ASSETS_TYPE == 'all' || inputs.ASSETS_TYPE == 'docker' }}
     name: Create versioned and latest images from RC
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/component_linux_build.yml
+++ b/.github/workflows/component_linux_build.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   test-build:
     name: Test binary compilation for all (linux) platforms:arch
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Login to DockerHub

--- a/.github/workflows/component_linux_harvest_test.yml
+++ b/.github/workflows/component_linux_harvest_test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-22.04 ]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/component_linux_harvest_test.yml
+++ b/.github/workflows/component_linux_harvest_test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04 ]
+        os: [ ubuntu-latest ]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/component_linux_packaging.yml
+++ b/.github/workflows/component_linux_packaging.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   packaging:
     name: Build and upload ${{ inputs.ARCH }} artifacts into GH Release assets
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/component_linux_proxy_test.yml
+++ b/.github/workflows/component_linux_proxy_test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: Proxy tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/component_linux_publish.yml
+++ b/.github/workflows/component_linux_publish.yml
@@ -67,7 +67,7 @@ env:
 jobs:
   publish:
     name: Publish linux artifacts into s3 staging bucket
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       max-parallel: 1

--- a/.github/workflows/component_linux_unit_test.yml
+++ b/.github/workflows/component_linux_unit_test.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   unit-test:
     name: Unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
@@ -34,7 +34,7 @@ jobs:
 
   databind-test:
     name: Unit tests for databind
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
@@ -51,7 +51,7 @@ jobs:
   unit-test-finish:
     name: Coveralls finish
     needs: [ unit-test ]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/component_prerelease_testing.yml
+++ b/.github/workflows/component_prerelease_testing.yml
@@ -37,7 +37,7 @@ permissions:
 
 jobs:
   provision:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -77,7 +77,7 @@ jobs:
 
   harvest-tests:
     needs: [ provision ]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -118,7 +118,7 @@ jobs:
           - "linux_arm64"
 
     needs: [ harvest-tests ]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -153,7 +153,7 @@ jobs:
   packaging-tests-windows:
     if: ${{ inputs.PLATFORM == 'windows' }}
     needs: [ harvest-tests ]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -187,7 +187,7 @@ jobs:
   provision-clean-linux:
     if: ${{ inputs.PLATFORM == 'linux' }}
     needs: [ packaging-tests-linux ]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -228,7 +228,7 @@ jobs:
   provision-clean-windows:
       if: ${{ inputs.PLATFORM == 'windows' }}
       needs: [ packaging-tests-windows ]
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v4
 

--- a/.github/workflows/component_purge_cdn.yml
+++ b/.github/workflows/component_purge_cdn.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   purge-cdn:
     name: Purge CDN
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Fasty purge

--- a/.github/workflows/component_trivy.yml
+++ b/.github/workflows/component_trivy.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   trivy_scanner:
     name: Trivy scanner for docker
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ ! github.event.schedule }} # Table output
     steps:
       - name: newrelic/infrastructure
@@ -67,7 +67,7 @@ jobs:
 
   trivy_scanner_scheduled:
     name: Scheduled Trivy scanner for docker
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ github.event.schedule }} # Upload sarif when running periodically
     steps:
       - name: Checkout

--- a/.github/workflows/component_windows_publish.yml
+++ b/.github/workflows/component_windows_publish.yml
@@ -70,7 +70,7 @@ env:
 jobs:
   publish:
     name: Publish windows artifacts into s3 staging bucket
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       max-parallel: 1

--- a/.github/workflows/license-notice.yml
+++ b/.github/workflows/license-notice.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   security:
     name: Run licenses check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Login to DockerHub

--- a/.github/workflows/prerelease_canaries.yml
+++ b/.github/workflows/prerelease_canaries.yml
@@ -68,7 +68,7 @@ jobs:
       CROWDSTRIKE_CUSTOMER_ID: ${{secrets.CROWDSTRIKE_CUSTOMER_ID}}
 
   get_previous_tag:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     # Map a step output to a job output
     outputs:
       previous_tag: ${{ steps.previous_tag_step.outputs.PREVIOUS_TAG }}

--- a/.github/workflows/prerelease_linux_on_demand.yml
+++ b/.github/workflows/prerelease_linux_on_demand.yml
@@ -54,7 +54,7 @@ env:
 jobs:
   packaging:
     name: Build and publish packages to custom repo
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: dest_prefix for testing

--- a/.github/workflows/prerelease_windows_on_demand.yml
+++ b/.github/workflows/prerelease_windows_on_demand.yml
@@ -91,7 +91,7 @@ jobs:
 
   publish:
     name: Build and upload artifacts into GH Release assets
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [ packaging ]
     strategy:
       matrix:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   scan-deps:
     name: Run security checks Snyk
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Login to DockerHub

--- a/test/harvest/rpm_test.go
+++ b/test/harvest/rpm_test.go
@@ -82,7 +82,7 @@ func rpmBasedDistribution() (bool, error) {
 		return false, err
 	}
 	regexps := []*regexp.Regexp{
-		regexp.MustCompile("(?m)^NAME=\"Ubuntu\""),
+		regexp.MustCompile("(?m)^NAME=\"Ubuntu\""), // Enables matching "NAME=\"Ubuntu\"" as the start of any line within multiline content
 		regexp.MustCompile("^NAME=\"Debian\""),
 		regexp.MustCompile("^NAME=\"SLES\""),
 	}

--- a/test/harvest/rpm_test.go
+++ b/test/harvest/rpm_test.go
@@ -82,7 +82,7 @@ func rpmBasedDistribution() (bool, error) {
 		return false, err
 	}
 	regexps := []*regexp.Regexp{
-		regexp.MustCompile("^NAME=\"Ubuntu\""),
+		regexp.MustCompile("(?m)^NAME=\"Ubuntu\""),
 		regexp.MustCompile("^NAME=\"Debian\""),
 		regexp.MustCompile("^NAME=\"SLES\""),
 	}


### PR DESCRIPTION
### Context

This pull request is driven by the upcoming deprecation of the Ubuntu 20.04 Actions runner image. GitHub has announced the following timeline for deprecation:

- **Deprecation Start Date**: 2025-02-01
- **Full Unsupported Date**: 2025-04-15

Given these dates, it is crucial to transition to supported runner images to ensure that our CI/CD pipelines do not encounter disruptions.

### Change Description

- **Objective**: Update all pipelines to use the `ubuntu-latest` runner image instead of the soon-to-be deprecated `ubuntu-20.xx`.
- **Background**: By updating to `ubuntu-latest`, we align our workflows with the latest stable and supported environment that GitHub provides. 
- **Impact**: Workflows using the `ubuntu-20.04` image label should be updated to `ubuntu-latest`.

