### PR TITLE
test: add a2q tests for networkSample

### DIFF
--- a/test/a2q/networkSampleTests.yml
+++ b/test/a2q/networkSampleTests.yml
@@ -1,0 +1,92 @@
+apiVersion: v1
+kind: TestSuite
+metadata:
+  name: NetworkSample - MELT
+  namespace: infra-agent
+  team: OHAI
+  owningTeam: OHAI
+  environment: ${var.sutEnvironment}
+  x-category: melt
+  x-period: 5m
+spec:
+  tests:
+    - nrql: "FROM NetworkSample SELECT agentName WHERE displayName = '${var.display_name_current}' LIMIT 1"
+      name: Check agent name current
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "agentName"
+          equals: "Infrastructure"
+    - nrql: "FROM NetworkSample SELECT agentName WHERE displayName = '${var.display_name_previous}' LIMIT 1"
+      name: Check agent name previous
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "agentName"
+          equals: "Infrastructure"
+    - nrql: "SELECT abs(filter(average(receiveBytesPerSecond), WHERE displayName = '${var.display_name_current}') - filter(average(receiveBytesPerSecond), WHERE displayName = '${var.display_name_previous}')) AS 'Receive Bytes Per Second Difference' FROM NetworkSample SINCE 5 minutes AGO"
+      name: Receive Bytes Per Second Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Receive Bytes Per Second Difference']"
+          less: 100
+    - nrql: "SELECT abs(filter(average(receiveDroppedPerSecond), WHERE displayName = '${var.display_name_current}') - filter(average(receiveDroppedPerSecond), WHERE displayName = '${var.display_name_previous}')) AS 'Receive Dropped Per Second Difference' FROM NetworkSample SINCE 5 minutes AGO"
+      name: Receive Dropped Per Second Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Receive Dropped Per Second Difference']"
+          less: 2
+    - nrql: "SELECT abs(filter(average(receiveErrorsPerSecond), WHERE displayName = '${var.display_name_current}') - filter(average(receiveErrorsPerSecond), WHERE displayName = '${var.display_name_previous}')) AS 'Receive Errors Per Second Difference' FROM NetworkSample SINCE 5 minutes AGO"
+      name: Receive Errors Per Second Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Receive Errors Per Second Difference']"
+          less: 2
+    - nrql: "SELECT abs(filter(average(receivePacketsPerSecond), WHERE displayName = '${var.display_name_current}') - filter(average(receivePacketsPerSecond), WHERE displayName = '${var.display_name_previous}')) AS 'Receive Packets Per Second Difference' FROM NetworkSample SINCE 5 minutes AGO"
+      name: Receive Packets Per Second Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Receive Packets Per Second Difference']"
+          less: 1
+    - nrql: "SELECT abs(filter(average(transmitBytesPerSecond), WHERE displayName = '${var.display_name_current}') - filter(average(transmitBytesPerSecond), WHERE displayName = '${var.display_name_previous}')) AS 'Transmit Bytes Per Second Difference' FROM NetworkSample SINCE 5 minutes AGO"
+      name: Transmit Bytes Per Second Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Transmit Bytes Per Second Difference']"
+          less: 300
+    - nrql: "SELECT abs(filter(average(transmitDroppedPerSecond), WHERE displayName = '${var.display_name_current}') - filter(average(transmitDroppedPerSecond), WHERE displayName = '${var.display_name_previous}')) AS 'Transmit Dropped Per Second Difference' FROM NetworkSample SINCE 5 minutes AGO"
+      name: Transmit Dropped Per Second Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Transmit Dropped Per Second Difference']"
+          less: 2
+    - nrql: "SELECT abs(filter(average(transmitErrorsPerSecond), WHERE displayName = '${var.display_name_current}') - filter(average(transmitErrorsPerSecond), WHERE displayName = '${var.display_name_previous}')) AS 'Transmit Errors Per Second Difference' FROM NetworkSample SINCE 5 minutes AGO"
+      name: Transmit Errors Per Second Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Transmit Errors Per Second Difference']"
+          less: 2
+    - nrql: "SELECT abs(filter(average(transmitPacketsPerSecond), WHERE displayName = '${var.display_name_current}') - filter(average(transmitPacketsPerSecond), WHERE displayName = '${var.display_name_previous}')) AS 'Transmit Packets Per Second Difference' FROM NetworkSample SINCE 5 minutes AGO"
+      name: Transmit Packets Per Second Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Transmit Packets Per Second Difference']"
+          less: 1


