### PR TITLE
feat: NR-442165-Write Go module framework stub for oracle cloud in infrastructure agent

### DIFF
--- a/internal/plugins/common/hostinfo_test.go
+++ b/internal/plugins/common/hostinfo_test.go
@@ -64,6 +64,18 @@ func (f *fakeHarvester) GetInstanceImageID() (string, error) {
 	return args.String(0), args.Error(1)
 }
 
+// GetInstanceDisplayName returns the cloud instance display name
+func (f *fakeHarvester) GetInstanceDisplayName() (string, error) {
+	args := f.Called()
+	return args.String(0), args.Error(1)
+}
+
+// GetInstanceTenantID returns the cloud instance tenant ID
+func (f *fakeHarvester) GetInstanceTenantID() (string, error) {
+	args := f.Called()
+	return args.String(0), args.Error(1)
+}
+
 // GetHarvester returns instance of the Harvester detected (or instance of themselves)
 func (f *fakeHarvester) GetHarvester() (cloud.Harvester, error) {
 	return f, nil

--- a/pkg/entity/host/host.go
+++ b/pkg/entity/host/host.go
@@ -43,6 +43,7 @@ func (i IDLookup) AgentShortEntityName() (string, error) {
 		sysinfo.HOST_SOURCE_AZURE_VM_ID,
 		sysinfo.HOST_SOURCE_GCP_VM_ID,
 		sysinfo.HOST_SOURCE_ALIBABA_VM_ID,
+		sysinfo.HOST_SOURCE_OCI_VM_ID,
 		sysinfo.HOST_SOURCE_DISPLAY_NAME,
 		sysinfo.HOST_SOURCE_HOSTNAME_SHORT,
 	}

--- a/pkg/sysinfo/cloud/cloud.go
+++ b/pkg/sysinfo/cloud/cloud.go
@@ -21,6 +21,7 @@ const (
 	TypeAzure      Type = "azure"       // This instance is running in Azure.
 	TypeGCP        Type = "gcp"         // This instance is running in gcp.
 	TypeAlibaba    Type = "alibaba"     // This instance is running in alibaba.
+	TypeOci        Type = "Oci"         // This instance is running in Oracle Cloud Infrastructure (OCI).
 )
 
 var dlog = log.WithComponent("CloudDetector")
@@ -34,7 +35,8 @@ func (t Type) IsValidCloud() bool {
 	return t == TypeAWS ||
 		t == TypeAzure ||
 		t == TypeGCP ||
-		t == TypeAlibaba
+		t == TypeAlibaba ||
+		t == TypeOci
 }
 
 var (
@@ -64,6 +66,10 @@ type Harvester interface {
 	GetZone() (string, error)
 	// GetInstanceImageID returns the cloud instance image ID
 	GetInstanceImageID() (string, error)
+	// GetInstanceDisplayName returns the cloud instance displayname
+	GetInstanceDisplayName() (string, error)
+	// GetInstanceTenantID returns the cloud instance tenant ID
+	GetInstanceTenantID() (string, error)
 	// GetHarvester returns instance of the Harvester detected (or instance of themselves)
 	GetHarvester() (Harvester, error)
 }
@@ -110,6 +116,9 @@ func WithProvider(cloudType Type) DetectorOption {
 		case TypeAlibaba:
 			detector.setHarvester(NewAlibabaHarvester(detector.disableKeepAlive))
 			detector.finishInit()
+		case TypeOci:
+			detector.setHarvester(NewOciHarvester(detector.disableKeepAlive))
+			detector.finishInit()
 		case TypeNoCloud:
 		case TypeInProgress:
 		default:
@@ -133,6 +142,7 @@ func (d *Detector) Initialize(opts ...DetectorOption) {
 		NewAzureHarvester(d.disableKeepAlive),
 		NewGCPHarvester(d.disableKeepAlive),
 		NewAlibabaHarvester(d.disableKeepAlive),
+		NewOciHarvester(d.disableKeepAlive),
 	}
 	d.initialize(harvesters...)
 }
@@ -239,6 +249,24 @@ func (d *Detector) GetCloudSource() string {
 		return ""
 	}
 	return cloudHarvester.GetCloudSource()
+}
+
+// GetInstanceDisplayName returns the cloud instance display name
+func (d *Detector) GetInstanceDisplayName() (string, error) {
+	cloudHarvester, err := d.GetHarvester()
+	if err != nil {
+		return "", err
+	}
+	return cloudHarvester.GetInstanceDisplayName()
+}
+
+// GetInstanceTenantID returns the cloud instance tenant ID
+func (d *Detector) GetInstanceTenantID() (string, error) {
+	cloudHarvester, err := d.GetHarvester()
+	if err != nil {
+		return "", err
+	}
+	return cloudHarvester.GetInstanceTenantID()
 }
 
 // isInitialized will check if the detector is Initialized.

--- a/pkg/sysinfo/cloud/cloud_alibaba.go
+++ b/pkg/sysinfo/cloud/cloud_alibaba.go
@@ -96,6 +96,16 @@ func (a *AlibabaHarvester) GetCloudSource() string {
 	return sysinfo.HOST_SOURCE_ALIBABA_VM_ID
 }
 
+// GetInstanceDisplayName returns the cloud instance display name (not supported for Alibaba)
+func (a *AlibabaHarvester) GetInstanceDisplayName() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetInstanceTenantID returns the cloud instance tenant ID (not supported for Alibaba)
+func (a *AlibabaHarvester) GetInstanceTenantID() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
 // GetRegion will return the cloud instance region.
 func (a *AlibabaHarvester) GetRegion() (string, error) {
 	if a.region == "" || a.timeout.HasExpired() {

--- a/pkg/sysinfo/cloud/cloud_aws.go
+++ b/pkg/sysinfo/cloud/cloud_aws.go
@@ -150,6 +150,16 @@ func (a *AWSHarvester) GetCloudSource() string {
 	return sysinfo.HOST_SOURCE_INSTANCE_ID
 }
 
+// GetInstanceDisplayName returns the cloud instance display name (not supported for AWS)
+func (a *AWSHarvester) GetInstanceDisplayName() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetInstanceTenantID returns the cloud instance tenant ID (not supported for AWS)
+func (a *AWSHarvester) GetInstanceTenantID() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
 // formatURL prepares the URL used for requesting AWS metadata.
 func formatURL(baseUrl string, query string) string {
 	return baseUrl + awsMetaDataPath + query

--- a/pkg/sysinfo/cloud/cloud_azure.go
+++ b/pkg/sysinfo/cloud/cloud_azure.go
@@ -79,6 +79,16 @@ func (a *AzureHarvester) GetCloudSource() string {
 	return sysinfo.HOST_SOURCE_AZURE_VM_ID
 }
 
+// GetInstanceDisplayName returns the cloud instance display name (not supported for Azure)
+func (a *AzureHarvester) GetInstanceDisplayName() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetInstanceTenantID returns the cloud instance tenant ID (not supported for Azure)
+func (a *AzureHarvester) GetInstanceTenantID() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
 // GetRegion will return the cloud instance region.
 func (a *AzureHarvester) GetRegion() (string, error) {
 	if a.region == "" || a.timeout.HasExpired() {

--- a/pkg/sysinfo/cloud/cloud_gcp.go
+++ b/pkg/sysinfo/cloud/cloud_gcp.go
@@ -89,6 +89,16 @@ func (gcp *GCPHarvester) GetCloudSource() string {
 	return sysinfo.HOST_SOURCE_GCP_VM_ID
 }
 
+// GetInstanceDisplayName returns the cloud instance display name (not supported for GCP)
+func (gcp *GCPHarvester) GetInstanceDisplayName() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetInstanceTenantID returns the cloud instance tenant ID (not supported for GCP)
+func (gcp *GCPHarvester) GetInstanceTenantID() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
 // GetRegion will return the cloud instance region.
 func (gcp *GCPHarvester) GetRegion() (string, error) {
 	if gcp.zone == "" || gcp.timeout.HasExpired() {

--- a/pkg/sysinfo/cloud/cloud_oci.go
+++ b/pkg/sysinfo/cloud/cloud_oci.go
@@ -1,0 +1,221 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+package cloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/newrelic/infrastructure-agent/pkg/sysinfo"
+)
+
+// Metadata sample: https://docs.microsoft.com/en-us/oci/virtual-machines/linux/instance-metadata-service?tabs=linux
+// API versions: https://learn.microsoft.com/en-us/oci/virtual-machines/windows/instance-metadata-service?tabs=windows#endpoint-categories
+
+const (
+	// OciEndpoint is the URL used for requesting Oci metadata.
+	ociEndpoint = "http://169.254.169.254/opc/v1/instance/"
+)
+
+// OciHarvester is used to fetch data from Oci api.
+type OciHarvester struct {
+	timeout          *Timeout
+	disableKeepAlive bool
+	instanceID       string // Cache the oci instance ID.
+	hostType         string // Cache the oci instance Type.
+	region           string
+	zone             string
+	subscriptionID   string
+	imageID          string
+	tenantID         string
+	displayName      string
+}
+
+// OciHarvester returns a new instance of OciHarvester.
+func NewOciHarvester(disableKeepAlive bool) *OciHarvester {
+	return &OciHarvester{
+		timeout:          NewTimeout(600),
+		disableKeepAlive: disableKeepAlive,
+	}
+}
+
+func (a *OciHarvester) GetHarvester() (Harvester, error) {
+	return a, nil
+}
+
+// GetInstanceID returns the Oci instance ID.
+func (a *OciHarvester) GetInstanceID() (string, error) {
+	//a.instanceID = "ocid1.instance.oc1.iad.anuwcljrtvlqdbycqmaxcv7d7muhpawcuwywgz6mqc7ipjyafo6dswjlmqca"
+	if a.instanceID == "" || a.timeout.HasExpired() {
+		ociMetadata, err := GetOciMetadata(a.disableKeepAlive)
+		if err != nil {
+			return "", err
+		}
+		a.instanceID = ociMetadata.VmId
+	}
+
+	return a.instanceID, nil
+}
+
+// GetHostType will return the cloud instance type.
+func (a *OciHarvester) GetHostType() (string, error) {
+	//a.hostType = "VM.Optimized3.Flex"
+	if a.hostType == "" || a.timeout.HasExpired() {
+		OciMetadata, err := GetOciMetadata(a.disableKeepAlive)
+		if err != nil {
+			return "", err
+		}
+
+		a.hostType = OciMetadata.VmSize
+	}
+
+	return a.hostType, nil
+}
+
+// GetCloudType returns the type of the cloud.
+func (a *OciHarvester) GetCloudType() Type {
+	return TypeOci
+}
+
+// GetCloudSource returns a string key which will be used as a HostSource (see host_aliases plugin).
+func (a *OciHarvester) GetCloudSource() string {
+	return sysinfo.HOST_SOURCE_OCI_VM_ID
+}
+
+// GetRegion will return the cloud instance region.
+func (a *OciHarvester) GetRegion() (string, error) {
+	//a.region = "iad"
+	if a.region == "" || a.timeout.HasExpired() {
+		ociMetadata, err := GetOciMetadata(a.disableKeepAlive)
+		if err != nil {
+			return "", err
+		}
+
+		a.region = ociMetadata.Location
+	}
+
+	return a.region, nil
+}
+
+// GetAccountID returns the cloud account
+func (a *OciHarvester) GetAccountID() (string, error) {
+	//a.subscriptionID = "ocid1.compartment.oc1..aaaaaaaad544qzjef2rhbitefrir7rekhrxn6tgc2ycms2nyzooh4nydp4uq"
+	if a.subscriptionID == "" || a.timeout.HasExpired() {
+		ociMetadata, err := GetOciMetadata(a.disableKeepAlive)
+		if err != nil {
+			return "", err
+		}
+
+		a.subscriptionID = ociMetadata.SubscriptionID
+	}
+
+	return a.subscriptionID, nil
+}
+
+// GetZone returns the cloud instance zone
+func (a *OciHarvester) GetZone() (string, error) {
+	//a.zone = "jyDh:US-ASHBURN-AD-1"
+	if a.zone == "" || a.timeout.HasExpired() {
+		ociMetadata, err := GetOciMetadata(a.disableKeepAlive)
+		if err != nil {
+			return "", err
+		}
+		a.zone = ociMetadata.Zone
+	}
+
+	return a.zone, nil
+}
+
+// GetInstanceImageID returns the cloud instance image ID
+func (a *OciHarvester) GetInstanceImageID() (string, error) {
+	//a.imageID = "ocid1.image.oc1.iad.aaaaaaaaylsmeurrokhxpgd2kg6akdd2qkuoryzauxart5ruowwgn3gpaxua"
+	if a.imageID == "" || a.timeout.HasExpired() {
+		ociMetadata, err := GetOciMetadata(a.disableKeepAlive)
+		if err != nil {
+			return "", err
+		}
+		a.imageID = ociMetadata.ImageID
+	}
+
+	return a.imageID, nil
+}
+
+// GetInstanceTenantID returns the cloud instance Tenant ID
+func (a *OciHarvester) GetInstanceTenantID() (string, error) {
+	if a.tenantID == "" || a.timeout.HasExpired() {
+		ociMetadata, err := GetOciMetadata(a.disableKeepAlive)
+		if err != nil {
+			return "", err
+		}
+		a.tenantID = ociMetadata.TenantID
+	}
+
+	return a.tenantID, nil
+}
+
+// GetInstanceDisplayName returns the cloud instance DisplayName
+func (a *OciHarvester) GetInstanceDisplayName() (string, error) {
+	if a.displayName == "" || a.timeout.HasExpired() {
+		ociMetadata, err := GetOciMetadata(a.disableKeepAlive)
+		if err != nil {
+			return "", err
+		}
+		a.displayName = ociMetadata.DisplayName
+	}
+
+	return a.displayName, nil
+}
+
+// Captures the fields we care about from the Oci metadata API
+type ociMetadata struct {
+	Location       string `json:"canonicalRegionName"`
+	VmId           string `json:"id"`
+	VmSize         string `json:"shape"`
+	SubscriptionID string `json:"compartmentId"`
+	Zone           string `json:"availabilityDomain"`
+	ImageID        string `json:"image"`
+	TenantID       string `json:"tenantId"`
+	DisplayName    string `json:"displayName"`
+}
+
+// GetOciMetadata is used to request metadata from Oci API.
+func GetOciMetadata(disableKeepAlive bool) (result *ociMetadata, err error) {
+	var request *http.Request
+	if request, err = http.NewRequest(http.MethodGet, ociEndpoint, nil); err != nil {
+		err = fmt.Errorf("unable to prepare Oci metadata request: %v", request)
+		return
+	}
+	request.Header.Add("Metadata", "true")
+
+	var response *http.Response
+	if response, err = clientWithFastTimeout(disableKeepAlive).Do(request); err != nil {
+		err = fmt.Errorf("unable to fetch Oci metadata: %s", err)
+		return
+	}
+	defer response.Body.Close()
+
+	return parseOciMetadataResponse(response)
+}
+
+// parseOciMetadataResponse is used to parse the value required from Oci response.
+func parseOciMetadataResponse(response *http.Response) (result *ociMetadata, err error) {
+	if response.StatusCode != http.StatusOK {
+		err = fmt.Errorf("cloud metadata request returned non-OK response: %d %s", response.StatusCode, response.Status)
+		return
+	}
+
+	var responseBody []byte
+	if responseBody, err = io.ReadAll(response.Body); err != nil {
+		err = fmt.Errorf("unable to read Oci metadata response body: %v", err)
+		return
+	}
+
+	if err = json.Unmarshal(responseBody, &result); err != nil {
+		err = fmt.Errorf("unable to unmarshal Oci metadata response body: %v", err)
+		return
+	}
+
+	return
+}

--- a/pkg/sysinfo/cloud/cloud_test.go
+++ b/pkg/sysinfo/cloud/cloud_test.go
@@ -30,31 +30,26 @@ func (s *CloudDetectionSuite) TestParseAWSMeta(c *C) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("i-db519dd1\n"))
-		return
 	}))
 	mux.Handle("/list", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("foo\nbar"))
-		return
 	}))
 	mux.Handle("/not200", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = w.Write([]byte("foo"))
-		return
 	}))
 	mux.Handle("/notplain", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("foo"))
