### PR TITLE
test(mac13): Remove macos-13 from CI test matrix

### DIFF
--- a/.github/workflows/component_macos_harvest_test.yml
+++ b/.github/workflows/component_macos_harvest_test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macos-13, macos-14, macos-15 ]
+        os: [ macos-14, macos-15 ]
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
## Summary

- Remove `macos-13` from the macOS harvest test workflow matrix
- macOS 13 has been EOL since September 2025 and GitHub Actions runners are no longer available
- CI jobs for macos-13 queue for 24 hours and never execute, eventually getting auto-cancelled

## References

- Jira: https://new-relic.atlassian.net/browse/NR-564881
- Example failed run: https://github.com/newrelic/infrastructure-agent/actions/runs/25362123990/job/74369869708?pr=2230

## Test plan

- [ ] Verify CI passes without macos-13 in the matrix
- [ ] Confirm macos-14 and macos-15 harvest tests still run successfully