### PR TITLE
feat: add Ubuntu 26.04 LTS (Resolute Raccoon) support

### DIFF
--- a/.github/workflows/component_molecule_packaging.yml
+++ b/.github/workflows/component_molecule_packaging.yml
@@ -28,7 +28,7 @@ jobs:
           repo_base_url: ${{ inputs.REPO_ENDPOINT }}
           package_name: 'newrelic-infra'
           package_version: ${{ inputs.TAG }}
-          platforms: "al2,al2023,debian-bullseye,debian-bookworm,redhat8,redhat9,redhat10,suse15.3,suse15.4,suse15.5,suse15.6,suse15.7,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204,ubuntu2404"
+          platforms: "al2,al2023,debian-bullseye,debian-bookworm,redhat8,redhat9,redhat10,suse15.3,suse15.4,suse15.5,suse15.6,suse15.7,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204,ubuntu2404,ubuntu2604"
       - name: Test NON-FIPS package installation for new GPG 
         uses: newrelic/pkg-installation-testing-action@v1
         with:
@@ -45,7 +45,7 @@ jobs:
           package_name: 'newrelic-infra-fips'
           exec_name: 'newrelic-infra'
           package_version: ${{ inputs.TAG }}
-          platforms: "al2,al2023,debian-bullseye,debian-bookworm,redhat8,redhat9,redhat10,suse15.3,suse15.4,suse15.5,suse15.6,suse15.7,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204,ubuntu2404"
+          platforms: "al2,al2023,debian-bullseye,debian-bookworm,redhat8,redhat9,redhat10,suse15.3,suse15.4,suse15.5,suse15.6,suse15.7,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204,ubuntu2404,ubuntu2604"
       - name: Test FIPS package installation for new GPG 
         uses: newrelic/pkg-installation-testing-action@v1
         with:

--- a/build/upload-schema-linux-deb-fips.yml
+++ b/build/upload-schema-linux-deb-fips.yml
@@ -8,6 +8,7 @@
       src_repo: "{access_point_host}/infrastructure_agent/linux/apt"
       dest: "{dest_prefix}linux/apt/"
       os_version:
+        - resolute
         - noble
         - jammy
         - focal

--- a/build/upload-schema-linux-deb.yml
+++ b/build/upload-schema-linux-deb.yml
@@ -9,6 +9,7 @@
       src_repo: "{access_point_host}/infrastructure_agent/linux/apt"
       dest: "{dest_prefix}linux/apt/"
       os_version:
+        - resolute
         - noble
         - jammy
         - focal

--- a/test/automated/ansible/group_vars/localhost/main.yml
+++ b/test/automated/ansible/group_vars/localhost/main.yml
@@ -18,6 +18,13 @@ instances:
   ############################
   # ubuntu amd64
   ############################
+  - ami: "ami-0fe18bc3cfa53a248"
+    type: "t3a.small"
+    name: "amd64:ubuntu26.04"
+    username: "ubuntu"
+    platform: "linux"
+    python_interpreter: "/usr/bin/python3"
+    launch_template: "LaunchTemplateId=lt-0b00afb3f5110a0e6,Version=3"
   - ami: "ami-09040d770ffe2224f"
     type: "t3a.small"
     name: "amd64:ubuntu24.04"
@@ -56,6 +63,13 @@ instances:
   ############################
   # ubuntu arm64
   ############################
+  - ami: "ami-005e7d5b13cc4b72b"
+    type: "t4g.small"
+    name: "arm64:ubuntu26.04"
+    username: "ubuntu"
+    platform: "linux"
+    python_interpreter: "/usr/bin/python3"
+    launch_template: "LaunchTemplateId=lt-0b00afb3f5110a0e6,Version=3"
   - ami: "ami-0acb327475c6fd498"
     type: "t4g.small"
     name: "arm64:ubuntu24.04"

--- a/test/provision/terraform/caos.auto.tfvars.dist
+++ b/test/provision/terraform/caos.auto.tfvars.dist
@@ -2,9 +2,9 @@ ec2_prefix = "PREFIX:TAG_OR_UNIQUE_NAME"
 
 windows_ec2 = ["windows_2016", "windows_2019", "windows_2022", "windows_2025"]
 
