### PR TITLE
feat(jp-region): add support for jp endpoints

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2035,7 +2035,21 @@ func calculateCollectorURL(licenseKey string, staging, fedramp bool) string {
 		return defaultSecureFederalURL
 	}
 
-	return fmt.Sprintf(baseCollectorURL, urlEnvironmentPrefix(staging), urlRegionPrefix(licenseKey))
+	prefix := urlRegionPrefix(licenseKey)
+	domain := nrDomainForRegion(prefix)
+
+	return fmt.Sprintf(baseCollectorURL, urlEnvironmentPrefix(staging), prefix, domain)
+}
+
+// nrDomainForRegion returns the NR domain to use based on the URL region prefix.
+// It compares only the first two chars of prefix against newRegions, since subregions
+// (e.g. "jp01") share the same two-char base ("jp") as their parent region.
+func nrDomainForRegion(prefix string) string {
+	if len(prefix) >= 2 && strings.Contains(newRegions, prefix[:2]) {
+		return newNRDomain
+	}
+
+	return oldNRDomain
 }
 
 func calculateIdentityURL(licenseKey string, staging, fedramp bool) string {
@@ -2049,19 +2063,29 @@ func calculateIdentityURL(licenseKey string, staging, fedramp bool) string {
 }
 
 func calculateIdentityProductionURL(licenseKey string) string {
-	// only EU supported
 	if license.IsRegionEU(licenseKey) {
 		return defaultIdentityURLEu
 	}
-	return defaultIdentityURL
+
+	r := license.GetRegionForURL(licenseKey)
+	if r == "" {
+		return defaultIdentityURL
+	}
+
+	return fmt.Sprintf(baseIdentityURLRegion, r)
 }
 
 func calculateIdentityStagingURL(licenseKey string) string {
-	// only EU supported
 	if license.IsRegionEU(licenseKey) {
 		return defaultIdentityStagingURLEu
 	}
-	return defaultIdentityStagingURL
+
+	r := license.GetRegionForURL(licenseKey)
+	if r == "" {
+		return defaultIdentityStagingURL
+	}
+
+	return fmt.Sprintf(baseIdentityStagingURLRegion, r)
 }
 
 func calculateCmdChannelURL(licenseKey string, staging, fedramp bool) string {
@@ -2075,19 +2099,29 @@ func calculateCmdChannelURL(licenseKey string, staging, fedramp bool) string {
 }
 
 func calculateCmdChannelProductionURL(licenseKey string) string {
-	// only EU supported
 	if license.IsRegionEU(licenseKey) {
 		return defaultCmdChannelURLEu
 	}
-	return defaultCmdChannelURL
+
+	r := license.GetRegionForURL(licenseKey)
+	if r == "" {
+		return defaultCmdChannelURL
+	}
+
+	return fmt.Sprintf(baseCmdChannelURLRegion, r)
 }
 
 func calculateCmdChannelStagingURL(licenseKey string) string {
-	// only EU supported
 	if license.IsRegionEU(licenseKey) {
 		return defaultCmdChannelStagingURLEu
 	}
-	return defaultCmdChannelStagingURL
+
+	r := license.GetRegionForURL(licenseKey)
+	if r == "" {
+		return defaultCmdChannelStagingURL
+	}
+
+	return fmt.Sprintf(baseCmdChannelStagingURLRegion, r)
 }
 
 func calculateSelfInstrumentationApmHost(licenseKey string, staging bool, fedramp bool) string {
@@ -2097,15 +2131,21 @@ func calculateSelfInstrumentationApmHost(licenseKey string, staging bool, fedram
 	if fedramp {
 		return defaultSecureFederalAPMCollectorHost
 	}
+
 	return calculateSelfInstrumentationApmProductionHost(licenseKey)
 }
 
 func calculateSelfInstrumentationApmProductionHost(licenseKey string) string {
-	// only EU supported
 	if license.IsRegionEU(licenseKey) {
 		return defaultAPMCollectorHostEu
 	}
-	return defaultAPMCollectorHost
+
+	r := license.GetRegionForURL(licenseKey)
+	if r == "" {
+		return defaultAPMCollectorHost
+	}
+
+	return fmt.Sprintf(baseAPMCollectorHostRegion, r)
 }
 
 func calculateDimensionalMetricURL(collectorURL string, licenseKey string, staging, fedramp bool) string {
@@ -2117,7 +2157,10 @@ func calculateDimensionalMetricURL(collectorURL string, licenseKey string, stagi
 		return defaultSecureFederalMetricURL
 	}
 
-	return fmt.Sprintf(baseDimensionalMetricURL, urlEnvironmentPrefix(staging), urlRegionPrefix(licenseKey))
+	prefix := urlRegionPrefix(licenseKey)
+	domain := nrDomainForRegion(prefix)
+
+	return fmt.Sprintf(baseDimensionalMetricURL, urlEnvironmentPrefix(staging), prefix, domain)
 }
 
 func urlEnvironmentPrefix(staging bool) string {
@@ -2128,11 +2171,18 @@ func urlEnvironmentPrefix(staging bool) string {
 }
 
 func urlRegionPrefix(licenseKey string) string {
+	// leaving this to not change anything for EU, will have to be optimised when we have clarity for
+	// all the regions.
 	if license.IsRegionEU(licenseKey) {
 		return "eu."
 	}
 
-	return ""
+	r := license.GetRegionForURL(licenseKey)
+	if r == "" {
+		return ""
+	}
+
+	return r + "."
 }
 
 func NormalizeConfig(cfg *Config, cfgMetadata config_loader.YAMLMetadata) (err error) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -43,7 +43,7 @@ http:
   headers:
     "test-key": "test-value"
 `
-	f, err := ioutil.TempFile("", "opsmatic_config_test")
+	f, err := os.CreateTemp("", "opsmatic_config_test")
 	c.Assert(err, IsNil)
 	f.WriteString(config)
 	f.Close()
@@ -106,7 +106,7 @@ collector_url:  http://foo.bar
 license_key: `
 	for _, test := range keyTest {
 		finalConfig := fmt.Sprintf("%s%s", config, test.inputKey)
-		f, err := ioutil.TempFile("", "opsmatic_config_test")
+		f, err := os.CreateTemp("", "opsmatic_config_test")
 		c.Assert(err, IsNil)
 		f.WriteString(finalConfig)
 		f.Close()
@@ -194,7 +194,7 @@ proxy_config_plugin: false
 trunc_text_values: false
 verbose: 4
 `
-	f, err := ioutil.TempFile("", "yaml_config_test")
+	f, err := os.CreateTemp("", "yaml_config_test")
 	c.Assert(err, IsNil)
 	f.WriteString(configStr)
 	f.Close()
@@ -247,6 +247,7 @@ license_key: abc123
 	c.Assert(cfg.Log.File, Equals, "agent.log")
 }
 
+//nolint:varnamelen
 func (s *ConfigSuite) TestWrongFormatDurations(c *C) {
 	// Given wrong duration format
 	configStr := `
@@ -254,7 +255,7 @@ license_key: abc123
 startup_connection_timeout: a duck
 startup_connection_retry_time: cow and pineapples
 `
-	f, err := ioutil.TempFile("", "wrong_yaml_config_test")
+	f, err := os.CreateTemp("", "wrong_yaml_config_test")
 	c.Assert(err, IsNil)
 	f.WriteString(configStr)
 	f.Close()
@@ -389,10 +390,24 @@ func (s *ConfigSuite) TestCalculateCollectorURL(c *C) {
 		{license: "0123456789012345678901234567890123456789", expectURL: "https://infra-api.newrelic.com", staging: false, fedramp: false},
 		// non-region license, staging true
 		{license: "0123456789012345678901234567890123456789", expectURL: "https://staging-infra-api.newrelic.com", staging: true, fedramp: false},
-		// four letter region
+		// two letter region eu
 		{license: "eu01xx6789012345678901234567890123456789", expectURL: "https://infra-api.eu.newrelic.com", staging: false, fedramp: false},
-		// four letter region
+		// two letter region eu, staging
 		{license: "eu01xx6789012345678901234567890123456789", expectURL: "https://staging-infra-api.eu.newrelic.com", staging: true, fedramp: false},
+		// two letter region jp
+		{
+			license:   "jpxxxx6789012345678901234567890123456789",
+			expectURL: "https://infra-api.jp.nr-data.net",
+			staging:   false,
+			fedramp:   false,
+		},
+		// two letter region jp, staging
+		{
+			license:   "jpxxxx6789012345678901234567890123456789",
+			expectURL: "https://staging-infra-api.jp.nr-data.net",
+			staging:   true,
+			fedramp:   false,
+		},
 		// non-region license, fedramp true
 		{license: "0123456789012345678901234567890123456789", expectURL: "https://gov-infra-api.newrelic.com", staging: false, fedramp: true},
 	}
@@ -445,6 +460,22 @@ func (s *ConfigSuite) TestCalculateDimensionalMetricURL(c *C) {
 			"https://staging-metric-api.eu.newrelic.com",
 		},
 		{
+			"Default URL, jp license region, no collector URL",
+			"jpxxxx6789012345678901234567890123456789",
+			"",
+			false,
+			false,
+			"https://metric-api.jp.nr-data.net",
+		},
+		{
+			"Staging URL, jp license region, no collector URL",
+			"jpxxxx6789012345678901234567890123456789",
+			"",
+			true,
+			false,
+			"https://staging-metric-api.jp.nr-data.net",
+		},
+		{
 			"Default URL, fedramp flag, no collector URL",
 			"0123456789012345678901234567890123456789",
 			"",
@@ -468,6 +499,7 @@ func (s *ConfigSuite) TestCalculateDimensionalMetricURL(c *C) {
 	}
 }
 
+//nolint:exhaustruct
 func (s *ConfigSuite) TestCalculateIdentityURL(c *C) {
 	testcases := []struct {
 		license   string
@@ -483,6 +515,18 @@ func (s *ConfigSuite) TestCalculateIdentityURL(c *C) {
 		{license: "eu01xx6789012345678901234567890123456789", expectURL: defaultIdentityURLEu, staging: false},
 		// four letter region
 		{license: "eu01xx6789012345678901234567890123456789", expectURL: defaultIdentityStagingURLEu, staging: true},
+		// two letter region jp
+		{
+			license:   "jpxxxx6789012345678901234567890123456789",
+			expectURL: fmt.Sprintf(baseIdentityURLRegion, "jp"),
+			staging:   false, fedramp: false,
+		},
+		// two letter region jp, staging
+		{
+			license:   "jpxxxx6789012345678901234567890123456789",
+			expectURL: fmt.Sprintf(baseIdentityStagingURLRegion, "jp"),
+			staging:   true, fedramp: false,
+		},
 		// five letter region
 		{license: "gov01x6789012345678901234567890123456789", expectURL: defaultIdentityURL, staging: false},
 		// five letter region
@@ -496,6 +540,7 @@ func (s *ConfigSuite) TestCalculateIdentityURL(c *C) {
 	}
 }
 
+//nolint:exhaustruct
 func (s *ConfigSuite) TestCalculateCmdChannelURL(c *C) {
 	testcases := []struct {
 		license   string
@@ -511,6 +556,18 @@ func (s *ConfigSuite) TestCalculateCmdChannelURL(c *C) {
 		{license: "eu01xx6789012345678901234567890123456789", expectURL: defaultCmdChannelURLEu, staging: false},
 		// four letter region
 		{license: "eu01xx6789012345678901234567890123456789", expectURL: defaultCmdChannelStagingURLEu, staging: true},
+		// two letter region jp
+		{
+			license:   "jpxxxx6789012345678901234567890123456789",
+			expectURL: fmt.Sprintf(baseCmdChannelURLRegion, "jp"),
+			staging:   false, fedramp: false,
+		},
+		// two letter region jp, staging
+		{
+			license:   "jpxxxx6789012345678901234567890123456789",
+			expectURL: fmt.Sprintf(baseCmdChannelStagingURLRegion, "jp"),
+			staging:   true, fedramp: false,
+		},
 		// five letter region
 		{license: "gov01x6789012345678901234567890123456789", expectURL: defaultCmdChannelURL, staging: false},
 		// five letter region
@@ -604,6 +661,7 @@ func TestConfig_SetBoolValueByYamlAttribute(t *testing.T) {
 	assert.Error(t, c.SetBoolValueByYamlAttribute("no_a_value", false))
 }
 
+//nolint:varnamelen
 func (s *ConfigSuite) Test_ParseIncludeMatchingRules(c *C) {
 	config := `
 license_key: test
@@ -614,7 +672,7 @@ include_matching_metrics:
   process.executable:
     - regex "^some-process" 
 `
-	f, err := ioutil.TempFile("", "include_matching_rules_config_test")
+	f, err := os.CreateTemp("", "include_matching_rules_config_test")
 	c.Assert(err, IsNil)
 	_, err = f.WriteString(config)
 	c.Assert(err, IsNil)
@@ -1162,7 +1220,7 @@ license_key: "xxx"
 }
 
 func createTestFile(data []byte) (*os.File, error) {
-	tmp, err := ioutil.TempFile("", "loadconfig")
+	tmp, err := os.CreateTemp("", "loadconfig")
 	if err != nil {
 		return nil, err
 	}
@@ -1172,4 +1230,27 @@ func createTestFile(data []byte) (*os.File, error) {
 	}
 	tmp.Close()
 	return tmp, nil
+}
+
+func TestNrDomainForRegion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		prefix string
+		want   string
+	}{
+		{"empty prefix (US)", "", oldNRDomain},
+		{"eu region", "eu.", oldNRDomain},
+		{"jp region", "jp.", newNRDomain},
+		{"jp subregion jp01", "jp01.", newNRDomain},
+		{"single char prefix", "j", oldNRDomain},
+	}
+	for _, tc := range cases {
+		testCase := tc
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, nrDomainForRegion(tc.prefix))
+		})
+	}
 }

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -21,8 +21,8 @@ const (
 	defaultCmdChannelStagingURL          = "https://staging-infrastructure-command-api.newrelic.com"
 	defaultIdentityURL                   = "https://identity-api.newrelic.com"
 	defaultIdentityStagingURL            = "https://staging-identity-api.newrelic.com"
-	baseCollectorURL                     = "https://%sinfra-api.%snewrelic.com"
-	baseDimensionalMetricURL             = "https://%smetric-api.%snewrelic.com"
+	baseCollectorURL                     = "https://%sinfra-api.%s%s"
+	baseDimensionalMetricURL             = "https://%smetric-api.%s%s"
 	defaultSecureFederalURL              = "https://gov-infra-api.newrelic.com"
 	defaultSecureFederalMetricURL        = "https://gov-metric-api.newrelic.com"
 	defaultSecureFedralIdentityURL       = "https://gov-identity-api.newrelic.com"
@@ -31,6 +31,14 @@ const (
 	defaultAPMCollectorHostEu            = "collector.eu.newrelic.com"
 	defaultSecureFederalAPMCollectorHost = "gov-collector.newrelic.com"
 	defaultAPMCollectorHostStaging       = "staging-collector.newrelic.com"
+	baseIdentityURLRegion                = "https://identity-api.%s.nr-data.net"
+	baseIdentityStagingURLRegion         = "https://staging-identity-api.%s.nr-data.net"
+	baseCmdChannelURLRegion              = "https://infrastructure-command-api.%s.nr-data.net"
+	baseCmdChannelStagingURLRegion       = "https://staging-infrastructure-command-api.%s.nr-data.net"
+	baseAPMCollectorHostRegion           = "collector.%s.nr-data.net"
+	newRegions                           = "jp" // add new regions to the same string e.g. "jp,in"
+	newNRDomain                          = "nr-data.net"
+	oldNRDomain                          = "newrelic.com"
 )
 
 // Default configurable values

--- a/pkg/integrations/v4/logs/cfg.go
+++ b/pkg/integrations/v4/logs/cfg.go
@@ -23,6 +23,7 @@ var cfgLogger = log.WithComponent("integrations.Supervisor.Config").WithField("p
 // FluentBit default values.
 const (
 	euEndpoint              = "https://log-api.eu.newrelic.com/log/v1"
+	baseEndpointRegion      = "https://log-api.%s.nr-data.net/log/v1"
 	fedrampEndpoint         = "https://gov-log-api.newrelic.com/log/v1"
 	stagingEndpoint         = "https://staging-log-api.newrelic.com/log/v1"
 	logRecordModifierSource = "nri-agent"
@@ -759,6 +760,8 @@ func newNROutput(cfg *config.LogForward) FBCfgOutput {
 
 	if license.IsRegionEU(cfg.License) {
 		ret.Endpoint = euEndpoint
+	} else if r := license.GetRegionForURL(cfg.License); r != "" {
+		ret.Endpoint = fmt.Sprintf(baseEndpointRegion, r)
 	}
 
 	return ret

--- a/pkg/integrations/v4/logs/cfg_test.go
+++ b/pkg/integrations/v4/logs/cfg_test.go
@@ -5,6 +5,7 @@
 package logs
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"runtime"
@@ -77,15 +78,51 @@ var outputBlock = FBCfgOutput{
 	HTTPClientTimeout: "10",
 }
 
+func TestNewNROutput_JPRegion(t *testing.T) {
+	cfg := &config.LogForward{
+		License: "jpxxxx6789012345678901234567890123456789",
+	}
+
+	output := newNROutput(cfg)
+
+	assert.Equal(t, fmt.Sprintf(baseEndpointRegion, "jp"), output.Endpoint)
+}
+
+func TestNewNROutput_EURegion(t *testing.T) {
+	cfg := &config.LogForward{
+		License: "eu01xx6789012345678901234567890123456789",
+	}
+
+	output := newNROutput(cfg)
+
+	assert.Equal(t, euEndpoint, output.Endpoint)
+}
+
+func TestNewNROutput_USRegion(t *testing.T) {
+	cfg := &config.LogForward{
+		License: "0123456789012345678901234567890123456789",
+	}
+
+	output := newNROutput(cfg)
+
+	assert.Empty(t, output.Endpoint)
+}
+
 func TestNewFBConf(t *testing.T) {
 	outputBlockFedramp := outputBlock
 	outputBlockFedramp.Endpoint = fedrampEndpoint
+	outputBlockJP := outputBlock
+	outputBlockJP.LicenseKey = "jpxxxx6789012345678901234567890123456789"
+	outputBlockJP.Endpoint = fmt.Sprintf(baseEndpointRegion, "jp")
 	outputBlockMultipleRetries := outputBlock
 
 	logFwdCfgMultipleRetries := logFwdCfg
 	logFwdCfgMultipleRetries.RetryLimit = "4"
 	outputBlockMultipleRetries.Retry_Limit = "4"
 	outputBlockMultipleRetries.HTTPClientTimeout = "10"
+
+	logFwdCfgJP := logFwdCfg
+	logFwdCfgJP.License = "jpxxxx6789012345678901234567890123456789"
 
 	tests := []struct {
 		name   string
@@ -172,6 +209,30 @@ func TestNewFBConf(t *testing.T) {
 				filterEntityBlock,
 			},
 			Output: outputBlockFedramp,
+		}},
+		{"single input jp", logFwdCfgJP, LogsCfg{
+			{
+				Name: "log-file",
+				File: "file.path",
+			},
+		}, FBCfg{
+			Inputs: []FBCfgInput{
+				{
+					Name:           "tail",
+					Tag:            "log-file",
+					DB:             dbDbPath,
+					Path:           "file.path",
+					BufferMaxSize:  "128k",
+					MemBufferLimit: "16384k",
+					SkipLongLines:  "On",
+					PathKey:        "filePath",
+				},
+			},
+			Filters: []FBCfgFilter{
+				inputRecordModifier("tail", "log-file"),
+				filterEntityBlock,
+			},
+			Output: outputBlockJP,
 		}},
 		{"input file + filter", logFwdCfg, LogsCfg{
 			{

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -4,12 +4,14 @@ package license
 
 import (
 	"regexp"
+	"strings"
 )
 
 var (
 	// We get our license from APM's Agent Key generator
 	licenseRegex       = regexp.MustCompile("^[[:alnum:]]+$")
 	regionLicenseRegex = regexp.MustCompile(`^([a-z]{2,3})`)
+	regionKeyRegex     = regexp.MustCompile(`^.+?x`)
 )
 
 // IsValid return true if license is in valid format.
@@ -20,10 +22,10 @@ func IsValid(licenseKey string) bool {
 // IsRegionEU returns true if license region is EU.
 func IsRegionEU(license string) bool {
 	r := GetRegion(license)
-	// only EU supported
 	if len(r) > 1 && r[:2] == "eu" {
 		return true
 	}
+
 	return false
 }
 
@@ -36,6 +38,34 @@ func IsFederalCompliance(licenseKey string) bool {
 	}
 
 	return false
+}
+
+// GetRegionForURL returns the region for constructing region-aware URLs.
+// Returns empty for US (default) or federal compliance licenses.
+// Following Protocol 15+, only region-aware keys contain 'x' (not a valid hex digit),
+// so we use its presence as the discriminator.
+func GetRegionForURL(licenseKey string) string {
+	if !strings.ContainsRune(licenseKey, 'x') || IsFederalCompliance(licenseKey) {
+		return ""
+	}
+
+	return GetRegionPrefix(licenseKey)
+}
+
+// GetRegionPrefix extracts the region prefix by applying the ^.+?x regex then stripping
+// all trailing 'x' characters. For example: "jpxx..." → "jpx" → "jp".
+func GetRegionPrefix(licenseKey string) string {
+	match := regionKeyRegex.FindString(licenseKey)
+	if match == "" {
+		return ""
+	}
+
+	return strings.TrimRight(match, "x")
+}
+
+// IsRegionJP returns true if license region is JP.
+func IsRegionJP(licenseKey string) bool {
+	return strings.HasPrefix(GetRegionPrefix(licenseKey), "jp")
 }
 
 // GetRegion returns license region or empty if none.

--- a/pkg/license/license_test.go
+++ b/pkg/license/license_test.go
@@ -4,19 +4,49 @@
 package license
 
 import (
-	"gotest.tools/assert"
 	"testing"
+
+	"gotest.tools/assert"
 )
 
 const (
-	basic = "0123456789012345678901234567890123456789"
-	eu    = "eu01xx6789012345678901234567890123456789"
+	basic     = "0123456789012345678901234567890123456789"
+	euLicense = "eu01xx6789012345678901234567890123456789"
+	jpLicense = "jpxxxx6789012345678901234567890123456789"
 )
 
 func TestLicense_GetRegion(t *testing.T) {
 	region := GetRegion(basic)
 	assert.Equal(t, region, "")
 
-	region = GetRegion(eu)
+	region = GetRegion(euLicense)
 	assert.Equal(t, region, "eu")
+}
+
+func TestLicense_GetRegionPrefix(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		key      string
+		expected string
+	}{
+		{"basic key has no x", basic, ""},
+		{"eu key", euLicense, "eu01"}, // eu still uses old logic, no change, doesn't flow through this func.
+		{"jp key", jpLicense, "jp"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, GetRegionPrefix(tc.key))
+		})
+	}
+}
+
+func TestLicense_IsRegionJP(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, false, IsRegionJP(basic))
+	assert.Equal(t, false, IsRegionJP(euLicense))
+	assert.Equal(t, true, IsRegionJP(jpLicense))
 }


### PR DESCRIPTION
## What?
Support JP endpoints while not changing any existing behaviour. We might have additional changes needed for JP, but we want to merge and check that we don't break any existing (US, EU, Gov) experience.
Will have additional patches for JP after testing (if needed).

## Why?
Needed for JP region right now, and for new regions in the future.
JP uses new domain - `nr-data.net`, different from old domain - `newrelic.com`