### PR TITLE
test: add a2q tests for storageSample

### DIFF
--- a/test/a2q/storageSampleTests.yml
+++ b/test/a2q/storageSampleTests.yml
@@ -33,7 +33,7 @@ spec:
       nrEnv: ${var.nrEnv}
       assertions:
         - fields: "['Disk Used Bytes Difference']"
-          less: 1000000000
+          greater: 1000000000
     - nrql: "SELECT abs(filter(average(diskUsedPercent), WHERE displayName = '${var.display_name_current}') - filter(average(diskUsedPercent), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Used Percent Difference' FROM StorageSample SINCE 5 minutes AGO"
       name: Disk Used Percent Difference
       account: ${var.accountId}
@@ -41,7 +41,7 @@ spec:
       nrEnv: ${var.nrEnv}
       assertions:
         - fields: "['Disk Used Percent Difference']"
-          less: 0.5
+          greater: 0.5
     - nrql: "SELECT abs(filter(average(diskFreeBytes), WHERE displayName = '${var.display_name_current}') - filter(average(diskFreeBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Free Bytes Difference' FROM StorageSample SINCE 5 minutes AGO"
       name: Disk Free Bytes Difference
       account: ${var.accountId}
@@ -49,7 +49,7 @@ spec:
       nrEnv: ${var.nrEnv}
       assertions:
         - fields: "['Disk Free Bytes Difference']"
-          less: 500000000
+          greater: 500000000
     - nrql: "SELECT abs(filter(average(diskFreePercent), WHERE displayName = '${var.display_name_current}') - filter(average(diskFreePercent), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Free Percent Difference' FROM StorageSample SINCE 5 minutes AGO"
       name: Disk Free Percent Difference
       account: ${var.accountId}
@@ -57,7 +57,7 @@ spec:
       nrEnv: ${var.nrEnv}
       assertions:
         - fields: "['Disk Free Percent Difference']"
-          less: 5
+          greater: 5
     - nrql: "SELECT abs(filter(average(diskTotalBytes), WHERE displayName = '${var.display_name_current}') - filter(average(diskTotalBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Total Bytes Difference' FROM StorageSample SINCE 5 minutes AGO"
       name: Disk Total Bytes Difference
       account: ${var.accountId}
@@ -65,7 +65,7 @@ spec:
       nrEnv: ${var.nrEnv}
       assertions:
         - fields: "['Disk Total Bytes Difference']"
-          greater: 10000
+          less: 10000
     - nrql: "SELECT abs(filter(average(inodesUsed), WHERE displayName = '${var.display_name_current}') - filter(average(inodesUsed), WHERE displayName = '${var.display_name_previous}')) AS 'Inodes Used Difference' FROM StorageSample SINCE 5 minutes AGO"
       name: Inodes Used Difference
       account: ${var.accountId}
@@ -73,7 +73,7 @@ spec:
       nrEnv: ${var.nrEnv}
       assertions:
         - fields: "['Inodes Used Difference']"
-          less: 5000
+          greater: 5000
     - nrql: "SELECT abs(filter(average(inodesFree), WHERE displayName = '${var.display_name_current}') - filter(average(inodesFree), WHERE displayName = '${var.display_name_previous}')) AS 'Inodes Free Difference' FROM StorageSample SINCE 5 minutes AGO"
       name: Inodes Free Difference
       account: ${var.accountId}
@@ -81,7 +81,7 @@ spec:
       nrEnv: ${var.nrEnv}
       assertions:
         - fields: "['Inodes Free Difference']"
-          less: 50000
+          greater: 50000
     - nrql: "SELECT abs(filter(average(inodesTotal), WHERE displayName = '${var.display_name_current}') - filter(average(inodesTotal), WHERE displayName = '${var.display_name_previous}')) AS 'Inodes Total Difference' FROM StorageSample SINCE 5 minutes AGO"
       name: Inodes Total Difference
       account: ${var.accountId}
