### PR TITLE
test: add a2q tests for systemSample

### DIFF
--- a/test/a2q/systemSampleTests.yml
+++ b/test/a2q/systemSampleTests.yml
@@ -1,0 +1,268 @@
+apiVersion: v1
+kind: TestSuite
+metadata:
+  name: SystemSample - MELT
+  namespace: infra-agent
+  team: OHAI
+  owningTeam: OHAI
+  environment: ${var.sutEnvironment}
+  x-category: melt
+  x-period: 5m
+spec:
+  tests:
+    - nrql: "FROM SystemSample SELECT agentName WHERE displayName = '${var.display_name_current}' LIMIT 1"
+      name: Check agent name current
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "agentName"
+          equals: "Infrastructure"
+    - nrql: "FROM SystemSample SELECT agentName WHERE displayName = '${var.display_name_previous}' LIMIT 1"
+      name: Check agent name previous
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "agentName"
+          equals: "Infrastructure"
+    - nrql: "SELECT abs(filter(average(cpuPercent), WHERE displayName = '${var.display_name_current}') - filter(average(cpuPercent), WHERE displayName = '${var.display_name_previous}')) AS 'CPU Percent Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: CPU Percent Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['CPU Percent Difference']"
+          less: 0.05
+    - nrql: "SELECT abs(filter(average(numeric(coreCount)), WHERE displayName = '${var.display_name_current}') - filter(average(numeric(coreCount)), WHERE displayName = '${var.display_name_previous}')) AS 'Core Count Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Core Count Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Core Count Difference']"
+          equals: 0
+    - nrql: "SELECT abs(filter(average(cpuIOWaitPercent), WHERE displayName = '${var.display_name_current}') - filter(average(cpuIOWaitPercent), WHERE displayName = '${var.display_name_previous}')) AS 'CPU IO Wait Percent Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: CPU IO Wait Percent Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['CPU IO Wait Percent Difference']"
+          less: 0.05
+    - nrql: "SELECT abs(filter(average(cpuIdlePercent), WHERE displayName = '${var.display_name_current}') - filter(average(cpuIdlePercent), WHERE displayName = '${var.display_name_previous}')) AS 'CPU Idle Percent Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: CPU Idle Percent Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['CPU Idle Percent Difference']"
+          less: 0.05
+    - nrql: "SELECT abs(filter(average(cpuSystemPercent), WHERE displayName = '${var.display_name_current}') - filter(average(cpuSystemPercent), WHERE displayName = '${var.display_name_previous}')) AS 'CPU System Percent Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: CPU System Percent Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['CPU System Percent Difference']"
+          less: 0.05
+    - nrql: "SELECT abs(filter(average(cpuUserPercent), WHERE displayName = '${var.display_name_current}') - filter(average(cpuUserPercent), WHERE displayName = '${var.display_name_previous}')) AS 'CPU User Percent Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: CPU User Percent Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['CPU User Percent Difference']"
+          less: 0.05
+    - nrql: "SELECT abs(filter(average(diskFreeBytes), WHERE displayName = '${var.display_name_current}') - filter(average(diskFreeBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Free Bytes Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Disk Free Bytes Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Disk Free Bytes Difference']"
+          less: 1000000
+    - nrql: "SELECT abs(filter(average(diskFreePercent), WHERE displayName = '${var.display_name_current}') - filter(average(diskFreePercent), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Free Percent Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Disk Free Percent Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Disk Free Percent Difference']"
+          less: 5
+    - nrql: "SELECT abs(filter(average(diskReadsPerSecond), WHERE displayName = '${var.display_name_current}') - filter(average(diskReadsPerSecond), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Read Per Second Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Disk Read Per Second Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Disk Read Per Second Difference']"
+          less: 5
+    - nrql: "SELECT abs(filter(average(diskTotalBytes), WHERE displayName = '${var.display_name_current}') - filter(average(diskTotalBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Total Bytes Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Disk Total Bytes Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Disk Total Bytes Difference']"
+          less: 5
+    - nrql: "SELECT abs(filter(average(diskUsedBytes), WHERE displayName = '${var.display_name_current}') - filter(average(diskUsedBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Used Bytes Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Disk Used Bytes Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Disk Used Bytes Difference']"
+          less: 1000000
+    - nrql: "SELECT abs(filter(average(diskUsedPercent), WHERE displayName = '${var.display_name_current}') - filter(average(diskUsedPercent), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Used Percent Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Disk Used Percent Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Disk Used Percent Difference']"
+          less: 3
+    - nrql: "SELECT abs(filter(average(diskUtilizationPercent), WHERE displayName = '${var.display_name_current}') - filter(average(diskUtilizationPercent), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Utilization Percent Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Disk Utilization Percent Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Disk Utilization Percent Difference']"
+          less: 0.7
+    - nrql: "SELECT abs(filter(average(diskWriteUtilizationPercent), WHERE displayName = '${var.display_name_current}') - filter(average(diskWriteUtilizationPercent), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Write Utilization Percent Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Disk Write Utilization Percent Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Disk Write Utilization Percent Difference']"
+          less: 0.5
+    - nrql: "SELECT abs(filter(average(diskWritesPerSecond), WHERE displayName = '${var.display_name_current}') - filter(average(diskWritesPerSecond), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Writes Per Second Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Disk Writes Per Second Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Disk Writes Per Second Difference']"
+          less: 10
+    - nrql: "SELECT abs(filter(average(loadAverageFifteenMinute), WHERE displayName = '${var.display_name_current}') - filter(average(loadAverageFifteenMinute), WHERE displayName = '${var.display_name_previous}')) AS 'Load Average Fifteen Minute Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Load Average Fifteen Minute Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Load Average Fifteen Minute Difference']"
+          less: 0.5
+    - nrql: "SELECT abs(filter(average(loadAverageFiveMinute), WHERE displayName = '${var.display_name_current}') - filter(average(loadAverageFiveMinute), WHERE displayName = '${var.display_name_previous}')) AS 'Load Average Five Minute Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Load Average Five Minute Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Load Average Five Minute Difference']"
+          less: 0.5
+    - nrql: "SELECT abs(filter(average(loadAverageOneMinute), WHERE displayName = '${var.display_name_current}') - filter(average(loadAverageOneMinute), WHERE displayName = '${var.display_name_previous}')) AS 'Load Average One Minute Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Load Average One Minute Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Load Average One Minute Difference']"
+          less: 0.7
+    - nrql: "SELECT abs(filter(average(memoryCachedBytes), WHERE displayName = '${var.display_name_current}') - filter(average(memoryCachedBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Memory Cached Bytes Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Memory Cached Bytes Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Memory Cached Bytes Difference']"
+          less: 3000000
+    - nrql: "SELECT abs(filter(average(memoryFreeBytes), WHERE displayName = '${var.display_name_current}') - filter(average(memoryFreeBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Memory Free Bytes Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Memory Free Bytes Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Memory Free Bytes Difference']"
+          less: 100000000
+    - nrql: "SELECT abs(filter(average(memoryFreePercent), WHERE displayName = '${var.display_name_current}') - filter(average(memoryFreePercent), WHERE displayName = '${var.display_name_previous}')) AS 'Memory Free Percent Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Memory Free Percent Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Memory Free Percent Difference']"
+          less: 5
+    - nrql: "SELECT abs(filter(average(memorySharedBytes), WHERE displayName = '${var.display_name_current}') - filter(average(memorySharedBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Memory Shared Bytes Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Memory Shared Bytes Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Memory Shared Bytes Difference']"
+          less: 15000000
+    - nrql: "SELECT abs(filter(average(memorySlabBytes), WHERE displayName = '${var.display_name_current}') - filter(average(memorySlabBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Memory Slab Bytes Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Memory Slab Bytes Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Memory Slab Bytes Difference']"
+          less: 50000000
+    - nrql: "SELECT abs(filter(average(memoryTotalBytes), WHERE displayName = '${var.display_name_current}') - filter(average(memoryTotalBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Memory Total Bytes Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Memory Total Bytes Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Memory Total Bytes Difference']"
+          less: 50000000
+    - nrql: "SELECT abs(filter(average(memoryUsedBytes), WHERE displayName = '${var.display_name_current}') - filter(average(memoryUsedBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Memory Used Bytes Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Memory Used Bytes Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Memory Used Bytes Difference']"
+          less: 100000000
+    - nrql: "SELECT abs(filter(average(memoryUsedPercent), WHERE displayName = '${var.display_name_current}') - filter(average(memoryUsedPercent), WHERE displayName = '${var.display_name_previous}')) AS 'Memory Used Percent Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Memory Used Percent Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Memory Used Percent Difference']"
+          less: 5
+    - nrql: "SELECT abs(filter(average(memoryKernelFree), WHERE displayName = '${var.display_name_current}') - filter(average(memoryKernelFree), WHERE displayName = '${var.display_name_previous}')) AS 'Memory Kernel Free Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Memory Kernel Free Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Memory Kernel Free Difference']"
+          less: 100000000
+    - nrql: "SELECT abs(filter(average(memoryBuffers), WHERE displayName = '${var.display_name_current}') - filter(average(memoryBuffers), WHERE displayName = '${var.display_name_previous}')) AS 'Memory Buffers Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Memory Buffers Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Memory Buffers Difference']"
+          less: 5000000
+    - nrql: "SELECT abs(filter(average(swapTotalBytes), WHERE displayName = '${var.display_name_current}') - filter(average(swapTotalBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Swap Total Bytes Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: Swap Total Bytes Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Swap Total Bytes Difference']"
+          equals: 0
+    - nrql: "SELECT abs(filter(average(numeric(systemMemoryBytes)), WHERE displayName = '${var.display_name_current}') - filter(average(numeric(systemMemoryBytes)), WHERE displayName = '${var.display_name_previous}')) AS 'System Memory Bytes Difference' FROM SystemSample SINCE 5 minutes AGO"
+      name: System Memory Bytes Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['System Memory Bytes Difference']"
+          less: 50000000


