### PR TITLE
chore(deps): update dependency newrelic/nri-flex to v1.16.6

### DIFF
--- a/build/embed/integrations.version
+++ b/build/embed/integrations.version
@@ -1,5 +1,5 @@
 #ohi-repo-name,version
 nri-docker,v2.5.0
-nri-flex,v1.16.5
+nri-flex,v1.16.6
 nri-winservices,v1.2.0
 nri-prometheus,v2.25.0


### PR DESCRIPTION
bump nri-flex to v1.16.6 to fix the following security vulenarability 

![image](https://github.com/user-attachments/assets/e0501a19-bf8f-4e7a-a2ce-67707f5ab6d7)