### PR DESCRIPTION
### Testing details
```sh
2025-05-07 09:15:50,863 [main] DEBUG c.n.a2q.validations.core.LocalTest - Definition location file: /a2q/networkSampleTests.yml
2025-05-07 09:15:50,867 [main] DEBUG c.n.a2q.validations.core.LocalTest - Dynamic variable detected: accountId=*******
2025-05-07 09:15:50,867 [main] DEBUG c.n.a2q.validations.core.LocalTest - Dynamic variable detected: nrEnv=stg
2025-05-07 09:15:50,867 [main] DEBUG c.n.a2q.validations.core.LocalTest - Dynamic variable detected: sutEnvironment=stg
2025-05-07 09:15:50,867 [main] DEBUG c.n.a2q.validations.core.LocalTest - Dynamic variable detected: display_name_previous=a2q_rohan_agent_1.63.0
2025-05-07 09:15:50,867 [main] DEBUG c.n.a2q.validations.core.LocalTest - Dynamic variable detected: display_name_current=a2q_rohan_agent_1.63.1
2025-05-07 09:15:50,868 [main] DEBUG c.n.a2q.validations.core.LocalTest - Secret detected: apiKey=********************************
2025-05-07 09:15:51,019 [main] DEBUG c.n.a2q.validations.core.LocalTest - Result publisher option detected: accountId=*******
2025-05-07 09:15:51,020 [main] DEBUG c.n.a2q.validations.core.LocalTest - Result publisher option detected: licenseKey=****************************************
2025-05-07 09:15:51,020 [main] DEBUG c.n.a2q.validations.core.LocalTest - Result publisher option detected: env=***
2025-05-07 09:15:51,058 [main] INFO  c.n.t.transport.BatchDataSender - BatchDataSender configured with endpoint https://staging-otlp.nr-data.net:4317/metric/v1
2025-05-07 09:15:51,058 [main] INFO  c.n.t.transport.BatchDataSender - BatchDataSender configured to use license keys
2025-05-07 09:15:51,059 [main] INFO  c.n.t.transport.BatchDataSender - BatchDataSender configured with endpoint https://staging-otlp.nr-data.net:4317/v1/accounts/events
2025-05-07 09:15:51,059 [main] INFO  c.n.t.transport.BatchDataSender - BatchDataSender configured to use license keys
2025-05-07 09:15:51,061 [main] DEBUG c.n.a.v.c.o.TestSuiteResultPublisher - Event publishers enabled: [console-raw, newrelic]
===================================
Common attributes: Attributes{rawAttributes={a2q.environment=test, hostname=1ac1558132e4, apiVersion=v1, x-category=melt, a2q.version=test, owningTeam=OHAI, testSuiteName=NetworkSample - MELT, namespace=infra-agent, runId=ddd55a6d-a904-42b8-ad9f-e1d3c5652465, sut.environment=stg, x-period=5m}}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=1045, queryDuration=1044, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Check agent name current, successful=true}}, timestamp=1746609356011}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=418, queryDuration=417, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Check agent name previous, successful=true}}, timestamp=1746609356011}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=435, queryDuration=433, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Receive Bytes Per Second Difference, successful=true}}, timestamp=1746609356011}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=435, queryDuration=434, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Receive Dropped Per Second Difference, successful=true}}, timestamp=1746609356011}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=431, queryDuration=430, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Receive Errors Per Second Difference, successful=true}}, timestamp=1746609356011}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=448, queryDuration=447, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Receive Packets Per Second Difference, successful=true}}, timestamp=1746609356011}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=415, queryDuration=414, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Transmit Bytes Per Second Difference, successful=true}}, timestamp=1746609356011}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=408, queryDuration=407, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Transmit Dropped Per Second Difference, successful=true}}, timestamp=1746609356011}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=408, queryDuration=407, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Transmit Errors Per Second Difference, successful=true}}, timestamp=1746609356011}
===================================
Event{eventType='A2QTestResult', attributes=Attributes{rawAttributes={duration=453, queryDuration=453, successfulAssertions=1, totalEvaluations=1, successfulEvaluations=1, failedAssertions=0, totalAssertions=1, failedEvaluations=0, testName=Transmit Packets Per Second Difference, successful=true}}, timestamp=1746609356011}
===================================
Event{eventType='A2QTestSuiteResult', attributes=Attributes{rawAttributes={duration=4896, successfulAssertions=10, totalEvaluations=10, successfulEvaluations=10, failedAssertions=0, failedTests=0, totalAssertions=10, successfulTests=10, failedEvaluations=0, successful=true, totalTests=10}}, timestamp=1746609356011}
===================================
TEST SUITE SUCCEEDED
2025-05-07 09:15:56,019 [Thread-1] INFO  c.n.a.v.c.util.ExecutorServiceUtils - Executor service shutdown started
2025-05-07 09:15:56,019 [Thread-0] INFO  c.newrelic.telemetry.TelemetryClient - Shutting down the TelemetryClient background Executor
2025-05-07 09:15:56,019 [Thread-1] INFO  c.n.a.v.c.util.ExecutorServiceUtils - Executor service shutdown gracefully: false
```