### PR TITLE
A2q processsample tests

### DIFF
--- a/test/a2q/processSampleTests.yml
+++ b/test/a2q/processSampleTests.yml
@@ -1,0 +1,84 @@
+apiVersion: v1
+kind: TestSuite
+metadata:
+  name: ProcessSample - MELT
+  namespace: infra-agent
+  team: OHAI
+  owningTeam: OHAI
+  environment: ${var.sutEnvironment}
+  x-category: melt
+  x-period: 5m
+spec:
+  tests:
+    - nrql: "FROM ProcessSample SELECT agentName WHERE displayName = '${var.display_name_current}' LIMIT 1"
+      name: Check agent name current
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "agentName"
+          equals: "Infrastructure"
+    - nrql: "FROM ProcessSample SELECT agentName WHERE displayName = '${var.display_name_previous}' LIMIT 1"
+      name: Check agent name previous
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "agentName"
+          equals: "Infrastructure"
+    - nrql: "SELECT abs(filter(average(cpuPercent), WHERE displayName = '${var.display_name_current}') - filter(average(cpuPercent), WHERE displayName = '${var.display_name_previous}')) AS 'CPU Percent Difference' FROM ProcessSample SINCE 5 minutes AGO"
+      name: CPU Percent Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['CPU Percent Difference']"
+          greater: 0.3
+    - nrql: "SELECT abs(filter(average(numeric(processorCount)), WHERE displayName = '${var.display_name_current}') - filter(average(numeric(processorCount)), WHERE displayName = '${var.display_name_previous}')) AS 'Processor Count Difference' FROM ProcessSample SINCE 5 minutes AGO"
+      name: Processor Count Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Core Count Difference']"
+          greater: 7
+    - nrql: "SELECT abs(filter(average(cpuSystemPercent), WHERE displayName = '${var.display_name_current}') - filter(average(cpuSystemPercent), WHERE displayName = '${var.display_name_previous}')) AS 'CPU System Percent Difference' FROM ProcessSample SINCE 5 minutes AGO"
+      name: CPU System Percent Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['CPU System Percent Difference']"
+          greater: 0.05
+    - nrql: "SELECT abs(filter(average(cpuUserPercent), WHERE displayName = '${var.display_name_current}') - filter(average(cpuUserPercent), WHERE displayName = '${var.display_name_previous}')) AS 'CPU User Percent Difference' FROM ProcessSample SINCE 5 minutes AGO"
+      name: CPU User Percent Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['CPU User Percent Difference']"
+          greater: 0.06
+    - nrql: "SELECT abs(filter(average(ioReadBytesPerSecond), WHERE displayName = '${var.display_name_current}') - filter(average(ioReadBytesPerSecond), WHERE displayName = '${var.display_name_previous}')) AS 'IO Read Bytes PerSecond Difference' FROM ProcessSample SINCE 5 minutes AGO"
+      name: IO Read Bytes PerSecond Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['IO Read Bytes PerSecond Difference']"
+          greater: 100
+    - nrql: "SELECT abs(filter(average(ioWriteBytesPerSecond), WHERE displayName = '${var.display_name_current}') - filter(average(ioWriteBytesPerSecond), WHERE displayName = '${var.display_name_previous}')) AS 'IO Write Bytes PerSecond Difference' FROM ProcessSample SINCE 5 minutes AGO"
+      name: IO Write Bytes PerSecond Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['IO Write Bytes PerSecond Difference']"
+          greater: 100
+    - nrql: "SELECT abs(filter(average(memoryResidentSizeBytes), WHERE displayName = '${var.display_name_current}') - filter(average(memoryResidentSizeBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Memory Resident Size Bytes Difference' FROM ProcessSample SINCE 5 minutes AGO"
+      name: Memory Resident Size Bytes Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Memory Resident Size Bytes Difference']"
+          greater: 5000000