@@ -89,7 +89,7 @@ spec:
       nrEnv: ${var.nrEnv}
       assertions:
         - fields: "['Inodes Total Difference']"
-          less: 1
+          greater: 1
     - nrql: "SELECT abs(filter(average(inodesUsedPercent), WHERE displayName = '${var.display_name_current}') - filter(average(inodesUsedPercent), WHERE displayName = '${var.display_name_previous}')) AS 'Inodes Used Percent Difference' FROM StorageSample SINCE 5 minutes AGO"
       name: Inodes Used Percent Difference
       account: ${var.accountId}

--- a/test/a2q/storageSampleTests.yml
+++ b/test/a2q/storageSampleTests.yml
@@ -26,37 +26,37 @@ spec:
       assertions:
         - fields: "agentName"
           equals: "Infrastructure"
-    - nrql: "SELECT abs(filter(average(diskUsedBytes), WHERE displayName = '${var.display_name_current}') - filter(average(diskUsedBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Used Bytes Difference' FROM StorageSample SINCE 5 minutes AGO"
-      name: Disk Used Bytes Difference
+    - nrql: "SELECT average(diskUsedBytes) AS 'Disk Used Bytes Current' FROM StorageSample WHERE displayName = '${var.display_name_current}' SINCE 5 minutes AGO"
+      name: Disk Used Bytes Current
       account: ${var.accountId}
       apiKey: ${secret.apiKey}
       nrEnv: ${var.nrEnv}
       assertions:
-        - fields: "['Disk Used Bytes Difference']"
+        - fields: "['Disk Used Bytes Current']"
           greater: 1000000000
-    - nrql: "SELECT abs(filter(average(diskUsedPercent), WHERE displayName = '${var.display_name_current}') - filter(average(diskUsedPercent), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Used Percent Difference' FROM StorageSample SINCE 5 minutes AGO"
-      name: Disk Used Percent Difference
+    - nrql: "SELECT average(diskUsedPercent) AS 'Disk Used Percent Current' FROM StorageSample WHERE displayName = '${var.display_name_current}' SINCE 5 minutes AGO"
+      name: Disk Used Percent Current
       account: ${var.accountId}
       apiKey: ${secret.apiKey}
       nrEnv: ${var.nrEnv}
       assertions:
-        - fields: "['Disk Used Percent Difference']"
+        - fields: "['Disk Used Percent Current']"
           greater: 0.5
-    - nrql: "SELECT abs(filter(average(diskFreeBytes), WHERE displayName = '${var.display_name_current}') - filter(average(diskFreeBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Free Bytes Difference' FROM StorageSample SINCE 5 minutes AGO"
-      name: Disk Free Bytes Difference
+    - nrql: "SELECT average(diskFreeBytes) AS 'Disk Free Bytes Current' FROM StorageSample WHERE displayName = '${var.display_name_current}' SINCE 5 minutes AGO"
+      name: Disk Free Bytes Current
       account: ${var.accountId}
       apiKey: ${secret.apiKey}
       nrEnv: ${var.nrEnv}
       assertions:
-        - fields: "['Disk Free Bytes Difference']"
+        - fields: "['Disk Free Bytes Current']"
           greater: 500000000
-    - nrql: "SELECT abs(filter(average(diskFreePercent), WHERE displayName = '${var.display_name_current}') - filter(average(diskFreePercent), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Free Percent Difference' FROM StorageSample SINCE 5 minutes AGO"
-      name: Disk Free Percent Difference
+    - nrql: "SELECT average(diskFreePercent) AS 'Disk Free Percent Current' FROM StorageSample WHERE displayName = '${var.display_name_current}' SINCE 5 minutes AGO"
+      name: Disk Free Percent Current
       account: ${var.accountId}
       apiKey: ${secret.apiKey}
       nrEnv: ${var.nrEnv}
       assertions:
-        - fields: "['Disk Free Percent Difference']"
+        - fields: "['Disk Free Percent Current']"
           greater: 5
     - nrql: "SELECT abs(filter(average(diskTotalBytes), WHERE displayName = '${var.display_name_current}') - filter(average(diskTotalBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Total Bytes Difference' FROM StorageSample SINCE 5 minutes AGO"
       name: Disk Total Bytes Difference
