### PR TITLE
feat: Add ZSTD compression support for Fluent Bit log forwarding

### DIFF
--- a/cmd/newrelic-infra/newrelic-infra.go
+++ b/cmd/newrelic-infra/newrelic-infra.go
@@ -470,7 +470,8 @@ func initializeAgentAndRun(c *config.Config, logFwCfg config.LogForward) error {
 	)
 
 	if fbIntCfg.IsLogForwarderAvailable() {
-		logCfgLoader := logs.NewFolderLoader(logFwCfg, agt.Context.Identity, agt.Context.HostnameResolver())
+		useZstdCompression, _ := ffManager.GetFeatureFlag(fflag.FlagFluentBitZstdCompression)
+		logCfgLoader := logs.NewFolderLoader(logFwCfg, agt.Context.Identity, agt.Context.HostnameResolver(), useZstdCompression)
 		logSupervisor := v4.NewFBSupervisor(
 			fbIntCfg,
 			logCfgLoader,

--- a/cmd/newrelic-infra/newrelic-infra.go
+++ b/cmd/newrelic-infra/newrelic-infra.go
@@ -470,7 +470,11 @@ func initializeAgentAndRun(c *config.Config, logFwCfg config.LogForward) error {
 	)
 
 	if fbIntCfg.IsLogForwarderAvailable() {
-		useZstdCompression, _ := ffManager.GetFeatureFlag(fflag.FlagFluentBitZstdCompression)
+		useZstdCompression, exists := ffManager.GetFeatureFlag(fflag.FlagFluentBitZstdCompression)
+		if !exists {
+			alog.Error("could not retrieve feature flag status for ZSTD compression, defaulting to GZIP compression")
+			useZstdCompression = false
+		}
 		logCfgLoader := logs.NewFolderLoader(logFwCfg, agt.Context.Identity, agt.Context.HostnameResolver(), useZstdCompression)
 		logSupervisor := v4.NewFBSupervisor(
 			fbIntCfg,

--- a/internal/agent/cmdchannel/fflag/ffhandler.go
+++ b/internal/agent/cmdchannel/fflag/ffhandler.go
@@ -23,11 +23,12 @@ const (
 	FlagParallelizeInventory  = "parallelize_inventory_enabled"
 	FlagAsyncInventoryHandler = "async_inventory_handler_enabled"
 
-	FlagProtocolV4            = "protocol_v4_enabled"
-	FlagFullProcess           = "full_process_sampling"
-	FlagDmRegisterDeprecated  = "dm_register_deprecated"
-	FlagFluentBit19           = "fluent_bit_19_win"
-	FlagFullInventoryDeletion = "full_inventory_deletion"
+	FlagProtocolV4               = "protocol_v4_enabled"
+	FlagFullProcess              = "full_process_sampling"
+	FlagDmRegisterDeprecated     = "dm_register_deprecated"
+	FlagFluentBit19              = "fluent_bit_19_win"
+	FlagFullInventoryDeletion    = "full_inventory_deletion"
+	FlagFluentBitZstdCompression = "fluent_bit_zstd_compression_enabled"
 	// Config
 	CfgYmlRegisterEnabled              = "register_enabled"
 	CfgYmlParallelizeInventory         = "inventory_queue_len"
@@ -152,6 +153,12 @@ func (h *handler) Handle(ctx context.Context, c commandapi.Command, isInitialFet
 	}
 
 	if ffArgs.Flag == FlagFluentBit19 {
+		h.handleFBRestart(ffArgs)
+
+		return
+	}
+
+	if ffArgs.Flag == FlagFluentBitZstdCompression {
 		h.handleFBRestart(ffArgs)
 
 		return

--- a/pkg/integrations/v4/logs/cfg.go
+++ b/pkg/integrations/v4/logs/cfg.go
@@ -32,6 +32,12 @@ const (
 	fluentBitDbName         = "fb.db"
 )
 
+// newrelic-fluent-bit-output plugin supported compression algorithms
+const (
+	compressionGzip = "gzip"
+	compressionZstd = "zstd"
+)
+
 // FluentBit INPUT plugin types
 const (
 	fbInputTypeTail      = "tail"
@@ -239,6 +245,7 @@ type FBCfgOutput struct {
 	Retry_Limit       string
 	HTTPClientTimeout string
 	SendMetrics       bool
+	Compression       string // compression algorithm: "gzip" or "zstd"
 }
 
 type FBWinlogLuaScript struct {
@@ -274,7 +281,7 @@ type FBOSConfig struct {
 }
 
 // NewFBConf creates a FluentBit config from several logging integration configs.
-func NewFBConf(loggingCfgs LogsCfg, logFwdCfg *config.LogForward, entityGUID, hostname string) (fb FBCfg, e error) {
+func NewFBConf(loggingCfgs LogsCfg, logFwdCfg *config.LogForward, entityGUID, hostname string, useZstdCompression bool) (fb FBCfg, e error) {
 	fb = FBCfg{
 		Inputs:  []FBCfgInput{},
 		Filters: []FBCfgFilter{},
@@ -339,7 +346,7 @@ func NewFBConf(loggingCfgs LogsCfg, logFwdCfg *config.LogForward, entityGUID, ho
 	})
 
 	// Newrelic OUTPUT plugin will send all the collected logs to Vortex
-	fb.Output = newNROutput(logFwdCfg)
+	fb.Output = newNROutput(logFwdCfg, useZstdCompression)
 
 	return
 }
@@ -724,7 +731,12 @@ func newModifyFilter(tag string) FBCfgFilter {
 	}
 }
 
-func newNROutput(cfg *config.LogForward) FBCfgOutput {
+func newNROutput(cfg *config.LogForward, useZstdCompression bool) FBCfgOutput {
+	compression := compressionGzip
+	if useZstdCompression {
+		compression = compressionZstd
+	}
+
 	ret := FBCfgOutput{
 		Name:              "newrelic",
 		Match:             "*",
@@ -737,6 +749,7 @@ func newNROutput(cfg *config.LogForward) FBCfgOutput {
 		Retry_Limit:       cfg.RetryLimit,
 		HTTPClientTimeout: cfg.HTTPClientTimeout,
 		SendMetrics:       cfg.FluentBitVerbose,
+		Compression:       compression,
 	}
 
 	if cfg.IsStaging {

--- a/pkg/integrations/v4/logs/cfg.go
+++ b/pkg/integrations/v4/logs/cfg.go
@@ -735,6 +735,9 @@ func newNROutput(cfg *config.LogForward, useZstdCompression bool) FBCfgOutput {
 	compression := compressionGzip
 	if useZstdCompression {
 		compression = compressionZstd
+		cfgLogger.Debug("Fluent Bit configured with ZSTD compression")
+	} else {
+		cfgLogger.Debug("Fluent Bit configured with GZIP compression (default)")
 	}
 
 	ret := FBCfgOutput{

--- a/pkg/integrations/v4/logs/cfg_template.go
+++ b/pkg/integrations/v4/logs/cfg_template.go
@@ -139,6 +139,9 @@ var fbConfigFormat = `{{- range .Inputs }}
     {{- if .Output.SendMetrics}}
     sendMetrics         {{ .Output.SendMetrics}}
     {{- end}}
+    {{- if .Output.Compression}}
+    compression         {{ .Output.Compression}}
+    {{- end}}
 {{ end -}}
 
 {{- if .ExternalCfg.CfgFilePath }}

--- a/pkg/integrations/v4/logs/cfg_test.go
+++ b/pkg/integrations/v4/logs/cfg_test.go
@@ -73,6 +73,7 @@ var outputBlock = FBCfgOutput{
 	ValidateCerts:     true,
 	Retry_Limit:       "5",
 	HTTPClientTimeout: "10",
+	Compression:       "gzip",
 }
 
 func TestNewFBConf(t *testing.T) {
@@ -704,9 +705,50 @@ func TestNewFBConf(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fbConf, err := NewFBConf(tt.ohiCfg, &tt.logFwd, "0", "")
+			fbConf, err := NewFBConf(tt.ohiCfg, &tt.logFwd, "0", "", false)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, fbConf)
+		})
+	}
+}
+
+func TestNewFBConf_ZstdCompression(t *testing.T) {
+	tests := []struct {
+		name                string
+		useZstdCompression  bool
+		expectedCompression string
+	}{
+		{
+			name:                "gzip compression when feature flag disabled",
+			useZstdCompression:  false,
+			expectedCompression: "gzip",
+		},
+		{
+			name:                "zstd compression when feature flag enabled",
+			useZstdCompression:  true,
+			expectedCompression: "zstd",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logsCfg := LogsCfg{
+				{
+					Name: "test-log",
+					File: "/var/log/test.log",
+				},
+			}
+
+			fbConf, err := NewFBConf(logsCfg, &logFwdCfg, "test-guid", "test-host", tt.useZstdCompression)
+			assert.NoError(t, err)
+			assert.NotNil(t, fbConf.Output)
+			assert.Equal(t, tt.expectedCompression, fbConf.Output.Compression)
+
+			// Verify compression is included in formatted output
+			formatted, _, err := fbConf.Format()
+			assert.NoError(t, err)
+			assert.Contains(t, formatted, "compression")
+			assert.Contains(t, formatted, tt.expectedCompression)
 		})
 	}
 }
@@ -870,7 +912,7 @@ func TestFBConfigForWinlog(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			fbConf, err := NewFBConf(test.logsCfg, &logFwdCfg, "0", "")
+			fbConf, err := NewFBConf(test.logsCfg, &logFwdCfg, "0", "", false)
 			assert.NoError(t, err)
 			assert.Equal(t, test.expected.Inputs, fbConf.Inputs)
 			assert.Equal(t, test.expected.Filters[0], fbConf.Filters[0])
@@ -1041,7 +1083,7 @@ func TestFBConfigForWinevtlog(t *testing.T) {
 
 		t.Run(testItem.name, func(t *testing.T) {
 			t.Parallel()
-			fbConf, err := NewFBConf(test.logsCfg, &test.logFwd, "0", "")
+			fbConf, err := NewFBConf(test.logsCfg, &test.logFwd, "0", "", false)
 			assert.NoError(t, err)
 			assert.Equal(t, test.expected.Inputs, fbConf.Inputs)
 			assert.Equal(t, test.expected.Filters[0], fbConf.Filters[0])
@@ -1926,7 +1968,7 @@ func TestNewFbConfForTargetFileCount(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			NewFBConf(test.logsCfg, &test.logFwd, "0", "")
+			NewFBConf(test.logsCfg, &test.logFwd, "0", "", false)
 			assert.Equal(t, test.expectedCount, test.logsCfg[0].targetFilesCnt)
 		})
 	}

--- a/pkg/integrations/v4/logs/loader.go
+++ b/pkg/integrations/v4/logs/loader.go
@@ -23,18 +23,20 @@ const (
 )
 
 type CfgLoader struct {
-	config           config.LogForward
-	loadFilesFn      fs.FilesInFolderFn
-	agentIDFn        id.Provide
-	hostnameResolver hostname.Resolver
+	config             config.LogForward
+	loadFilesFn        fs.FilesInFolderFn
+	agentIDFn          id.Provide
+	hostnameResolver   hostname.Resolver
+	useZstdCompression bool
 }
 
-func NewFolderLoader(c config.LogForward, agentIDFn id.Provide, hostnameResolver hostname.Resolver) *CfgLoader {
+func NewFolderLoader(c config.LogForward, agentIDFn id.Provide, hostnameResolver hostname.Resolver, useZstdCompression bool) *CfgLoader {
 	return &CfgLoader{
-		config:           c,
-		loadFilesFn:      fs.OSFilesInFolderFn,
-		agentIDFn:        agentIDFn,
-		hostnameResolver: hostnameResolver,
+		config:             c,
+		loadFilesFn:        fs.OSFilesInFolderFn,
+		agentIDFn:          agentIDFn,
+		hostnameResolver:   hostnameResolver,
+		useZstdCompression: useZstdCompression,
 	}
 }
 
@@ -75,7 +77,7 @@ func (l *CfgLoader) LoadAll() (c FBCfg, ok bool) {
 		loaderLogger.Debug("Could not determine hostname.")
 	}
 
-	c, err = NewFBConf(allFilesCfgs, &(l.config), agentGUID.String(), shortHostName)
+	c, err = NewFBConf(allFilesCfgs, &(l.config), agentGUID.String(), shortHostName, l.useZstdCompression)
 	if err != nil {
 		loaderLogger.WithError(err).Error("could not process logging configurations")
 		return FBCfg{}, false

--- a/pkg/integrations/v4/logs/loader_test.go
+++ b/pkg/integrations/v4/logs/loader_test.go
@@ -28,6 +28,7 @@ var (
 		Match:       "*",
 		LicenseKey:  "license",
 		SendMetrics: false,
+		Compression: "gzip",
 	}
 	fbCfgEntityDecoration = FBCfgFilter{
 		Name:  "record_modifier",
@@ -127,7 +128,7 @@ logs:
 		t.Run(tt.name, func(t *testing.T) {
 			// SUT
 			conf := newTestConf(tt.folder, disabledTroubleshootCfg, false)
-			cfg, ok := NewFolderLoader(conf, idnProvide, hostnameProvider).LoadAll()
+			cfg, ok := NewFolderLoader(conf, idnProvide, hostnameProvider, false).LoadAll()
 
 			assert.Equal(t, tt.expectOK, ok)
 			assert.Equal(t, tt.wantCfg, cfg)
@@ -175,24 +176,25 @@ logs:
 			Match:       "*",
 			LicenseKey:  "license",
 			SendMetrics: true,
+			Compression: "gzip",
 		},
 	}
 
 	conf := newTestConf(validFileFolder, disabledTroubleshootCfg, true)
-	cfg, ok := NewFolderLoader(conf, idnProvide, hostnameProvider).LoadAll()
+	cfg, ok := NewFolderLoader(conf, idnProvide, hostnameProvider, false).LoadAll()
 	assert.Equal(t, true, ok)
 	assert.Equal(t, expectedCfg, cfg)
 }
 
 func TestCfgLoader_LoadAll_TroubleshootDisabed(t *testing.T) {
 	disabledTroubleshootCfg := config.NewTroubleshootCfg(false, false, "")
-	_, ok := NewFolderLoader(newTestConf("", disabledTroubleshootCfg, false), idnProvide, hostnameProvider).LoadAll()
+	_, ok := NewFolderLoader(newTestConf("", disabledTroubleshootCfg, false), idnProvide, hostnameProvider, false).LoadAll()
 	assert.False(t, ok, "should return ok=false when there is no logging configuration directory and troubleshoot is disabled")
 }
 
 func TestCfgLoader_LoadAll_TroubleshootNoLogFile(t *testing.T) {
 	troublesCfg := config.NewTroubleshootCfg(true, false, "")
-	cfg, ok := NewFolderLoader(newTestConf("", troublesCfg, false), idnProvide, hostnameProvider).LoadAll()
+	cfg, ok := NewFolderLoader(newTestConf("", troublesCfg, false), idnProvide, hostnameProvider, false).LoadAll()
 	assert.Equal(t, ok, true, "Enabling troubleshoot with no logging configurations should start the log forwarder")
 	assert.Equal(t, FBCfg{
 		Inputs: []FBCfgInput{
@@ -219,7 +221,7 @@ func TestCfgLoader_LoadAll_TroubleshootNoLogFile(t *testing.T) {
 
 func TestCfgLoader_LoadAll_TroubleshootLogFile(t *testing.T) {
 	troublesCfg := config.NewTroubleshootCfg(true, true, "/agent_log_file")
-	cfg, ok := NewFolderLoader(newTestConf("", troublesCfg, false), idnProvide, hostnameProvider).LoadAll()
+	cfg, ok := NewFolderLoader(newTestConf("", troublesCfg, false), idnProvide, hostnameProvider, false).LoadAll()
 	assert.Equal(t, ok, true, "Enabling troubleshoot with no logging configurations should start the log forwarder")
 	assert.Equal(t, FBCfg{
 		Inputs: []FBCfgInput{
@@ -437,7 +439,7 @@ logs:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// SUT
-			gotC, err := NewFolderLoader(newTestConf("", disabledTroubleshootCfg, false), idnProvide, hostnameProvider).parseYAML(tt.contents)
+			gotC, err := NewFolderLoader(newTestConf("", disabledTroubleshootCfg, false), idnProvide, hostnameProvider, false).parseYAML(tt.contents)
 			assert.Equal(t, tt.wantErr, err)
 			assert.Equal(t, tt.wantC, gotC)
 		})

--- a/pkg/integrations/v4/supervisor_fb_test.go
+++ b/pkg/integrations/v4/supervisor_fb_test.go
@@ -113,7 +113,7 @@ func TestFBSupervisorConfig_LicenseKeyShouldBePassedAsEnvVar(t *testing.T) {
 	license := "some_license"
 	c := config.LogForward{License: license, Troubleshoot: config.Troubleshoot{Enabled: true}}
 
-	confLoader := logs.NewFolderLoader(c, agentIdentity, hostnameResolver)
+	confLoader := logs.NewFolderLoader(c, agentIdentity, hostnameResolver, false)
 	executorBuilder := buildFbExecutor(fbConf, confLoader)
 
 	exec, err := executorBuilder()
@@ -143,7 +143,7 @@ func Test_ConfigTemporaryFolderCreation(t *testing.T) {
 	hostnameResolver := testhelpers.NewFakeHostnameResolver("full_hostname", "short_hostname", nil)
 	c := config.LogForward{Troubleshoot: config.Troubleshoot{Enabled: true}}
 
-	confLoader := logs.NewFolderLoader(c, agentIdentity, hostnameResolver)
+	confLoader := logs.NewFolderLoader(c, agentIdentity, hostnameResolver, false)
 	executorBuilder := buildFbExecutor(fbConf, confLoader)
 
 	_, err = executorBuilder()
@@ -454,7 +454,7 @@ func confLoaderForTest() *logs.CfgLoader {
 	license := "some_license"
 	c := config.LogForward{License: license, Troubleshoot: config.Troubleshoot{Enabled: true}}
 
-	return logs.NewFolderLoader(c, agentIdentity, hostnameResolver)
+	return logs.NewFolderLoader(c, agentIdentity, hostnameResolver, false)
 }
 
 // bypassIsLogForwarderAvailable bypasses the check of some files to be able to run fb


### PR DESCRIPTION
Implements account-level feature flag control for ZSTD compression in the Fluent Bit log forwarder. When disabled (default), uses GZIP compression. When enabled, switches to ZSTD compression for improved performance.

Changes:
 - Add fluent_bit_zstd_compression_enabled feature flag
 - Feature flag triggers Fluent Bit restart when toggled
 - Pass compression setting through loader chain to Fluent Bit config
 - Add compression field to OUTPUT template
 - Default to GZIP compression for backward compatibility
 - Comprehensive test coverage for both compression modes