### PR TITLE
fix: GH windows runner version

### DIFF
--- a/.github/workflows/component_windows_packaging.yml
+++ b/.github/workflows/component_windows_packaging.yml
@@ -34,7 +34,7 @@ env:
 jobs:
   packaging:
     name: Create MSI & Upload into GH Release assets
-    runs-on: windows-2019
+    runs-on: windows-2025
     env:
       GOPATH: ${{ env.GOPATH }}
     defaults:

--- a/.github/workflows/prerelease_windows.yml
+++ b/.github/workflows/prerelease_windows.yml
@@ -31,7 +31,7 @@ jobs:
   # Keeping it as no component until we figure out how to pass env variables to component
   packaging:
     name: Create MSI & Upload into GH Release assets
-    runs-on: windows-2019
+    runs-on: windows-2025
     needs: [ unit-test ]
     env:
       GOPATH: ${{ github.workspace }}

--- a/.github/workflows/prerelease_windows_on_demand.yml
+++ b/.github/workflows/prerelease_windows_on_demand.yml
@@ -38,7 +38,7 @@ jobs:
   # Keeping it as no component until we figure out how to pass env variables to component
   packaging:
     name: Create MSI & Upload into GHA workflow cache
-    runs-on: windows-2019
+    runs-on: windows-2025
     strategy:
       matrix:
         goarch: [ amd64, 386 ]


### PR DESCRIPTION
- Update github runner for windows due to windows-2019 deprecated on 2025-06-30