### PR TITLE
fix: remove EOL sles-15.3 and improve provision log visibility

### DIFF
--- a/.github/workflows/component_prerelease_testing.yml
+++ b/.github/workflows/component_prerelease_testing.yml
@@ -268,4 +268,3 @@ jobs:
               ERROR!
               fatal:
               Error:
-              │\s+Error

--- a/.github/workflows/component_prerelease_testing.yml
+++ b/.github/workflows/component_prerelease_testing.yml
@@ -68,6 +68,9 @@ jobs:
             PLAY\sRECAP\s
             Apply\scomplete!
             ok=\d+\s+changed=\d+\s+unreachable=\d+\s+failed=\d+\s+skipped=\d+\s+rescued=\d+\s+ignored=\d+
+            ERROR!
+            fatal:
+            Error:
 
   harvest-tests:
     needs: [ provision ]
@@ -218,6 +221,9 @@ jobs:
             PLAY\sRECAP\s
             Apply\scomplete!
             ok=\d+\s+changed=\d+\s+unreachable=\d+\s+failed=\d+\s+skipped=\d+\s+rescued=\d+\s+ignored=\d+
+            ERROR!
+            fatal:
+            Error:
 
   provision-clean-windows:
       if: ${{ inputs.PLATFORM == 'windows' }}
@@ -259,3 +265,7 @@ jobs:
               PLAY\sRECAP\s
               Apply\scomplete!
               ok=\d+\s+changed=\d+\s+unreachable=\d+\s+failed=\d+\s+skipped=\d+\s+rescued=\d+\s+ignored=\d+
+              ERROR!
+              fatal:
+              Error:
+              │\s+Error

--- a/test/automated/ansible/group_vars/localhost/main.yml
+++ b/test/automated/ansible/group_vars/localhost/main.yml
@@ -121,13 +121,6 @@ instances:
     platform: "linux"
     python_interpreter: "/usr/bin/python"
     launch_template: "LaunchTemplateId=lt-0b00afb3f5110a0e6,Version=3"
-  - ami: "ami-0446c700e1dc61753" # based on suse-sles-15-sp3-v20210622-hvm-ssd-x86_64
-    type: "t3a.small"
-    name: "amd64:sles-15.3"
-    username: "ec2-user"
-    platform: "linux"
-    python_interpreter: "/usr/bin/python3"
-    launch_template: "LaunchTemplateId=lt-0b00afb3f5110a0e6,Version=3"
   - ami: "ami-0bde5989b70490b94" # based on suse-sles-15-sp4-v20220915-hvm-ssd-x86_64
     type: "t3a.small"
     name: "amd64:sles-15.4"

--- a/test/provision/terraform/caos.auto.tfvars.dist
+++ b/test/provision/terraform/caos.auto.tfvars.dist
@@ -2,7 +2,7 @@ ec2_prefix = "PREFIX:TAG_OR_UNIQUE_NAME"
 
 windows_ec2 = ["windows_2016", "windows_2019", "windows_2022", "windows_2025"]
 
-linux_ec2_amd = ["amd64:ubuntu24.04", "amd64:ubuntu22.04", "amd64:ubuntu20.04", "amd64:ubuntu18.04", "amd64:ubuntu16.04", "amd64:centos-stream", "amd64:sles-12.5", "amd64:sles-15.3",  "amd64:sles-15.4", "amd64:sles-15.5", "amd64:sles-15.6", "amd64:sles-15.7", "amd64:redhat-8.4", "amd64:redhat-9.0", "amd64:redhat-10.0", "amd64:debian-bookworm", "amd64:debian-trixie", "amd64:al-2", "amd64:al-2023", "amd64:al-2023-fips"]
+linux_ec2_amd = ["amd64:ubuntu24.04", "amd64:ubuntu22.04", "amd64:ubuntu20.04", "amd64:ubuntu18.04", "amd64:ubuntu16.04", "amd64:centos-stream", "amd64:sles-12.5", "amd64:sles-15.4", "amd64:sles-15.5", "amd64:sles-15.6", "amd64:sles-15.7", "amd64:redhat-8.4", "amd64:redhat-9.0", "amd64:redhat-10.0", "amd64:debian-bookworm", "amd64:debian-trixie", "amd64:al-2", "amd64:al-2023", "amd64:al-2023-fips"]
 
 linux_ec2_arm = ["arm64:ubuntu24.04", "arm64:ubuntu22.04", "arm64:ubuntu20.04", "arm64:ubuntu18.04", "arm64:ubuntu16.04", "arm64:centos-stream",  "arm64:sles-15.4", "arm64:sles-15.5", "arm64:sles-15.6", "arm64:sles-15.7", "arm64:redhat-8.4", "arm64:redhat-9.0", "arm64:redhat-10.0", "arm64:debian-bookworm", "arm64:debian-trixie", "arm64:al-2", "arm64:al-2023", "arm64:al-2023-fips"]
 


### PR DESCRIPTION
## Problem

The [test-prerelease-linux / provision](https://github.com/newrelic/infrastructure-agent/actions/runs/26525484833/job/78281080049) job started failing with exit code 2 and no visible error in GitHub Actions logs.

### CouldWatch Logs:

`Error: [0m[0m[1mcreating EC2 Instance: operation error EC2: RunInstances, https response error StatusCode: 400, RequestID: e771XXX-XXX-XXX-XXX-XXX, api error InvalidAMIID.NotFound: The image id '[ami-0b7b425050b12e3f9]' does not exist[0m`

## Root cause

`terraform apply` attempted to launch an EC2 instance using AMI
`ami-0b7b425050b12e3f9` (SLES 15.3 amd64). This AMI was deregistered by
SUSE  confirmed via CloudTrail (no `DeregisterImage` event in our
account, meaning it was removed by the AMI owner, not by our team).

SLES 15.3 reached EOL in January 2023. Newer versions (15.4–15.7) are
already covered in the test matrix.

## Why the error was invisible

`fargate-runner-action` uses `log_filters` to stream only matching lines
from CloudWatch to GitHub Actions output. The existing filters only
allowed success-path patterns (`TASK [...]`, `PLAY [...]`,
`Apply complete!`). Terraform and Ansible error lines were silently
dropped, making diagnosis require direct CloudWatch access.

## Changes

1. **`test/provision/terraform/caos.auto.tfvars.dist`** — remove
   `amd64:sles-15.3` (same approach as the earlier `sles-15.2` removal)

2. **`.github/workflows/component_prerelease_testing.yml`** — add three
   error patterns to all `log_filters` blocks:
   - `ERROR!` — catches Ansible and ansible-galaxy errors
   - `fatal:` — catches Ansible fatal task failures
   - `Error:` — catches Terraform errors (validated against the actual
     CloudWatch log line which contains ANSI escape codes between the
     Terraform box character and `Error:`, making a `│\s+Error` pattern
     unreliable)