### PR TITLE
feat: Add OCI IMDS v2 endpoint support

### DIFF
--- a/pkg/sysinfo/cloud/cloud_oci.go
+++ b/pkg/sysinfo/cloud/cloud_oci.go
@@ -30,9 +30,12 @@ var (
 const (
 	// ociTimeout is the timeout for OCI metadata requests.
 	ociTimeout = 600
-	// OciEndpoint is the URL used for requesting OCI metadata.
-	ociEndpoint = "http://169.254.169.254/opc/v1/instance/"
+	// ociV2AuthorizationHeader is the required Authorization header value for OCI IMDSv2.
+	ociV2AuthorizationHeader = "Bearer Oracle"
 )
+
+// ociEndpoint is the URL used for requesting OCI instance metadata (v2). Var to allow test overrides.
+var ociEndpoint = "http://169.254.169.254/opc/v2/instance/" //nolint:gochecknoglobals
 
 // OCIHarvester is used to fetch data from OCI api.
 type OCIHarvester struct {
@@ -205,7 +208,7 @@ func GetOCIMetadata(disableKeepAlive bool) (*OCIMetadata, error) {
 		return nil, fmt.Errorf("%w: %w", ErrOCIRequestFailed, err) //nolint:wrapcheck
 	}
 
-	request.Header.Add("Metadata", "true")
+	request.Header.Add("Authorization", ociV2AuthorizationHeader)
 
 	var response *http.Response
 	if response, err = clientWithFastTimeout(disableKeepAlive).Do(request); err != nil {

--- a/pkg/sysinfo/cloud/cloud_oci_test.go
+++ b/pkg/sysinfo/cloud/cloud_oci_test.go
@@ -6,13 +6,14 @@ package cloud
 import (
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-// output generated with: curl -s http://169.254.169.254/opc/v1/instance/
+// output generated with: curl -s -H "Authorization: Bearer Oracle" http://169.254.169.254/opc/v2/instance/
 func TestParseOCIMetadataResponse(t *testing.T) {
 	t.Parallel()
 
@@ -67,4 +68,30 @@ func TestParseOCIMetadataResponse(t *testing.T) {
 	require.Equal(t, "jyDh:US-ASHBURN-AD-1", metadata.Zone)
 	require.Equal(t, "ocid1.image.oc1", metadata.ImageID)
 	require.Equal(t, "ubuntu-instance-20250722-1328", metadata.DisplayName)
+}
+
+func TestGetOCIMetadataSendsV2AuthorizationHeader(t *testing.T) {
+	t.Parallel()
+
+	var receivedAuth string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { //nolint:varnamelen
+		receivedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+
+		responseJSON := `{"id":"test-id","shape":"VM.Standard2.1","canonicalRegionName":"us-ashburn-1",` +
+			`"compartmentId":"ocid1.compartment","availabilityDomain":"AD-1","image":"ocid1.image","displayName":"test"}`
+		_, _ = w.Write([]byte(responseJSON))
+	}))
+
+	defer server.Close()
+
+	origEndpoint := ociEndpoint
+	ociEndpoint = server.URL + "/"
+
+	defer func() { ociEndpoint = origEndpoint }()
+
+	_, err := GetOCIMetadata(false)
+	require.NoError(t, err)
+	require.Equal(t, ociV2AuthorizationHeader, receivedAuth)
 }


### PR DESCRIPTION
Use OCI Instance Metadata Service v2 endpoint with Authorization: Bearer Oracle header for enhanced security.

Metadata from entity inspector:

{
    "created": "2026-02-24T10:11:51.753142Z",
    "entityType": "HOST",
    "metadata": {
        "metadata/attributes": {
            "nr_deployed_by": "newrelic-cli"
        },
        "metadata/host_aliases": {
            "fullHostname": "instance-202509.vcn07221338.oraclevcn.com",
            "host.id": "ocid1.instance.oc1.iad.anuwcljrtvlqdbycwztzdcblj45rf7prak227q3rarwxwutl6u6whi73v2na",
            "hostname": "instance-202509"
        },
        "metadata/system": {
            "agentName": "Infrastructure",
            "agentVersion": "1.74.5",
            "coreCount": "2",
            "instanceType": "VM.Optimized3.Flex",
            "oci.availabilityDomain": "jyDh:US-ASHBURN-AD-1",
            "oci.compartmentId": "ocid1.compartment.oc1..aaaaaaaad544qzjef2rhbitefrir7rekhrxn6tgc2ycms2nyzooh4nydp4uq",
            "oci.imageId": "ocid1.image.oc1.iad.aaaaaaaapvao2syhh6mfh7ophsdipz2g66vdz4u5dysqxkec6t6xgm5zzsma",
            "oci.region": "us-ashburn-1",
            "oci.shape": "VM.Optimized3.Flex",
            "operatingSystem": "windows",
            "processorCount": "1",
            "systemMemoryBytes": "15026655232",
            "windowsFamily": "Server",
            "windowsPlatform": "Microsoft Windows Server 2022 Standard",
            "windowsVersion": "10.0.20348.4052 Build 20348.4052"
        },
        "system/host_status": {
            "hostStatus": "running"
        }
    },
    "updated": "2026-05-13T15:44:37.534338Z"
}