### PR TITLE
chore(deps): bump newrelic fluent bit output version to 3.6.0 and fluent-bit to 5.0.6

### DIFF
--- a/build/embed/fluent-bit.version
+++ b/build/embed/fluent-bit.version
@@ -5,7 +5,7 @@
 #
 # OS, newrelic_plugin_version, fluent-bit
 
-linux,3.5.1
-windows,3.5.1,4.2.2
+linux,3.6.0
+windows,3.6.0,5.0.6
 #To be removed on removal of the ff fluent_bit_19
 windows-legacy,1.19.1,1.9.3


### PR DESCRIPTION
Bumps the embedded fluent-bit plugin and fluent-bit versions used by the Infrastructure Agent installers.

- Linux plugin: 3.5.1 → 3.6.0
- Windows plugin: 3.5.1 → 3.6.0
- Windows fluent-bit: 4.2.2 → 5.0.6

Aligns with:
- newrelic/fluent-bit-package Release 240 (Fluent Bit 5.0.6 published to nr-downloads-main)
- newrelic/newrelic-fluent-bit-output v3.6.0 (Docker Hub + GitHub Release published)