--- a/test/a2q/storageSampleTests.yml
+++ b/test/a2q/storageSampleTests.yml
@@ -1,0 +1,100 @@
+apiVersion: v1
+kind: TestSuite
+metadata:
+  name: StorageSample - MELT
+  namespace: infra-agent
+  team: OHAI
+  owningTeam: OHAI
+  environment: ${var.sutEnvironment}
+  x-category: melt
+  x-period: 5m
+spec:
+  tests:
+    - nrql: "FROM StorageSample SELECT agentName WHERE displayName = '${var.display_name_current}' LIMIT 1"
+      name: Check agent name current
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "agentName"
+          equals: "Infrastructure"
+    - nrql: "FROM StorageSample SELECT agentName WHERE displayName = '${var.display_name_previous}' LIMIT 1"
+      name: Check agent name previous
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "agentName"
+          equals: "Infrastructure"
+    - nrql: "SELECT abs(filter(average(diskUsedBytes), WHERE displayName = '${var.display_name_current}') - filter(average(diskUsedBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Used Bytes Difference' FROM StorageSample SINCE 5 minutes AGO"
+      name: Disk Used Bytes Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Disk Used Bytes Difference']"
+          less: 1000000000
+    - nrql: "SELECT abs(filter(average(diskUsedPercent), WHERE displayName = '${var.display_name_current}') - filter(average(diskUsedPercent), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Used Percent Difference' FROM StorageSample SINCE 5 minutes AGO"
+      name: Disk Used Percent Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Disk Used Percent Difference']"
+          less: 0.5
+    - nrql: "SELECT abs(filter(average(diskFreeBytes), WHERE displayName = '${var.display_name_current}') - filter(average(diskFreeBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Free Bytes Difference' FROM StorageSample SINCE 5 minutes AGO"
+      name: Disk Free Bytes Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Disk Free Bytes Difference']"
+          less: 500000000
+    - nrql: "SELECT abs(filter(average(diskFreePercent), WHERE displayName = '${var.display_name_current}') - filter(average(diskFreePercent), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Free Percent Difference' FROM StorageSample SINCE 5 minutes AGO"
+      name: Disk Free Percent Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Disk Free Percent Difference']"
+          less: 5
+    - nrql: "SELECT abs(filter(average(diskTotalBytes), WHERE displayName = '${var.display_name_current}') - filter(average(diskTotalBytes), WHERE displayName = '${var.display_name_previous}')) AS 'Disk Total Bytes Difference' FROM StorageSample SINCE 5 minutes AGO"
+      name: Disk Total Bytes Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Disk Total Bytes Difference']"
+          greater: 10000
+    - nrql: "SELECT abs(filter(average(inodesUsed), WHERE displayName = '${var.display_name_current}') - filter(average(inodesUsed), WHERE displayName = '${var.display_name_previous}')) AS 'Inodes Used Difference' FROM StorageSample SINCE 5 minutes AGO"
+      name: Inodes Used Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Inodes Used Difference']"
+          less: 5000
+    - nrql: "SELECT abs(filter(average(inodesFree), WHERE displayName = '${var.display_name_current}') - filter(average(inodesFree), WHERE displayName = '${var.display_name_previous}')) AS 'Inodes Free Difference' FROM StorageSample SINCE 5 minutes AGO"
+      name: Inodes Free Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Inodes Free Difference']"
+          less: 50000
+    - nrql: "SELECT abs(filter(average(inodesTotal), WHERE displayName = '${var.display_name_current}') - filter(average(inodesTotal), WHERE displayName = '${var.display_name_previous}')) AS 'Inodes Total Difference' FROM StorageSample SINCE 5 minutes AGO"
+      name: Inodes Total Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Inodes Total Difference']"
+          less: 1
+    - nrql: "SELECT abs(filter(average(inodesUsedPercent), WHERE displayName = '${var.display_name_current}') - filter(average(inodesUsedPercent), WHERE displayName = '${var.display_name_previous}')) AS 'Inodes Used Percent Difference' FROM StorageSample SINCE 5 minutes AGO"
+      name: Inodes Used Percent Difference
+      account: ${var.accountId}
+      apiKey: ${secret.apiKey}
+      nrEnv: ${var.nrEnv}
+      assertions:
+        - fields: "['Inodes Used Percent Difference']"
+          greater: 0.1


