### PR TITLE
Support macOS 15 (Sequoia)

### DIFF
--- a/.github/workflows/component_macos_harvest_test.yml
+++ b/.github/workflows/component_macos_harvest_test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macos-13, macos-14, macos-15]
+        os: [ macos-13, macos-14, macos-15 ]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/component_macos_harvest_test.yml
+++ b/.github/workflows/component_macos_harvest_test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macos-13, macos-14 macos-15]
+        os: [ macos-13, macos-14, macos-15]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/component_macos_harvest_test.yml
+++ b/.github/workflows/component_macos_harvest_test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macos-13, macos-14 ]
+        os: [ macos-13, macos-14 macos-15]
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
# Description
This update modifies the `component_macos_harvest_test.yml` workflow to include support for **macOS 15**. The workflow now runs harvest tests on macOS versions 13, 14, and 15, ensuring compatibility with the latest macOS environment.

## Key Changes
- Updated the `matrix.os` strategy in the `harvest-test-macos` job to include `macos-15`.
- The workflow now tests on the following macOS versions:
  - macOS 13
  - macOS 14
  - macOS 15

## Why This Change?
- To ensure the `harvest-tests` are compatible with the latest macOS version (macOS 15).
- To maintain support for newer macOS environments as part of our CI/CD pipeline.

## Testing
- Verified that the workflow successfully runs on macOS 15.
- Ensured no regressions on macOS 13 and macOS 14.