### PR TITLE
fix: Handle tag input for component_trivy workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -15,5 +15,5 @@ jobs:
     secrets:
       slack_webhook: ${{ secrets.CAOS_SLACK_WEBHOOK }}
     with:
-      tag: "${{ github.event.inputs.tag }}"
+      tag: "${{ github.event.inputs.tag  || 'latest'}}"
       severity: "CRITICAL,HIGH"


### PR DESCRIPTION
## Description

### Issue: 
Currently the trivy scanner workflow is failing because the input value of tag field is empty when triggered by scheduled run. Refer the tag value in the 1st step under inputs. ([Reference](https://github.com/newrelic/infrastructure-agent/actions/runs/18400314782/job/52427835793))
<img width="3454" height="1860" alt="image" src="https://github.com/user-attachments/assets/5b39a681-b7ed-4d56-ae01-a221f5ff8834" />


### Change in this PR:
Add tag value as `latest` when calling component_trivy workflow

