### PR TITLE
feat: support Unicode.Encoding option for tail input plugin for fluent-bit (NR-557219)

### DIFF
--- a/pkg/integrations/v4/logs/cfg.go
+++ b/pkg/integrations/v4/logs/cfg.go
@@ -102,6 +102,7 @@ type LogCfg struct {
 	Winlog          *LogWinlogCfg     `yaml:"winlog"`
 	Winevtlog       *LogWinevtlogCfg  `yaml:"winevtlog"`
 	MultilineParser string            `yaml:"multilineParser"`
+	UnicodeEncoding string            `yaml:"unicodeEncoding"`
 	targetFilesCnt  int
 }
 
@@ -190,6 +191,7 @@ type FBCfgInput struct {
 	MemBufferLimit        string // plugin: tail
 	PathKey               string // plugin: tail
 	MultilineParser       string // plugin: tail
+	UnicodeEncoding       string // plugin: tail
 	SkipLongLines         string // always on
 	Systemd_Filter        string // plugin: systemd
 	Channels              string // plugin: winlog
@@ -393,7 +395,7 @@ func parseConfigBlock(l LogCfg, logsHomeDir string, fbOSConfig FBOSConfig) (inpu
 
 // Single file
 func parseFileInput(l LogCfg, dbPath string) (input FBCfgInput, filters []FBCfgFilter) {
-	input = newFileInput(l.File, dbPath, l.Name, getBufferMaxSize(l), l.MultilineParser)
+	input = newFileInput(l.File, dbPath, l.Name, getBufferMaxSize(l), l.MultilineParser, l.UnicodeEncoding)
 	filters = append(filters, newRecordModifierFilterForInput(l.Name, fbInputTypeTail, l.Attributes))
 	filters = parsePattern(l, fbGrepFieldForTail, filters)
 	return input, filters
@@ -548,7 +550,7 @@ func newFBExternalConfig(l LogExternalFBCfg) FBCfgExternal {
 	}
 }
 
-func newFileInput(filePath string, dbPath string, tag string, bufSize int, multilineParser string) FBCfgInput {
+func newFileInput(filePath string, dbPath string, tag string, bufSize int, multilineParser string, unicodeEncoding string) FBCfgInput {
 	return FBCfgInput{
 		Name:            fbInputTypeTail,
 		PathKey:         "filePath",
@@ -558,6 +560,7 @@ func newFileInput(filePath string, dbPath string, tag string, bufSize int, multi
 		BufferMaxSize:   fmt.Sprintf("%dk", bufSize),
 		MemBufferLimit:  fmt.Sprintf("%dk", memBufferLimit),
 		MultilineParser: multilineParser,
+		UnicodeEncoding: unicodeEncoding,
 		SkipLongLines:   "On",
 	}
 }

--- a/pkg/integrations/v4/logs/cfg_template.go
+++ b/pkg/integrations/v4/logs/cfg_template.go
@@ -23,6 +23,9 @@ var fbConfigFormat = `{{- range .Inputs }}
     {{- if .MultilineParser }}
     Multiline.Parser {{ .MultilineParser }}
     {{- end }}
+    {{- if .UnicodeEncoding }}
+    Unicode.Encoding {{ .UnicodeEncoding }}
+    {{- end }}
     {{- if .PathKey }}
     Path_Key {{ .PathKey }}
     {{- end }}

--- a/pkg/integrations/v4/logs/cfg_test.go
+++ b/pkg/integrations/v4/logs/cfg_test.go
@@ -2121,3 +2121,77 @@ func TestMlParserFBCfgWithMultipleParsers(t *testing.T) {
 	assert.Equal(t, "/path/to/fb/parsers", extCfg.ParsersFilePath)
 	assert.Equal(t, expected, result)
 }
+
+func TestUnicodeEncodingFBCfgFormat(t *testing.T) {
+	expected := `
+[INPUT]
+    Name tail
+    Path /path/to/folder/*
+    Buffer_Max_Size 32k
+    Skip_Long_Lines On
+    Multiline.Parser multiline_mssql
+    Unicode.Encoding UTF-16LE
+    Path_Key filePath
+    Tag  mssql_error_log
+    DB   fb.db
+
+[FILTER]
+    Name  record_modifier
+    Match mssql_error_log
+    Record "fb.input" "tail"
+
+[FILTER]
+    Name  record_modifier
+    Match *
+    Record "entity.guid.INFRA" "testGUID"
+    Record "fb.source" "nri-agent"
+
+[OUTPUT]
+    Name                newrelic
+    Match               *
+    licenseKey          ${NR_LICENSE_KEY_ENV_VAR}
+    validateProxyCerts  false
+`
+
+	fbCfg := FBCfg{
+		Inputs: []FBCfgInput{
+			{
+				Name:            "tail",
+				Tag:             "mssql_error_log",
+				DB:              "fb.db",
+				Path:            "/path/to/folder/*",
+				BufferMaxSize:   "32k",
+				SkipLongLines:   "On",
+				MultilineParser: "multiline_mssql",
+				UnicodeEncoding: "UTF-16LE",
+				PathKey:         "filePath",
+			},
+		},
+		Filters: []FBCfgFilter{
+			{
+				Name:  "record_modifier",
+				Match: "mssql_error_log",
+				Records: map[string]string{
+					"fb.input": "tail",
+				},
+			},
+			{
+				Name:  "record_modifier",
+				Match: "*",
+				Records: map[string]string{
+					"entity.guid.INFRA": "testGUID",
+					"fb.source":         "nri-agent",
+				},
+			},
+		},
+		Output: FBCfgOutput{
+			Name:       "newrelic",
+			Match:      "*",
+			LicenseKey: "licenseKey",
+		},
+	}
+
+	result, _, err := fbCfg.Format()
+	assert.Empty(t, err)
+	assert.Equal(t, expected, result)
+}


### PR DESCRIPTION
1. Add unicodeEncoding field to LogCfg and FBCfgInput to allow configuring the Unicode.Encoding option of the Fluent Bit tail plugin. 
2. Required for reading UTF-16LE encoded log files such as those generated by MSSQL.

changes are testing by making the utf16 encoded file in ubuntu setup
1) log file set it up /logging.d/dummy.yml 
2) started the infra-agent and observed logs are not coming in newrelic dashboard as the logs are encoded in utf16.
3) Next added UTF16 encoding in loggingdd/logs.yml and restarted infra agent and observed logs are apearing in good way as like below screeshot.

### Testing:

1) Changes were tested end-to-end on Ubuntu 24.04 with a UTF-16LE encoded log file:

2) Created a UTF-16LE encoded log file and configured it in /etc/newrelic-infra/logging.d/ without unicodeEncoding — logs did not appear in the New Relic dashboard (Fluent Bit drops UTF-16 encoded lines silently).

3) Added unicodeEncoding: UTF-16LE to the logging config and restarted the agent — logs appeared correctly in the New Relic dashboard as shown below.

Logging config used: logging.yml:

```
logs:
  - name: utf16-test
    file: /tmp/test-utf16.log
    unicodeEncoding: UTF-16LE
```

<img width="2748" height="1340" alt="image" src="https://github.com/user-attachments/assets/b0504b84-f9d1-4047-b7bd-ade3f4ac2d46" />
 