### PR TITLE
feat(logging): add configurable log endpoint 

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -929,7 +929,7 @@ type Config struct {
 	// LoggingEndpoint overrides the default New Relic logs endpoint used by the Fluent Bit output plugin.
 	// Default: Empty
 	// Public: Yes
-	LoggingEndpoint string `yaml:"logging_endpoint" envconfig:"logging_endpoint" public:"true"`
+	LoggingEndpoint string `envconfig:"logging_endpoint" public:"true" yaml:"logging_endpoint"`
 
 	// FluentBitExePath is the location from where the agent can execute fluent-bit.
 	// Default (Linux): /opt/td-agent-bit/bin/td-agent-bit

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -926,6 +926,11 @@ type Config struct {
 	// Public: Yes
 	LoggingHTTPClientTimeout string `envconfig:"logging_http_client_timeout" public:"true" yaml:"logging_http_client_timeout"` //nolint:lll
 
+	// LoggingEndpoint overrides the default New Relic logs endpoint used by the Fluent Bit output plugin.
+	// Default: Empty
+	// Public: Yes
+	LoggingEndpoint string `yaml:"logging_endpoint" envconfig:"logging_endpoint" public:"true"`
+
 	// FluentBitExePath is the location from where the agent can execute fluent-bit.
 	// Default (Linux): /opt/td-agent-bit/bin/td-agent-bit
 	// Default (Windows): C:\Program Files\New Relic\newrelic-infra\newrelic-integrations\logging\fluent-bit
@@ -1565,6 +1570,7 @@ type LogForward struct {
 	ConfigsDir        string
 	HomeDir           string
 	License           string
+	Endpoint          string
 	IsFedramp         bool
 	IsStaging         bool
 	ProxyCfg          LogForwardProxy
@@ -1588,6 +1594,7 @@ func NewLogForward(config *Config, troubleshoot Troubleshoot) LogForward {
 		ConfigsDir:        config.LoggingConfigsDir,
 		HomeDir:           config.LoggingHomeDir,
 		License:           config.License,
+		Endpoint:          config.LoggingEndpoint,
 		IsFedramp:         config.Fedramp,
 		IsStaging:         config.Staging,
 		RetryLimit:        config.LoggingRetryLimit,

--- a/pkg/integrations/v4/logs/cfg.go
+++ b/pkg/integrations/v4/logs/cfg.go
@@ -764,6 +764,10 @@ func newNROutput(cfg *config.LogForward) FBCfgOutput {
 		ret.Endpoint = fmt.Sprintf(baseEndpointRegion, r)
 	}
 
+	if cfg.Endpoint != "" {
+		ret.Endpoint = cfg.Endpoint
+	}
+
 	return ret
 }
 

--- a/pkg/integrations/v4/logs/cfg_test.go
+++ b/pkg/integrations/v4/logs/cfg_test.go
@@ -108,12 +108,25 @@ func TestNewNROutput_USRegion(t *testing.T) {
 	assert.Empty(t, output.Endpoint)
 }
 
+func TestNewNROutput_CustomEndpointOverride(t *testing.T) {
+	cfg := &config.LogForward{
+		License:  "eu01xx6789012345678901234567890123456789",
+		Endpoint: "https://custom-log.example.com/log/v1",
+	}
+
+	output := newNROutput(cfg)
+
+	assert.Equal(t, "https://custom-log.example.com/log/v1", output.Endpoint)
+}
+
 func TestNewFBConf(t *testing.T) {
 	outputBlockFedramp := outputBlock
 	outputBlockFedramp.Endpoint = fedrampEndpoint
 	outputBlockJP := outputBlock
 	outputBlockJP.LicenseKey = "jpxxxx6789012345678901234567890123456789"
 	outputBlockJP.Endpoint = fmt.Sprintf(baseEndpointRegion, "jp")
+	outputBlockCustom := outputBlock
+	outputBlockCustom.Endpoint = "https://custom-log.example.com/log/v1"
 	outputBlockMultipleRetries := outputBlock
 
 	logFwdCfgMultipleRetries := logFwdCfg
@@ -123,6 +136,9 @@ func TestNewFBConf(t *testing.T) {
 
 	logFwdCfgJP := logFwdCfg
 	logFwdCfgJP.License = "jpxxxx6789012345678901234567890123456789"
+
+	logFwdCfgCustom := logFwdCfg
+	logFwdCfgCustom.Endpoint = "https://custom-log.example.com/log/v1"
 
 	tests := []struct {
 		name   string
@@ -136,6 +152,32 @@ func TestNewFBConf(t *testing.T) {
 			FBCfg{
 				Inputs:  []FBCfgInput{},
 				Filters: []FBCfgFilter{},
+			},
+		},
+		{
+			"custom endpoint", logFwdCfgCustom,
+			LogsCfg{{
+				Name: "log-file",
+				File: "file.path",
+			}},
+			FBCfg{
+				Inputs: []FBCfgInput{
+					{
+						Name:           "tail",
+						Tag:            "log-file",
+						DB:             dbDbPath,
+						Path:           "file.path",
+						BufferMaxSize:  "128k",
+						MemBufferLimit: "16384k",
+						SkipLongLines:  "On",
+						PathKey:        "filePath",
+					},
+				},
+				Filters: []FBCfgFilter{
+					inputRecordModifier("tail", "log-file"),
+					filterEntityBlock,
+				},
+				Output: outputBlockCustom,
 			},
 		},
 		{"single input", logFwdCfg, LogsCfg{

--- a/tools/cdn-purge/go.mod
+++ b/tools/cdn-purge/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/infrastructure-agent/tools/cdn-purge
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.39.0

--- a/tools/spin-ec2/go.mod
+++ b/tools/spin-ec2/go.mod
@@ -1,6 +1,6 @@
 module spin-ec2
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/spf13/cobra v1.10.1

--- a/tools/yamlgen/go.mod
+++ b/tools/yamlgen/go.mod
@@ -1,6 +1,6 @@
 module yamlgen
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION

### **Overview**
This PR introduces the ability to configure a custom logging endpoint for the New Relic infrastructure agent. By default, the agent sends logs to the standard New Relic logging endpoints, but this change allows users to override that destination.

### **Key Changes**
* **New Configuration Option:** Added a `logging_endpoint` configuration variable. This can be set via the agent's YAML configuration file (`yaml:"logging_endpoint"`) or through an environment variable (`envconfig:"logging_endpoint"`).
* **Fluent Bit Output Override:** Modified the Fluent Bit output plugin logic (`pkg/integrations/v4/logs/cfg.go`). If a custom `LoggingEndpoint` is provided by the user, the agent will use it instead of dynamically generating the default regional New Relic endpoint.
* **Testing:** Added new unit tests (`TestNewNROutput_CustomEndpointOverride`) in `pkg/integrations/v4/logs/cfg_test.go` to ensure the custom endpoint configuration correctly overrides the default behavior.

### **Minor Updates**
* **Go Version Bump:** Updated the Go version requirement from `1.26.3` to `1.26.4` in the `go.mod` files for several internal tools (`cdn-purge`, `spin-ec2`, and `yamlgen`).