### PR DESCRIPTION
### Test local run
```sh
2025-05-07 08:31:38,295 [main] DEBUG c.n.a2q.validations.core.LocalTest - Definition location file: /a2q/systemSampleTests.yml
2025-05-07 08:31:38,298 [main] DEBUG c.n.a2q.validations.core.LocalTest - Dynamic variable detected: accountId=*******
2025-05-07 08:31:38,298 [main] DEBUG c.n.a2q.validations.core.LocalTest - Dynamic variable detected: nrEnv=stg
2025-05-07 08:31:38,298 [main] DEBUG c.n.a2q.validations.core.LocalTest - Dynamic variable detected: sutEnvironment=stg
2025-05-07 08:31:38,298 [main] DEBUG c.n.a2q.validations.core.LocalTest - Dynamic variable detected: display_name_previous=a2q_rohan_agent_1.63.0
2025-05-07 08:31:38,298 [main] DEBUG c.n.a2q.validations.core.LocalTest - Dynamic variable detected: display_name_current=a2q_rohan_agent_1.63.1
2025-05-07 08:31:38,299 [main] DEBUG c.n.a2q.validations.core.LocalTest - Secret detected: apiKey=********************************
2025-05-07 08:31:38,442 [main] DEBUG c.n.a2q.validations.core.LocalTest - Result publisher option detected: accountId=*******
2025-05-07 08:31:38,443 [main] DEBUG c.n.a2q.validations.core.LocalTest - Result publisher option detected: licenseKey=****************************************
2025-05-07 08:31:38,443 [main] DEBUG c.n.a2q.validations.core.LocalTest - Result publisher option detected: env=***
2025-05-07 08:31:38,473 [main] INFO  c.n.t.transport.BatchDataSender - BatchDataSender configured with endpoint https://staging-otlp.nr-data.net:4317/metric/v1
2025-05-07 08:31:38,474 [main] INFO  c.n.t.transport.BatchDataSender - BatchDataSender configured to use license keys
2025-05-07 08:31:38,475 [main] INFO  c.n.t.transport.BatchDataSender - BatchDataSender configured with endpoint https://staging-otlp.nr-data.net:4317/v1/accounts/events
2025-05-07 08:31:38,475 [main] INFO  c.n.t.transport.BatchDataSender - BatchDataSender configured to use license keys
2025-05-07 08:31:38,476 [main] DEBUG c.n.a.v.c.o.TestSuiteResultPublisher - Event publishers enabled: [console-raw, newrelic]
===================================
Common attributes: Attributes{rawAttributes={a2q.environment=test, hostname=6fdd14d2d48a, apiVersion=v1, x-category=melt, a2q.version=test, owningTeam=OHAI, testSuiteName=SystemSample - MELT, namespace=infra-agent, runId=c9318ede-aae9-4c3f-b127-7eab26d1c609, sut.environment=stg, x-period=5m}}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=1060, queryDuration=1058, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Check agent name current, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=438, queryDuration=438, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Check agent name previous, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=446, queryDuration=444, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=CPU Percent Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=440, queryDuration=439, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Core Count Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=447, queryDuration=446, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=CPU IO Wait Percent Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=428, queryDuration=427, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=CPU Idle Percent Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=416, queryDuration=415, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=CPU System Percent Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=398, queryDuration=398, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=CPU User Percent Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=390, queryDuration=389, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Disk Free Bytes Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=425, queryDuration=424, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Disk Free Percent Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=439, queryDuration=438, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Disk Read Per Second Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=403, queryDuration=402, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Disk Total Bytes Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=408, queryDuration=407, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Disk Used Bytes Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=413, queryDuration=412, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Disk Used Percent Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=414, queryDuration=414, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Disk Utilization Percent Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=429, queryDuration=429, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Disk Write Utilization Percent Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=407, queryDuration=407, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Disk Writes Per Second Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=393, queryDuration=392, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Load Average Fifteen Minute Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=427, queryDuration=427, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Load Average Five Minute Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=413, queryDuration=412, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Load Average One Minute Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=423, queryDuration=422, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Memory Cached Bytes Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=437, queryDuration=436, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Memory Free Bytes Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=440, queryDuration=439, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Memory Free Percent Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=418, queryDuration=417, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Memory Shared Bytes Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=459, queryDuration=458, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Memory Slab Bytes Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=411, queryDuration=410, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Memory Total Bytes Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=420, queryDuration=419, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Memory Used Bytes Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=397, queryDuration=397, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Memory Used Percent Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=426, queryDuration=426, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Memory Kernel Free Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=454, queryDuration=454, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Memory Buffers Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=424, queryDuration=423, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Swap Total Bytes Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=437, queryDuration=436, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=System Memory Bytes Difference, successful=true}}, timestamp=1746606712721}
===================================
Event{eventType='A2QTestSuiteResult', attributes=Attributes{rawAttributes={duration=14180, successfulAssertions=32, totalEvaluations=32, successfulEvaluations=32, failedAssertions=0, failedTests=0, totalAssertions=32, successfulTests=32, failedEvaluations=0, successful=true, totalTests=32}}, timestamp=1746606712721}
===================================
TEST SUITE SUCCEEDED
2025-05-07 08:31:52,730 [Thread-0] INFO  c.newrelic.telemetry.TelemetryClient - Shutting down the TelemetryClient background Executor
2025-05-07 08:31:52,730 [Thread-1] INFO  c.n.a.v.c.util.ExecutorServiceUtils - Executor service shutdown started
2025-05-07 08:31:52,730 [Thread-1] INFO  c.n.a.v.c.util.ExecutorServiceUtils - Executor service shutdown gracefully: false
```