### PR TITLE
core(deps): Bump Go version from 1.26.3 to 1.26.4

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:16.04
 
 # Define Go version
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.4
 # Define build-time arguments for the GitHub CLI version and architecture
 ARG GH_VERSION='2.0.0'
 ARG GH_ARCH='amd64'
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y \
 # RUN apt-get install -y \
 # gcc-5-multilib-mips-linux-gnu
 
-# Install Go 1.26.3
+# Install Go 1.26.4
 RUN curl -sSL https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz -o go${GO_VERSION}.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && \
     rm go${GO_VERSION}.linux-amd64.tar.gz

--- a/go.mod
+++ b/go.mod
@@ -40,8 +40,8 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tevino/abool v1.2.0
 	go.uber.org/multierr v1.8.0
-	golang.org/x/net v0.53.0
-	golang.org/x/sys v0.43.0
+	golang.org/x/net v0.54.0
+	golang.org/x/sys v0.44.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools v2.2.1-0.20181123051433-bcbf6e613274+incompatible
@@ -113,7 +113,7 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/text v0.36.0 // indirect
+	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto v0.0.0-20231211222908-989df2bf70f3 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/grpc v1.79.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -281,8 +281,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
-golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
+golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
+golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.34.0 h1:hqK/t4AKgbqWkdkcAeI8XLmbK+4m4G5YeQRrmiotGlw=
@@ -309,12 +309,12 @@ golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
-golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
-golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
+golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
+golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/test/canaries/deploy_macos_canaries.yml
+++ b/test/canaries/deploy_macos_canaries.yml
@@ -30,7 +30,7 @@
             vars:
               self_instrumentation: true
               target_agent_version: "{{ current_version }}"
-              go_version: 1.26.3
+              go_version: 1.26.4
               display_name: "{{ inventory_hostname }}-current"
 
 - hosts: macos_previous
@@ -50,6 +50,6 @@
             vars:
               self_instrumentation: true
               target_agent_version: "{{ previous_version }}"
-              go_version: 1.26.3
+              go_version: 1.26.4
               display_name: "{{ inventory_hostname }}-previous"
 ...

--- a/test/databind/fargate/Dockerfile_test
+++ b/test/databind/fargate/Dockerfile_test
@@ -1,4 +1,4 @@
-FROM golang:1.26.3
+FROM golang:1.26.4
 
 WORKDIR /go/src/github.com/newrelic/infrastructure-agent/
 

--- a/test/proxy/Dockerfile_agent
+++ b/test/proxy/Dockerfile_agent
@@ -1,4 +1,4 @@
-FROM golang:1.26.3 as builder
+FROM golang:1.26.4 as builder
 
 ARG CGO_ENABLED=0
 WORKDIR /go/src/github.com/newrelic/infrastructure-agent

--- a/test/proxy/Dockerfile_collector
+++ b/test/proxy/Dockerfile_collector
@@ -1,4 +1,4 @@
-FROM golang:1.26.3 as builder
+FROM golang:1.26.4 as builder
 ARG CGO_ENABLED=0
 WORKDIR /go/src/github.com/newrelic/infrastructure-agent
 COPY . .


### PR DESCRIPTION
## Summary
- Bumps Go toolchain from 1.26.3 to 1.26.4 across build Dockerfile, test Dockerfiles, and canary configs
- Fixes **CVE-2026-42504** (HIGH) — maliciously-crafted MIME header decoding vulnerability in Go stdlib
- Unblocks PRs that are currently failing the Trivy security gate

## Changes
| File | Change |
|------|--------|
| `build/Dockerfile` | `GO_VERSION` ARG: 1.26.3 → 1.26.4 |
| `test/proxy/Dockerfile_agent` | base image: golang:1.26.3 → 1.26.4 |
| `test/proxy/Dockerfile_collector` | base image: golang:1.26.3 → 1.26.4 |
| `test/databind/fargate/Dockerfile_test` | base image: golang:1.26.3 → 1.26.4 |
| `test/canaries/deploy_macos_canaries.yml` | go_version: 1.26.3 → 1.26.4 |

## Test plan
- [x] CI builds successfully with Go 1.26.4
- [ ] Trivy security scan passes with no HIGH/CRITICAL findings
- [x] Unit tests pass
