### PR TITLE
ci: validate input tag before provisioning and running packaging tests

### DIFF
--- a/.github/workflows/prerelease_testing.yml
+++ b/.github/workflows/prerelease_testing.yml
@@ -17,10 +17,41 @@ on:
         default: true
         required: false
 
+# Added 'contents: read' to allow fetching release information
 permissions:
   id-token: write
+  contents: read
 
 jobs:
+  validate-tag:
+    name: Validate Input Tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate that tag is the latest pre-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          echo "Fetching latest pre-release tag from newrelic/infrastructure-agent..."
+
+          # Use the GitHub CLI to call the API, find all pre-releases, and get the tag_name of the very first one (the latest)
+          LATEST_PRERELEASE_TAG=$(gh api /repos/newrelic/infrastructure-agent/releases --jq 'map(select(.prerelease == true)) | .[0].tag_name')
+
+          if [ -z "$LATEST_PRERELEASE_TAG" ]; then
+            echo "Could not determine the latest pre-release tag. Please check the repository."
+            exit 1
+          fi
+
+          echo "Input tag: $INPUT_TAG"
+          echo "Latest pre-release tag: $LATEST_PRERELEASE_TAG"
+
+          if [ "$INPUT_TAG" == "$LATEST_PRERELEASE_TAG" ]; then
+            echo "Validation successful. Input tag matches the latest pre-release."
+          else
+            echo "Validation Failed: The provided tag is not the latest pre-release."
+            exit 1
+          fi
+
   test-prerelease-windows:
     if: ${{ github.event.inputs.windows == 'true' }}
     uses: ./.github/workflows/component_prerelease_testing.yml
@@ -35,6 +66,7 @@ jobs:
       CROWDSTRIKE_CUSTOMER_ID: ${{secrets.CROWDSTRIKE_CUSTOMER_ID}}
 
   test-prerelease-linux:
+    needs: validate-tag
     if: ${{ github.event.inputs.linux == 'true' }}
     uses: ./.github/workflows/component_prerelease_testing.yml
     with:


### PR DESCRIPTION
- Update the `prerelease-testing` workflow to validate the input tag.
- The input tag should be the latest pre-release tag because the workflow will run provision test in amd64, arm64 linux instances which will try to install the latest available infra-agent version from staging repo.
- Add `validate-tag` job as dependency to `test-prerelease-linux` job.

Testing details:
- Input valid tag the `validate-tag` job succeeded - https://github.com/newrelic/infrastructure-agent/actions/runs/16462116536
- Input invalid tag the `validate-tag` job failed - https://github.com/newrelic/infrastructure-agent/actions/runs/16462125404