-linux_ec2_amd = ["amd64:ubuntu24.04", "amd64:ubuntu22.04", "amd64:ubuntu20.04", "amd64:ubuntu18.04", "amd64:ubuntu16.04", "amd64:centos-stream", "amd64:sles-12.5", "amd64:sles-15.4", "amd64:sles-15.5", "amd64:sles-15.6", "amd64:sles-15.7", "amd64:redhat-8.4", "amd64:redhat-9.0", "amd64:redhat-10.0", "amd64:debian-bookworm", "amd64:debian-trixie", "amd64:al-2", "amd64:al-2023", "amd64:al-2023-fips"]
+linux_ec2_amd = ["amd64:ubuntu26.04", "amd64:ubuntu24.04", "amd64:ubuntu22.04", "amd64:ubuntu20.04", "amd64:ubuntu18.04", "amd64:ubuntu16.04", "amd64:centos-stream", "amd64:sles-12.5", "amd64:sles-15.4", "amd64:sles-15.5", "amd64:sles-15.6", "amd64:sles-15.7", "amd64:redhat-8.4", "amd64:redhat-9.0", "amd64:redhat-10.0", "amd64:debian-bookworm", "amd64:debian-trixie", "amd64:al-2", "amd64:al-2023", "amd64:al-2023-fips"]
 
-linux_ec2_arm = ["arm64:ubuntu24.04", "arm64:ubuntu22.04", "arm64:ubuntu20.04", "arm64:ubuntu18.04", "arm64:ubuntu16.04", "arm64:centos-stream",  "arm64:sles-15.4", "arm64:sles-15.5", "arm64:sles-15.6", "arm64:sles-15.7", "arm64:redhat-8.4", "arm64:redhat-9.0", "arm64:redhat-10.0", "arm64:debian-bookworm", "arm64:debian-trixie", "arm64:al-2", "arm64:al-2023", "arm64:al-2023-fips"]
+linux_ec2_arm = ["arm64:ubuntu26.04", "arm64:ubuntu24.04", "arm64:ubuntu22.04", "arm64:ubuntu20.04", "arm64:ubuntu18.04", "arm64:ubuntu16.04", "arm64:centos-stream",  "arm64:sles-15.4", "arm64:sles-15.5", "arm64:sles-15.6", "arm64:sles-15.7", "arm64:redhat-8.4", "arm64:redhat-9.0", "arm64:redhat-10.0", "arm64:debian-bookworm", "arm64:debian-trixie", "arm64:al-2", "arm64:al-2023", "arm64:al-2023-fips"]
 
 ssh_pub_key      = "AAAAB3NzaC1yc2EAAAADAQABAAABAQDH9C7BS2XrtXGXFFyL0pNku/Hfy84RliqvYKpuslJFeUivf5QY6Ipi8yXfXn6TsRDbdxfGPi6oOR60Fa+4cJmCo6N5g57hBS6f2IdzQBNrZr7i1I/a3cFeK6XOc1G1tQaurx7Pu+qvACfJjLXKG66tHlaVhAHd/1l2FocgFNUDFFuKS3mnzt9hKys7sB4aO3O0OdohN/0NJC4ldV8/OmeXqqfkiPWcgPx3C8bYyXCX7QJNBHKrzbX1jW51Px7SIDWFDV6kxGwpQGGBMJg/k79gjjM+jhn4fg1/VP/Fx37mAnfLqpcTfiOkzSE80ORGefQ1XfGK/Dpa3ITrzRYW8xlR caos-dev-arm"
 pvt_key          = "~/.ssh/caos-dev-arm.cer"


### PR DESCRIPTION
 Adds Ubuntu 26.04 LTS "Resolute Raccoon" support to the infrastructure agent, including package publishing, CI packaging tests, and automated harvest test infrastructure.                                                                                                 
                                                                                                                                                                                                                                                                             
  Changes                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                             
  Package publishing                                                                                                                                                                                                                                                         
  - Add resolute apt codename to build/upload-schema-linux-deb.yml so packages are published to the Ubuntu 26.04 apt repository                                                                                                                                              
  - Add resolute apt codename to build/upload-schema-linux-deb-fips.yml for FIPS packages                                                                                                                                                                                    
                                                                                                                                                                                                                                                                             
  CI packaging tests                                                                                                                                                                                                                                                         
  - Add ubuntu2604 to the molecule packaging test platform list in .github/workflows/component_molecule_packaging.yml (both standard and FIPS workflows)                                                                                                                     
                                                                                                                                                                                                                                                                             
  Automated harvest tests                                                                                                                                                                                                                                                    
  - Add Ubuntu 26.04 amd64 and arm64 AMI IDs to test/automated/ansible/group_vars/localhost/main.yml                                                                                                                                                                         
  - Add amd64:ubuntu26.04 and arm64:ubuntu26.04 EC2 instance entries to test/provision/terraform/caos.auto.tfvars.dist   