-		return
 	}))
 	mux.Handle("/justgarbage", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("<html>this is some test</html>"))
-		return
 	}))
 	server := httptest.NewServer(mux)
 
@@ -296,6 +291,16 @@ func (a *MockHarvester) GetInstanceImageID() (string, error) {
 // GetZone returns the instance cloud zone.
 func (a *MockHarvester) GetZone() (string, error) {
 	return "", nil
+}
+
+// GetInstanceDisplayName returns the cloud instance display name (mock implementation)
+func (m *MockHarvester) GetInstanceDisplayName() (string, error) {
+	return "mock-display-name", nil
+}
+
+// GetInstanceTenantID returns the cloud instance tenant ID (mock implementation)
+func (m *MockHarvester) GetInstanceTenantID() (string, error) {
+	return "mock-tenant-id", nil
 }
 
 // GetHarvester returns the MockHarvester

--- a/pkg/sysinfo/types.go
+++ b/pkg/sysinfo/types.go
@@ -12,6 +12,7 @@ const (
 	HOST_SOURCE_AZURE_VM_ID    = "azure_vm_id"
 	HOST_SOURCE_GCP_VM_ID      = "gcp_vm_id"
 	HOST_SOURCE_ALIBABA_VM_ID  = "alibaba_vm_id"
+	HOST_SOURCE_OCI_VM_ID      = "oci_vm_id"
 	HOST_SOURCE_HOSTNAME       = "hostname"
 	HOST_SOURCE_HOSTNAME_SHORT = "hostname_short"
 
@@ -30,6 +31,7 @@ var (
 		HOST_SOURCE_AZURE_VM_ID,
 		HOST_SOURCE_GCP_VM_ID,
 		HOST_SOURCE_ALIBABA_VM_ID,
+		HOST_SOURCE_OCI_VM_ID,
 		HOST_SOURCE_DISPLAY_NAME,
 		HOST_SOURCE_HOSTNAME,
 	}


### PR DESCRIPTION
The Infrastructure agent code that retrieves OCI compute instance metadata and sends it to IDP.
It sends the following metadata fields to IDP:

`parsed Oci metadata: &{Location:us-ashburn-1 VmId:ocid1.instance.oc1.iad.anuwcljrtvlqdbycqmaxcv7d7muhpawcuwywgz6mqc7ipjyafo6dswjlmqca VmSize:VM.Optimized3.Flex SubscriptionID:ocid1.compartment.oc1..aaaaaaaad544qzjef2rhbitefrir7rekhrxn6tgc2ycms2nyzooh4nydp4uq Zone:jyDh:US-ASHBURN-AD-1 ImageID:ocid1.image.oc1.iad.aaaaaaaaylsmeurrokhxpgd2kg6akdd2qkuoryzauxart5ruowwgn3gpaxua TenantID:ocid1.tenancy.oc1..aaaaaaaaslaq5synueyzouxaimk3szzf66iw6od7xyiam5myn4lqhcsfu5fq DisplayName:ubunut-instance-20250722-1328}`

We can see them in the entity inspector https://infrastructure-entity-inspector.vip.cf.nr-ops.net/?guid=[ MzIzMTkyOXxJTkZSQXxOQXw4NDg4Njk2NzM0MjQzNTk4MTA5](https://infrastructure-entity-inspector.vip.cf.nr-ops.net/?guid=%20MzIzMTkyOXxJTkZSQXxOQXw4NDg4Njk2NzM0MjQzNTk4MTA5)
GUID: MzIzMTkyOXxJTkZSQXxOQXwxNDAzNzA2ODg0NjUwNzQxMjUy
…
"metadata/host_aliases": {
        ...
        "oci_vm_id": {
            "alias": "ocid1.instance.oc1.iad.anuwcljrtvlqdbycqmaxcv7d7muhpawcuwywgz6mqc7ipjyafo6dswjlmqca",
            "id": "oci_vm_id"
        }
    },
…
    "metadata/system": {
        "system": {
            ...
            "oci_account_id": "ocid1.compartment.oc1..aaaaaaaad544qzjef2rhbitefrir7rekhrxn6tgc2ycms2nyzooh4nydp4uq",
            "oci_availability_zone": "jyDh:US-ASHBURN-AD-1",
            "oci_display_name": "ubunut-instance-20250722-1328",
            "oci_image_id": "ocid1.image.oc1.iad.aaaaaaaaylsmeurrokhxpgd2kg6akdd2qkuoryzauxart5ruowwgn3gpaxua",
            "oci_region": "us-ashburn-1",
            "oci_tenant_id": "ocid1.tenancy.oc1..aaaaaaaaslaq5synueyzouxaimk3szzf66iw6od7xyiam5myn4lqhcsfu5fq",
          ...
    },