### PR TITLE
fix: bumped nri-flex version to 1.18.4

### DIFF
--- a/build/embed/integrations.version
+++ b/build/embed/integrations.version
@@ -1,5 +1,5 @@
 #ohi-repo-name,version
 nri-docker,v2.7.2
-nri-flex,v1.18.3
+nri-flex,v1.18.4
 nri-winservices,v1.5.1
 nri-prometheus,v2.29.1


### PR DESCRIPTION
### Changes:
- Bumped nri-flex to 1.18.4 verison.