### PR TITLE
Fix set-service-account fails for local users

### DIFF
--- a/build/package/binaries/windows/set-service-account.ps1
+++ b/build/package/binaries/windows/set-service-account.ps1
@@ -227,6 +227,7 @@ Write-Host ""
 $credential = $null
 $isGMSA = $false
 $isBuiltinTarget = $false  # set here so all branches have it defined; updated per-branch below
+$builtinNames = @('LocalSystem', 'LocalService', 'NetworkService', 'SYSTEM')
 
 # Check if using gMSA
 if ($GMSAUsername) {
@@ -285,8 +286,7 @@ public static extern void CredFree(IntPtr credentialPtr);
             Write-Host "Username: $Username" -ForegroundColor Green
 
             # Compute $isBuiltinTarget now that $Username is known for this branch
-            $isBuiltinTarget = ($Username -notlike '*\*') -or ($Username -match '^NT (AUTHORITY|SERVICE)\\')
-
+            $isBuiltinTarget = ($builtinNames -icontains $Username) -or ($Username -match '^NT (AUTHORITY|SERVICE)\\')
             if ($cred.CredentialBlobSize -gt 0) {
                 $securePassword = New-Object System.Security.SecureString
                 $charCount = $cred.CredentialBlobSize / 2
@@ -318,7 +318,7 @@ else {
     $Username = Read-Host "Username"
 
     # Built-in accounts (LocalSystem, NT AUTHORITY\*, NT SERVICE\*) don't have a password
-    $isBuiltinTarget = ($Username -notlike '*\*') -or ($Username -match '^NT (AUTHORITY|SERVICE)\\')
+    $isBuiltinTarget = ($builtinNames -icontains $Username) -or ($Username -match '^NT (AUTHORITY|SERVICE)\\')
     if (-not $isBuiltinTarget) {
         $securePassword = Read-Host -AsSecureString "Password"
         $credential = New-Object System.Management.Automation.PSCredential($Username, $securePassword)
@@ -326,7 +326,7 @@ else {
 }
 
 # Validate username format for regular accounts
-if (-not $isGMSA -and $Username -notlike "*\*") {
+if (-not $isGMSA -and $Username -notlike "*\*" -and ($builtinNames -inotcontains $Username)) {
     $Username = ".\$Username"
 }
 
@@ -718,7 +718,7 @@ try {
     if ($isGMSA -or $isBuiltinTarget) {
         $result = $serviceWMI.Change($null, $null, $null, $null, $null, $null, $Username, $null, $null, $null, $null)
     } else {
-        $result = $serviceWMI.Change($null, $null, $null, $null, $null, $null, $credential.UserName, $credential.GetNetworkCredential().Password, $null, $null, $null)
+        $result = $serviceWMI.Change($null, $null, $null, $null, $null, $null, $UserName, $credential.GetNetworkCredential().Password, $null, $null, $null)
     }
 
     if ($result.ReturnValue -ne 0) {


### PR DESCRIPTION
Test result:

PS C:\Users\nravada\newrelic\infrastructure-agent\build\package\binaries\windows> .\set-service-account.ps1
=== New Relic Infrastructure Agent - Service User Change Utility ===

Service found: newrelic-infra
Current service account: localsystem

Please enter the credentials for the service account:
Username: nragentuser
Password: **********

=== Validating User Account and Permissions ===
✓ Local user account exists: nragentuser

Checking folder permissions...
User has permissions on: C:\ProgramData\New Relic\newrelic-infra
User has permissions on: C:\Program Files\New Relic\newrelic-infra

Checking user privileges...
  Already has: Restore files and directories
  Already has: Log on as a service
  Already has: Debug programs
  Already has: Back up files and directories

Checking local group memberships...
  ✓ Added to group: Performance Monitor Users
  ✓ Added to group: Performance Log Users
  ✓ Added to group: Event Log Readers

=== Changing Service Account ===
Stopping service...
✓ Service stopped
Updating service account to: .\nragentuser
✓ Service account updated successfully
Starting service...
✓ Service started successfully

=== Summary ===
Service Name:    newrelic-infra
Service Account: .\nragentuser
Service Status:  Running

Service account change completed successfully!
PS C:\Users\nravada\newrelic\infrastructure-agent\build\package\binaries\windows>