### PR DESCRIPTION
**Test command:**
java -jar build/libs/validations-core-2.0.28-standalone.jar  --json  definition.location.file=/Users/nravada/newrelic/infrastructure-agent/test/a2q/ProcessSampleTests.yml result.newrelic.accountId=xxx result.newrelic.licenseKey=xxxx result.newrelic.env=stg definition.var.sutEnvironment=stg definition.var.display_name_previous=a2q_nar_agent_1.63.0 definition.var.display_name_current=a2q_nar_agent_1.63.1 definition.var.accountId=xxx definition.secret.apiKey=xxxx definition.var.nrEnv=stg

**Test results:**
2025-05-08 18:06:01,648 [main] DEBUG c.n.a2q.validations.core.LocalTest - Definition location file: /Users/nravada/newrelic/infrastructure-agent/test/a2q/ProcessSampleTests.yml
2025-05-08 18:06:01,650 [main] DEBUG c.n.a2q.validations.core.LocalTest - Dynamic variable detected: sutEnvironment=stg
2025-05-08 18:06:01,650 [main] DEBUG c.n.a2q.validations.core.LocalTest - Dynamic variable detected: display_name_previous=a2q_nar_agent_1.63.0
2025-05-08 18:06:01,650 [main] DEBUG c.n.a2q.validations.core.LocalTest - Dynamic variable detected: display_name_current=a2q_nar_agent_1.63.1
2025-05-08 18:06:01,650 [main] DEBUG c.n.a2q.validations.core.LocalTest - Dynamic variable detected: accountId=1015429
2025-05-08 18:06:01,650 [main] DEBUG c.n.a2q.validations.core.LocalTest - Dynamic variable detected: nrEnv=stg
2025-05-08 18:06:01,651 [main] DEBUG c.n.a2q.validations.core.LocalTest - Secret detected: apiKey=********************************
2025-05-08 18:06:01,846 [main] DEBUG c.n.a2q.validations.core.LocalTest - Result publisher option detected: accountId=*******
2025-05-08 18:06:01,846 [main] DEBUG c.n.a2q.validations.core.LocalTest - Result publisher option detected: licenseKey=****************************************
2025-05-08 18:06:01,846 [main] DEBUG c.n.a2q.validations.core.LocalTest - Result publisher option detected: env=***
2025-05-08 18:06:01,881 [main] INFO  c.n.t.transport.BatchDataSender - BatchDataSender configured with endpoint https://staging-otlp.nr-data.net:4317/metric/v1
2025-05-08 18:06:01,881 [main] INFO  c.n.t.transport.BatchDataSender - BatchDataSender configured to use license keys
2025-05-08 18:06:01,882 [main] INFO  c.n.t.transport.BatchDataSender - BatchDataSender configured with endpoint https://staging-otlp.nr-data.net:4317/v1/accounts/events
2025-05-08 18:06:01,882 [main] INFO  c.n.t.transport.BatchDataSender - BatchDataSender configured to use license keys
2025-05-08 18:06:01,885 [main] DEBUG c.n.a.v.c.o.TestSuiteResultPublisher - Event publishers enabled: [console-json, newrelic]
2025-05-08 18:06:09,300 [tse-593e49a7-ProcessSample - MELT] DEBUG c.n.a.v.c.o.TestSuiteResultPublisher - Failed assertion result: AssertionResult(successful=false, json={"data":{"actor":{"account":{"nrql":{"results":[{"Processor Count Difference":null}]}}}}}, filterCriteria=null, assertion=Assertion[field=['Core Count Difference'], function=greater, value=7], actualValues=null, evaluatedElements=0, successfulEvaluations=0, error=AssertionError(type=ASSERTION_ERROR, description=Expected field ['Core Count Difference'] is missing))
{"timestamp":1746707769311,"testSuiteName":"ProcessSample - MELT","duration":7351,"successful":false,"totalTests":9,"successfulTests":8,"failedTests":1,"totalAssertions":9,"successfulAssertions":8,"failedAssertions":1,"totalEvaluations":8,"successfulEvaluations":8,"failedEvaluations":0,"metadata":{"a2q.environment":"test","hostname":"L7TM74JFQR","apiVersion":"v1","x-category":"melt","a2q.version":"test","owningTeam":"OHAI","namespace":"infra-agent","runId":"593e49a7-0396-432a-ae4c-e3c50dd623cd","sut.environment":"stg","x-period":"5m"},"testResults":[{"timestamp":1746707769300,"testName":"Check agent name current","duration":4087,"queryDuration":4085,"successful":true,"totalAssertions":1,"successfulAssertions":1,"failedAssertions":0,"totalEvaluations":1,"successfulEvaluations":1,"failedEvaluations":0,"assertionResults":[]},{"timestamp":1746707769300,"testName":"Check agent name previous","duration":457,"queryDuration":456,"successful":true,"totalAssertions":1,"successfulAssertions":1,"failedAssertions":0,"totalEvaluations":1,"successfulEvaluations":1,"failedEvaluations":0,"assertionResults":[]},{"timestamp":1746707769300,"testName":"CPU Percent Difference","duration":391,"queryDuration":390,"successful":true,"totalAssertions":1,"successfulAssertions":1,"failedAssertions":0,"totalEvaluations":1,"successfulEvaluations":1,"failedEvaluations":0,"assertionResults":[]},{"timestamp":1746707769311,"testName":"Processor Count Difference","duration":404,"queryDuration":403,"successful":false,"totalAssertions":1,"successfulAssertions":0,"failedAssertions":1,"totalEvaluations":0,"successfulEvaluations":0,"failedEvaluations":0,"assertionResults":[{"timestamp":1746707769311,"successful":false,"filter":"","field":"['Core Count Difference']","function":"greater","expectedValue":"7","actualValues":"","totalEvaluations":0,"successfulEvaluations":0,"failedEvaluations":0,"errorType":"ASSERTION_ERROR","errorMessage":"Expected field ['Core Count Difference'] is missing"}]},{"timestamp":1746707769311,"testName":"CPU System Percent Difference","duration":401,"queryDuration":400,"successful":true,"totalAssertions":1,"successfulAssertions":1,"failedAssertions":0,"totalEvaluations":1,"successfulEvaluations":1,"failedEvaluations":0,"assertionResults":[]},{"timestamp":1746707769311,"testName":"CPU User Percent Difference","duration":415,"queryDuration":414,"successful":true,"totalAssertions":1,"successfulAssertions":1,"failedAssertions":0,"totalEvaluations":1,"successfulEvaluations":1,"failedEvaluations":0,"assertionResults":[]},{"timestamp":1746707769311,"testName":"IO Read Bytes PerSecond Difference","duration":406,"queryDuration":405,"successful":true,"totalAssertions":1,"successfulAssertions":1,"failedAssertions":0,"totalEvaluations":1,"successfulEvaluations":1,"failedEvaluations":0,"assertionResults":[]},{"timestamp":1746707769311,"testName":"IO Write Bytes PerSecond Difference","duration":384,"queryDuration":384,"successful":true,"totalAssertions":1,"successfulAssertions":1,"failedAssertions":0,"totalEvaluations":1,"successfulEvaluations":1,"failedEvaluations":0,"assertionResults":[]},{"timestamp":1746707769311,"testName":"Memory Resident Size Bytes Difference","duration":406,"queryDuration":405,"successful":true,"totalAssertions":1,"successfulAssertions":1,"failedAssertions":0,"totalEvaluations":1,"successfulEvaluations":1,"failedEvaluations":0,"assertionResults":[]}]}
2025-05-08 18:06:09,337 [Thread-1] INFO  c.n.a.v.c.util.ExecutorServiceUtils - Executor service shutdown started
2025-05-08 18:06:09,337 [Thread-0] INFO  c.newrelic.telemetry.TelemetryClient - Shutting down the TelemetryClient background Executor
2025-05-08 18:06:09,337 [Thread-1] INFO  c.n.a.v.c.util.ExecutorServiceUtils - Executor service shutdown gracefully: false
