### PR TITLE
Add JP region support for logging component (NR-560784)

### DIFF
--- a/pkg/integrations/v4/logs/cfg_test.go
+++ b/pkg/integrations/v4/logs/cfg_test.go
@@ -81,6 +81,36 @@ var outputBlock = FBCfgOutput{
 	HTTPClientTimeout: "10",
 }
 
+func TestNewNROutput_JPRegion(t *testing.T) {
+	cfg := &config.LogForward{
+		License: "jp01xx6789012345678901234567890123456789",
+	}
+
+	output := newNROutput(cfg)
+
+	assert.Equal(t, jpEndpoint, output.Endpoint)
+}
+
+func TestNewNROutput_EURegion(t *testing.T) {
+	cfg := &config.LogForward{
+		License: "eu01xx6789012345678901234567890123456789",
+	}
+
+	output := newNROutput(cfg)
+
+	assert.Equal(t, euEndpoint, output.Endpoint)
+}
+
+func TestNewNROutput_USRegion(t *testing.T) {
+	cfg := &config.LogForward{
+		License: "0123456789012345678901234567890123456789",
+	}
+
+	output := newNROutput(cfg)
+
+	assert.Equal(t, "", output.Endpoint)
+}
+
 func TestNewFBConf(t *testing.T) {
 	outputBlockFedramp := outputBlock
 	outputBlockFedramp.Endpoint = fedrampEndpoint


### PR DESCRIPTION
## Summary
Implemented support for Japan (JP) region in the infrastructure agent's logging component to enable proper routing of log data to JP endpoints.

## Changes
- Added `IsRegionJP()` function to detect JP license keys (prefix: `jp`)
- Added JP log endpoint: `https://log-api.jp.newrelic.com/log/v1`
- Updated `newNROutput()` to route JP region logs to correct endpoint
- Added comprehensive unit tests for JP region detection and routing

## Testing
- All existing tests pass
- New tests verify JP license detection and endpoint selection
- EU and US region functionality remains unchanged

## Files Modified
- `pkg/license/license.go`
- `pkg/license/license_test.go`
- `pkg/integrations/v4/logs/cfg.go`
- `pkg/integrations/v4/logs/cfg_test.go`

## Jira
https://new-relic.atlassian.net/browse/NR-560784