### PR TITLE
fix: version upgrade for output plugin

### DIFF
--- a/build/embed/fluent-bit.version
+++ b/build/embed/fluent-bit.version
@@ -5,7 +5,7 @@
 #
 # OS, newrelic_plugin_version, fluent-bit
 
-linux,3.4.0
-windows,3.4.0,4.2.2
+linux,3.5.1
+windows,3.5.1,4.2.2
 #To be removed on removal of the ff fluent_bit_19
 windows-legacy,1.19.1,1.9.3


### PR DESCRIPTION
**Summary**
Bumps the New Relic Fluent Bit output plugin version from 3.4.0 to 3.5.1 for both Linux and Windows.
