### PR TITLE
Fix: Add quotes to service BinaryPathName for paths with spaces

### DIFF
--- a/build/package/binaries/windows/installer.ps1
+++ b/build/package/binaries/windows/installer.ps1
@@ -331,12 +331,12 @@ try {
     } else {
         # Fresh installation scenario: create service with LocalSystem
         Write-DebugLog "Creating new service: $ServiceName"
-        Write-DebugLog "Binary path: $AgentDir\newrelic-infra-service.exe -config $ConfigFile"
+        Write-DebugLog "Binary path: `"$AgentDir\newrelic-infra-service.exe`" -config `"$ConfigFile`""
         # Write marker before New-Service so that if anything fails afterward the
         # rollback CA knows it must clean up the service created by this run.
         "1" | Out-File -FilePath $markerFile -Force -ErrorAction SilentlyContinue
         try {
-            New-Service -Name $ServiceName -DisplayName 'New Relic Infrastructure Agent' -BinaryPathName "$AgentDir\newrelic-infra-service.exe -config $ConfigFile" -StartupType Automatic -ErrorAction Stop | Out-Null
+            New-Service -Name $ServiceName -DisplayName 'New Relic Infrastructure Agent' -BinaryPathName "`"$AgentDir\newrelic-infra-service.exe`" -config `"$ConfigFile`"" -StartupType Automatic -ErrorAction Stop | Out-Null
             Write-DebugLog "Service created successfully"
             # Restore auto-restart on crash (first failure: restart after 30s).
             # Equivalent to the original WiX <util:ServiceConfig FirstFailureActionType='restart' RestartServiceDelayInSeconds='30'>.


### PR DESCRIPTION
After fix image path in the registry as shown below
<img width="1007" height="58" alt="image" src="https://github.com/user-attachments/assets/ad31815c-67b0-4ed2-b3f7-e692fddb3f9d" />