@@ -66,35 +66,43 @@ spec:
       assertions:
         - fields: "['Disk Total Bytes Difference']"
           less: 10000
-    - nrql: "SELECT abs(filter(average(inodesUsed), WHERE displayName = '${var.display_name_current}') - filter(average(inodesUsed), WHERE displayName = '${var.display_name_previous}')) AS 'Inodes Used Difference' FROM StorageSample SINCE 5 minutes AGO"
-      name: Inodes Used Difference
+    - nrql: "SELECT average(inodesUsed) AS 'Inodes Used Current' FROM StorageSample WHERE displayName = '${var.display_name_current}' SINCE 5 minutes AGO"
+      name: Inodes Used Current
       account: ${var.accountId}
       apiKey: ${secret.apiKey}
       nrEnv: ${var.nrEnv}
       assertions:
-        - fields: "['Inodes Used Difference']"
+        - fields: "['Inodes Used Current']"
           greater: 5000
-    - nrql: "SELECT abs(filter(average(inodesFree), WHERE displayName = '${var.display_name_current}') - filter(average(inodesFree), WHERE displayName = '${var.display_name_previous}')) AS 'Inodes Free Difference' FROM StorageSample SINCE 5 minutes AGO"
-      name: Inodes Free Difference
+    - nrql: "SELECT average(inodesFree) AS 'Inodes Free Current' FROM StorageSample WHERE displayName = '${var.display_name_current} SINCE 5 minutes AGO"
+      name: Inodes Free Current
       account: ${var.accountId}
       apiKey: ${secret.apiKey}
       nrEnv: ${var.nrEnv}
       assertions:
-        - fields: "['Inodes Free Difference']"
+        - fields: "['Inodes Free Current']"
           greater: 50000
-    - nrql: "SELECT abs(filter(average(inodesTotal), WHERE displayName = '${var.display_name_current}') - filter(average(inodesTotal), WHERE displayName = '${var.display_name_previous}')) AS 'Inodes Total Difference' FROM StorageSample SINCE 5 minutes AGO"
-      name: Inodes Total Difference
+    - nrql: "SELECT average(inodesTotal) AS 'Inodes Total Current' FROM StorageSample WHERE displayName = '${var.display_name_current}' SINCE 5 minutes AGO"
+      name: Inodes Total Current
       account: ${var.accountId}
       apiKey: ${secret.apiKey}
       nrEnv: ${var.nrEnv}
       assertions:
-        - fields: "['Inodes Total Difference']"
+        - fields: "['Inodes Total Current']"
           greater: 1
-    - nrql: "SELECT abs(filter(average(inodesUsedPercent), WHERE displayName = '${var.display_name_current}') - filter(average(inodesUsedPercent), WHERE displayName = '${var.display_name_previous}')) AS 'Inodes Used Percent Difference' FROM StorageSample SINCE 5 minutes AGO"
-      name: Inodes Used Percent Difference
+    - nrql: "SELECT average(inodesUsedPercent) AS 'Inodes Used Percent Current' FROM StorageSample WHERE displayName = '${var.display_name_current}' SINCE 5 minutes AGO"
+      name: Inodes Used Percent Current
       account: ${var.accountId}
       apiKey: ${secret.apiKey}
       nrEnv: ${var.nrEnv}
       assertions:
-        - fields: "['Inodes Used Percent Difference']"
+        - fields: "['Inodes Used Percent Current']"
           greater: 0.1
+    - nrql: "SELECT abs(filter(average(systemMemoryBytes), WHERE displayName = '${var.display_name_current}') - filter(average(systemMemoryBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Memory Bytes Difference' FROM StorageSample SINCE 5 minutes AGO"
+      name: Memory Bytes Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Memory Bytes Difference']"
+          less: 50000000

