### PR TITLE
chore: bump embedded integration versions to latest

### DIFF
--- a/build/embed/integrations.version
+++ b/build/embed/integrations.version
@@ -1,5 +1,5 @@
 #ohi-repo-name,version
-nri-docker,v2.7.3
-nri-flex,v1.18.7
-nri-winservices,v1.5.2
-nri-prometheus,v2.29.3
+nri-docker,v2.8.1
+nri-flex,v1.18.8
+nri-winservices,v1.5.3
+nri-prometheus,v2.29.4


### PR DESCRIPTION
## What
Bumps embedded integration pins to latest: `nri-docker v2.7.3→v2.8.1`, `nri-flex v1.18.7→v1.18.8`, `nri-winservices v1.5.2→v1.5.3`, `nri-prometheus v2.29.3→v2.29.4`.

## Why
Pick up the latest integration releases (incl. `nri-prometheus v2.29.4` carrying the go1.26.5 security fix) ahead of the agent pre-release.
