### PR TITLE
chore(deps): bump newrelic fluent bit output version to 3.5.1

### DIFF
--- a/build/embed/fluent-bit.version
+++ b/build/embed/fluent-bit.version
@@ -5,7 +5,7 @@
 #
 # OS, newrelic_plugin_version, fluent-bit
 
-linux,3.4.0
-windows,3.4.0,4.2.2
+linux,3.5.1
+windows,3.5.1,4.2.2
 #To be removed on removal of the ff fluent_bit_19
 windows-legacy,1.19.1,1.9.3


### PR DESCRIPTION
[#2225](https://github.com/newrelic/infrastructure-agent/pull/2225)