--- a/test/a2q/storageSampleTests.yml
+++ b/test/a2q/storageSampleTests.yml
@@ -1,0 +1,100 @@
+apiVersion: v1
+kind: TestSuite
+metadata:
+  name: StorageSample - MELT
+  namespace: infra-agent
+  team: OHAI
+  owningTeam: OHAI
+  environment: ${var.sutEnvironment}
+  x-category: melt
+  x-period: 5m
+spec:
+  tests:
+    - nrql: "FROM StorageSample SELECT agentName WHERE displayName = '${var.display_name_current}' LIMIT 1"
+      name: Check agent name current
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "agentName"
+          equals: "Infrastructure"
+    - nrql: "FROM StorageSample SELECT agentName WHERE displayName = '${var.display_name_previous}' LIMIT 1"
+      name: Check agent name previous
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "agentName"
+          equals: "Infrastructure"
+    - nrql: "SELECT abs(filter(average(diskUsedBytes), WHERE displayName = '${var.display_name_current}') - filter(average(diskUsedBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Used Bytes Difference' FROM StorageSample SINCE 5 minutes AGO"
+      name: Disk Used Bytes Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Disk Used Bytes Difference']"
+          less: 1000000000
+    - nrql: "SELECT abs(filter(average(diskUsedPercent), WHERE displayName = '${var.display_name_current}') - filter(average(diskUsedPercent), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Used Percent Difference' FROM StorageSample SINCE 5 minutes AGO"
+      name: Disk Used Percent Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Disk Used Percent Difference']"
+          less: 0.5
+    - nrql: "SELECT abs(filter(average(diskFreeBytes), WHERE displayName = '${var.display_name_current}') - filter(average(diskFreeBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Free Bytes Difference' FROM StorageSample SINCE 5 minutes AGO"
+      name: Disk Free Bytes Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Disk Free Bytes Difference']"
+          less: 500000000
+    - nrql: "SELECT abs(filter(average(diskFreePercent), WHERE displayName = '${var.display_name_current}') - filter(average(diskFreePercent), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Free Percent Difference' FROM StorageSample SINCE 5 minutes AGO"
+      name: Disk Free Percent Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Disk Free Percent Difference']"
+          less: 5
+    - nrql: "SELECT abs(filter(average(diskTotalBytes), WHERE displayName = '${var.display_name_current}') - filter(average(diskTotalBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Total Bytes Difference' FROM StorageSample SINCE 5 minutes AGO"
+      name: Disk Total Bytes Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Disk Total Bytes Difference']"
+          greater: 10000
+    - nrql: "SELECT abs(filter(average(inodesUsed), WHERE displayName = '${var.display_name_current}') - filter(average(inodesUsed), WHERE displayName = '${var.display_name_previous}')) AS 'Inodes Used Difference' FROM StorageSample SINCE 5 minutes AGO"
+      name: Inodes Used Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Inodes Used Difference']"
+          less: 5000
+    - nrql: "SELECT abs(filter(average(inodesFree), WHERE displayName = '${var.display_name_current}') - filter(average(inodesFree), WHERE displayName = '${var.display_name_previous}')) AS 'Inodes Free Difference' FROM StorageSample SINCE 5 minutes AGO"
+      name: Inodes Free Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Inodes Free Difference']"
+          less: 50000
+    - nrql: "SELECT abs(filter(average(inodesTotal), WHERE displayName = '${var.display_name_current}') - filter(average(inodesTotal), WHERE displayName = '${var.display_name_previous}')) AS 'Inodes Total Difference' FROM StorageSample SINCE 5 minutes AGO"
+      name: Inodes Total Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Inodes Total Difference']"
+          less: 1
+    - nrql: "SELECT abs(filter(average(inodesUsedPercent), WHERE displayName = '${var.display_name_current}') - filter(average(inodesUsedPercent), WHERE displayName = '${var.display_name_previous}')) AS 'Inodes Used Percent Difference' FROM StorageSample SINCE 5 minutes AGO"
+      name: Inodes Used Percent Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Inodes Used Percent Difference']"
+          greater: 0.1


