### PR TITLE
feat(canaries): add SRE Agent notification workflow to canary alerts

### DIFF
--- a/test/canaries/alerts/main.tf
+++ b/test/canaries/alerts/main.tf
@@ -12,3 +12,49 @@ module "alerts" {
         var.macos_display_names
   ])
 }
+
+resource "newrelic_notification_channel" "sre_agent_channel" {
+  name           = "Canary Alerts SRE Agent Channel"
+  account_id     = var.account_id
+  destination_id = "0b7bf32c-f336-442e-8be4-42e5f3eda718"
+  product        = "IINT"
+  type           = "WEBHOOK"
+
+  property {
+    key   = "headers"
+    value = "{\"x-respond-async\":\"true\",\"x-Account-Id\":\"{{nrAccountId}}\"}"
+  }
+
+  property {
+    key   = "payload"
+    value = <<-EOT
+    {"messages":[{"role":"user","content":"I was paged for an alert issue '{{ issueId }}' for entity '{{ entitiesData.names.[0] }}'. This is a canary alert comparing infrastructure agent versions. What seems to be the cause of this alert? Provide detailed analysis of the historical trends on the alert signal.","context":[{"state":"{{ state }}","accountId":"{{ nrAccountId }}","status":"{{ status }}","triggerEvent":"{{ triggerEvent }}","activatedAt":"{{ activatedAt }}","acknowledgedAt":"{{ acknowledgedAt }}","acknowledgedByChannel":"{{#if acknowledgedByChannel}}{{ acknowledgedByChannel }}{{else}}N/A{{/if}}","closedByChannel":"{{#if closedByChannel}}{{ closedByChannel }}{{else}}N/A{{/if}}","closedAt":"{{ closedAt }}","createdAt":"{{ createdAt }}","unAcknowledgedAt":"{{#if unAcknowledgedAt}}{{ unAcknowledgedAt }}{{else}}N/A{{/if}}","updatedAt":"{{ updatedAt }}","issueId":"{{ issueId }}","mutingState":"{{ mutingState }}","isCorrelated":"{{ isCorrelated }}","correlatedBy":"{{#if correlatedBy}}{{ correlatedBy }}{{else}}N/A{{/if}}","priority":"{{ priority }}"}]}]}
+    EOT
+  }
+}
+
+resource "newrelic_workflow" "canary_alerts_workflow" {
+  name                  = "Infra Agent Canary Alerts - SRE Agent"
+  account_id            = var.account_id
+  muting_rules_handling = "DONT_NOTIFY_FULLY_MUTED_ISSUES"
+  enabled               = true
+
+  issues_filter {
+    name = "canary-policy-filter"
+    type = "FILTER"
+
+    predicate {
+      attribute = "labels.policyName"
+      operator  = "CONTAINS"
+      values    = [var.policies_prefix]
+    }
+  }
+
+  destination {
+    channel_id              = newrelic_notification_channel.sre_agent_channel.id
+    notification_triggers   = ["ACTIVATED"]
+    update_original_message = true
+  }
+
+  depends_on = [module.alerts]
+}

--- a/test/canaries/alerts/vars.auto.tfvars.dist
+++ b/test/canaries/alerts/vars.auto.tfvars.dist
@@ -1,7 +1,7 @@
 # api_key               = "***" # NR User Api Key
 # account_id            = 0 # NR Account ID
 # region                = "US" # US | EU | Staging
-policies_prefix       = "[pre-release] Infra Agent Canaries metric comparator"
+policies_prefix           = "[pre-release] Infra Agent Canaries metric comparator"
 conditions            = [
   {
     name          = "System / Core Count"


### PR DESCRIPTION
## Summary
- Adds a New Relic notification channel and workflow to route canary alert policy incidents to the SRE Agent for automated root cause analysis
- When a canary alert fires (comparing infra agent versions), the SRE Agent receives full alert context, analyzes historical trends, and writes findings back into the alert issue
- Follows the same pattern used by the Virtuoso team (source.datanerd.us/virtuoso/install-atlantis/pull/525)

## Test plan
- [ ] Run `terraform plan` in `test/canaries/alerts/` to validate configuration
- [ ] Trigger a manual workflow dispatch via `ci_canary_alerts_provision.yml`
- [ ] Verify the workflow appears in NR UI under Alerts > Workflows
- [ ] Confirm the SRE Agent destination receives notifications and writes analysis back into alert issues