### PR TITLE
ci: Support Rocky Linux

### DIFF
--- a/test/automated/ansible/group_vars/localhost/main.yml
+++ b/test/automated/ansible/group_vars/localhost/main.yml
@@ -201,6 +201,26 @@ instances:
     python_interpreter: "/usr/bin/python"
     launch_template: "LaunchTemplateId=lt-0b00afb3f5110a0e6,Version=3"
   ############################
+  # rocky linux amd64
+  ############################
+  - ami: "ami-05150ea4d8a533099"  # Replace with the correct Rocky Linux 9 AMI ID
+    type: "t3a.small"
+    name: "amd64:rocky-9"
+    username: "rocky"
+    platform: "linux"
+    python_interpreter: "/usr/bin/python3"
+    launch_template: "LaunchTemplateId=lt-0b00afb3f5110a0e6,Version=3"
+  ############################
+  # rocky linux arm64
+  ############################
+  - ami: "ami-0cc73a60867904383"  # Replace with the correct Rocky Linux 9 ARM64 AMI ID
+    type: "t4g.small"
+    name: "arm64:rocky-9"
+    username: "rocky"
+    platform: "linux"
+    python_interpreter: "/usr/bin/python3"
+    launch_template: "LaunchTemplateId=lt-0b00afb3f5110a0e6,Version=3"
+  ############################
   # debian amd64
   ############################
   - ami: "ami-08a0dab67e025361b"

--- a/test/provision/terraform/caos.auto.tfvars.dist
+++ b/test/provision/terraform/caos.auto.tfvars.dist
@@ -2,9 +2,9 @@ ec2_prefix = "PREFIX:TAG_OR_UNIQUE_NAME"
 
 windows_ec2 = ["windows_2016", "windows_2019", "windows_2022", "windows_2025"]
 
-linux_ec2_amd = ["amd64:ubuntu24.04", "amd64:ubuntu22.04", "amd64:ubuntu20.04", "amd64:ubuntu18.04", "amd64:ubuntu16.04", "amd64:centos-stream", "amd64:sles-12.5", "amd64:sles-15.3",  "amd64:sles-15.4", "amd64:sles-15.5", "amd64:sles-15.6", "amd64:redhat-8.4", "amd64:redhat-9.0", "amd64:debian-bookworm", "amd64:al-2", "amd64:al-2023", "amd64:al-2023-fips"]
+linux_ec2_amd = ["amd64:ubuntu24.04", "amd64:ubuntu22.04", "amd64:ubuntu20.04", "amd64:ubuntu18.04", "amd64:ubuntu16.04", "amd64:centos-stream", "amd64:sles-12.5", "amd64:sles-15.3",  "amd64:sles-15.4", "amd64:sles-15.5", "amd64:sles-15.6", "amd64:redhat-8.4", "amd64:redhat-9.0", "amd64:debian-bookworm", "amd64:al-2", "amd64:al-2023", "amd64:al-2023-fips", "amd64:rocky-9"]
 
-linux_ec2_arm = ["arm64:ubuntu24.04", "arm64:ubuntu22.04", "arm64:ubuntu20.04", "arm64:ubuntu18.04", "arm64:ubuntu16.04", "arm64:centos-stream",  "arm64:sles-15.4", "arm64:sles-15.5", "arm64:sles-15.6", "arm64:redhat-9.0", "arm64:debian-bookworm", "arm64:al-2", "arm64:al-2023", "arm64:al-2023-fips"]
+linux_ec2_arm = ["arm64:ubuntu24.04", "arm64:ubuntu22.04", "arm64:ubuntu20.04", "arm64:ubuntu18.04", "arm64:ubuntu16.04", "arm64:centos-stream",  "arm64:sles-15.4", "arm64:sles-15.5", "arm64:sles-15.6", "arm64:redhat-9.0", "arm64:debian-bookworm", "arm64:al-2", "arm64:al-2023", "arm64:al-2023-fips", "arm64:rocky-9"]
 
 ssh_pub_key      = "AAAAB3NzaC1yc2EAAAADAQABAAABAQDH9C7BS2XrtXGXFFyL0pNku/Hfy84RliqvYKpuslJFeUivf5QY6Ipi8yXfXn6TsRDbdxfGPi6oOR60Fa+4cJmCo6N5g57hBS6f2IdzQBNrZr7i1I/a3cFeK6XOc1G1tQaurx7Pu+qvACfJjLXKG66tHlaVhAHd/1l2FocgFNUDFFuKS3mnzt9hKys7sB4aO3O0OdohN/0NJC4ldV8/OmeXqqfkiPWcgPx3C8bYyXCX7QJNBHKrzbX1jW51Px7SIDWFDV6kxGwpQGGBMJg/k79gjjM+jhn4fg1/VP/Fx37mAnfLqpcTfiOkzSE80ORGefQ1XfGK/Dpa3ITrzRYW8xlR caos-dev-arm"
 pvt_key          = "~/.ssh/caos-dev-arm.cer"


### PR DESCRIPTION
### Description of Changes: Added Rocky Linux Support for Infrastructure Agent

This update introduces explicit support for **Rocky Linux 9** in the infrastructure agent's provisioning and configuration processes. The changes ensure compatibility and validation for both AMD64 and ARM64 architectures, enabling automated testing and deployment on Rocky Linux 9.

---

### Key Changes

1. **Ansible Configuration (`main.yml`)**:
   - Added entries for **Rocky Linux 9**:
     - **AMD64**:
       - AMI ID: `ami-05150ea4d8a533099`

     - **ARM64**:
       - AMI ID: `ami-0cc73a60867904383`

2. **Terraform Configuration (`caos.auto.tfvars.dist`)**:
   - Added `amd64:rocky-9` to the `linux_ec2_amd` list.
   - Added `arm64:rocky-9` to the `linux_ec2_arm` list.

---

### Purpose of the Changes

- **Explicit Testing**: Ensures Rocky Linux 9 is tested and validated during automated provisioning and configuration.
- **Compatibility**: Confirms the infrastructure agent works seamlessly on Rocky Linux 9 for both AMD64 and ARM64 architectures.
- **Clarity**: Clearly documents Rocky Linux 9 as a supported platform for the infrastructure agent.

---