### PR DESCRIPTION
**Test command:**
java -jar build/libs/validations-core-2.0.28-standalone.jar  --json  definition.location.file=/Users/nravada/newrelic/infrastructure-agent/test/a2q/StorageSampleTests.yml result.newrelic.accountId=xxx result.newrelic.licenseKey=xxxx result.newrelic.env=stg definition.var.sutEnvironment=stg definition.var.display_name_previous=a2q_nar_agent_1.63.0 definition.var.display_name_current=a2q_nar_agent_1.63.1 definition.var.accountId=xxx definition.secret.apiKey=xxxx definition.var.nrEnv=stg

**Test results:**
2025-05-08 18:07:51,634 [main] DEBUG c.n.a2q.validations.core.LocalTest - Definition location file: /Users/nravada/newrelic/infrastructure-agent/test/a2q/StorageSampleTests.yml
2025-05-08 18:07:51,636 [main] DEBUG c.n.a2q.validations.core.LocalTest - Dynamic variable detected: sutEnvironment=stg
2025-05-08 18:07:51,636 [main] DEBUG c.n.a2q.validations.core.LocalTest - Dynamic variable detected: display_name_previous=a2q_nar_agent_1.63.0
2025-05-08 18:07:51,636 [main] DEBUG c.n.a2q.validations.core.LocalTest - Dynamic variable detected: display_name_current=a2q_nar_agent_1.63.1
2025-05-08 18:07:51,636 [main] DEBUG c.n.a2q.validations.core.LocalTest - Dynamic variable detected: accountId=1015429
2025-05-08 18:07:51,636 [main] DEBUG c.n.a2q.validations.core.LocalTest - Dynamic variable detected: nrEnv=stg
2025-05-08 18:07:51,636 [main] DEBUG c.n.a2q.validations.core.LocalTest - Secret detected: apiKey=********************************
2025-05-08 18:07:51,791 [main] DEBUG c.n.a2q.validations.core.LocalTest - Result publisher option detected: accountId=*******
2025-05-08 18:07:51,791 [main] DEBUG c.n.a2q.validations.core.LocalTest - Result publisher option detected: licenseKey=****************************************
2025-05-08 18:07:51,791 [main] DEBUG c.n.a2q.validations.core.LocalTest - Result publisher option detected: env=***
2025-05-08 18:07:51,822 [main] INFO  c.n.t.transport.BatchDataSender - BatchDataSender configured with endpoint https://staging-otlp.nr-data.net:4317/metric/v1
2025-05-08 18:07:51,823 [main] INFO  c.n.t.transport.BatchDataSender - BatchDataSender configured to use license keys
2025-05-08 18:07:51,823 [main] INFO  c.n.t.transport.BatchDataSender - BatchDataSender configured with endpoint https://staging-otlp.nr-data.net:4317/v1/accounts/events
2025-05-08 18:07:51,823 [main] INFO  c.n.t.transport.BatchDataSender - BatchDataSender configured to use license keys
2025-05-08 18:07:51,825 [main] DEBUG c.n.a.v.c.o.TestSuiteResultPublisher - Event publishers enabled: [console-json, newrelic]
2025-05-08 18:07:57,099 [tse-6aacd1a4-StorageSample - MELT] DEBUG c.n.a.v.c.o.TestSuiteResultPublisher - Failed assertion result: AssertionResult(successful=false, json={"data":{"actor":{"account":{"nrql":{"results":[{"Disk Total Bytes Difference":0.0}]}}}}}, filterCriteria=null, assertion=Assertion[field=['Disk Total Bytes Difference'], function=greater, value=10000], actualValues=[0.0], evaluatedElements=1, successfulEvaluations=0, error=AssertionError(type=ASSERTION_ERROR, description=Expected ['Disk Total Bytes Difference'] greater 10000. Actual value: 0.0))
2025-05-08 18:07:57,109 [tse-6aacd1a4-StorageSample - MELT] DEBUG c.n.a.v.c.o.TestSuiteResultPublisher - Failed assertion result: AssertionResult(successful=false, json={"data":{"actor":{"account":{"nrql":{"results":[{"Inodes Used Difference":null}]}}}}}, filterCriteria=null, assertion=Assertion[field=['Inodes Used Difference'], function=less, value=5000], actualValues=[null], evaluatedElements=1, successfulEvaluations=0, error=AssertionError(type=ASSERTION_ERROR, description=Expected ['Inodes Used Difference'] less 5000. Actual value: null))
2025-05-08 18:07:57,109 [tse-6aacd1a4-StorageSample - MELT] DEBUG c.n.a.v.c.o.TestSuiteResultPublisher - Failed assertion result: AssertionResult(successful=false, json={"data":{"actor":{"account":{"nrql":{"results":[{"Inodes Free Difference":null}]}}}}}, filterCriteria=null, assertion=Assertion[field=['Inodes Free Difference'], function=less, value=50000], actualValues=[null], evaluatedElements=1, successfulEvaluations=0, error=AssertionError(type=ASSERTION_ERROR, description=Expected ['Inodes Free Difference'] less 50000. Actual value: null))
2025-05-08 18:07:57,109 [tse-6aacd1a4-StorageSample - MELT] DEBUG c.n.a.v.c.o.TestSuiteResultPublisher - Failed assertion result: AssertionResult(successful=false, json={"data":{"actor":{"account":{"nrql":{"results":[{"Inodes Total Difference":null}]}}}}}, filterCriteria=null, assertion=Assertion[field=['Inodes Total Difference'], function=less, value=1], actualValues=[null], evaluatedElements=1, successfulEvaluations=0, error=AssertionError(type=ASSERTION_ERROR, description=Expected ['Inodes Total Difference'] less 1. Actual value: null))
{"timestamp":1746707877109,"testSuiteName":"StorageSample - MELT","duration":5214,"successful":false,"totalTests":11,"successfulTests":7,"failedTests":4,"totalAssertions":11,"successfulAssertions":7,"failedAssertions":4,"totalEvaluations":11,"successfulEvaluations":7,"failedEvaluations":4,"metadata":{"hostname":"L7TM74JFQR","a2q.environment":"test","apiVersion":"v1","x-category":"melt","a2q.version":"test","owningTeam":"OHAI","namespace":"infra-agent","runId":"6aacd1a4-1596-41b1-b6f6-28793425953c","sut.environment":"stg","x-period":"5m"},"testResults":[{"timestamp":1746707877099,"testName":"Check agent name current","duration":1025,"queryDuration":1023,"successful":true,"totalAssertions":1,"successfulAssertions":1,"failedAssertions":0,"totalEvaluations":1,"successfulEvaluations":1,"failedEvaluations":0,"assertionResults":[]},{"timestamp":1746707877099,"testName":"Check agent name previous","duration":375,"queryDuration":374,"successful":true,"totalAssertions":1,"successfulAssertions":1,"failedAssertions":0,"totalEvaluations":1,"successfulEvaluations":1,"failedEvaluations":0,"assertionResults":[]},{"timestamp":1746707877099,"testName":"Disk Used Bytes Difference","duration":423,"queryDuration":422,"successful":true,"totalAssertions":1,"successfulAssertions":1,"failedAssertions":0,"totalEvaluations":1,"successfulEvaluations":1,"failedEvaluations":0,"assertionResults":[]},{"timestamp":1746707877099,"testName":"Disk Used Percent Difference","duration":444,"queryDuration":443,"successful":true,"totalAssertions":1,"successfulAssertions":1,"failedAssertions":0,"totalEvaluations":1,"successfulEvaluations":1,"failedEvaluations":0,"assertionResults":[]},{"timestamp":1746707877099,"testName":"Disk Free Bytes Difference","duration":388,"queryDuration":387,"successful":true,"totalAssertions":1,"successfulAssertions":1,"failedAssertions":0,"totalEvaluations":1,"successfulEvaluations":1,"failedEvaluations":0,"assertionResults":[]},{"timestamp":1746707877099,"testName":"Disk Free Percent Difference","duration":613,"queryDuration":612,"successful":true,"totalAssertions":1,"successfulAssertions":1,"failedAssertions":0,"totalEvaluations":1,"successfulEvaluations":1,"failedEvaluations":0,"assertionResults":[]},{"timestamp":1746707877109,"testName":"Disk Total Bytes Difference","duration":394,"queryDuration":393,"successful":false,"totalAssertions":1,"successfulAssertions":0,"failedAssertions":1,"totalEvaluations":1,"successfulEvaluations":0,"failedEvaluations":1,"assertionResults":[{"timestamp":1746707877109,"successful":false,"filter":"","field":"['Disk Total Bytes Difference']","function":"greater","expectedValue":"10000","actualValues":"[0.0]","totalEvaluations":1,"successfulEvaluations":0,"failedEvaluations":1,"errorType":"ASSERTION_ERROR","errorMessage":"Expected ['Disk Total Bytes Difference'] greater 10000. Actual value: 0.0"}]},{"timestamp":1746707877109,"testName":"Inodes Used Difference","duration":394,"queryDuration":393,"successful":false,"totalAssertions":1,"successfulAssertions":0,"failedAssertions":1,"totalEvaluations":1,"successfulEvaluations":0,"failedEvaluations":1,"assertionResults":[{"timestamp":1746707877109,"successful":false,"filter":"","field":"['Inodes Used Difference']","function":"less","expectedValue":"5000","actualValues":"[null]","totalEvaluations":1,"successfulEvaluations":0,"failedEvaluations":1,"errorType":"ASSERTION_ERROR","errorMessage":"Expected ['Inodes Used Difference'] less 5000. Actual value: null"}]},{"timestamp":1746707877109,"testName":"Inodes Free Difference","duration":413,"queryDuration":412,"successful":false,"totalAssertions":1,"successfulAssertions":0,"failedAssertions":1,"totalEvaluations":1,"successfulEvaluations":0,"failedEvaluations":1,"assertionResults":[{"timestamp":1746707877109,"successful":false,"filter":"","field":"['Inodes Free Difference']","function":"less","expectedValue":"50000","actualValues":"[null]","totalEvaluations":1,"successfulEvaluations":0,"failedEvaluations":1,"errorType":"ASSERTION_ERROR","errorMessage":"Expected ['Inodes Free Difference'] less 50000. Actual value: null"}]},{"timestamp":1746707877109,"testName":"Inodes Total Difference","duration":367,"queryDuration":366,"successful":false,"totalAssertions":1,"successfulAssertions":0,"failedAssertions":1,"totalEvaluations":1,"successfulEvaluations":0,"failedEvaluations":1,"assertionResults":[{"timestamp":1746707877109,"successful":false,"filter":"","field":"['Inodes Total Difference']","function":"less","expectedValue":"1","actualValues":"[null]","totalEvaluations":1,"successfulEvaluations":0,"failedEvaluations":1,"errorType":"ASSERTION_ERROR","errorMessage":"Expected ['Inodes Total Difference'] less 1. Actual value: null"}]},{"timestamp":1746707877109,"testName":"Inodes Used Percent Difference","duration":378,"queryDuration":377,"successful":true,"totalAssertions":1,"successfulAssertions":1,"failedAssertions":0,"totalEvaluations":1,"successfulEvaluations":1,"failedEvaluations":0,"assertionResults":[]}]}
2025-05-08 18:07:57,127 [Thread-0] INFO  c.newrelic.telemetry.TelemetryClient - Shutting down the TelemetryClient background Executor
2025-05-08 18:07:57,127 [Thread-1] INFO  c.n.a.v.c.util.ExecutorServiceUtils - Executor service shutdown started
2025-05-08 18:07:57,127 [Thread-1] INFO  c.n.a.v.c.util.ExecutorServiceUtils - Executor service shutdown gracefully: false