### PR TITLE
chore(deps): bump Go to 1.26.5

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:16.04
 
 # Define Go version
-ARG GO_VERSION=1.26.4
+ARG GO_VERSION=1.26.5
 # Define build-time arguments for the GitHub CLI version and architecture
 ARG GH_VERSION='2.0.0'
 ARG GH_ARCH='amd64'
@@ -33,7 +33,6 @@ RUN apt-get update && apt-get install -y \
 # RUN apt-get install -y \
 # gcc-5-multilib-mips-linux-gnu
 
-# Install Go 1.26.4
 RUN curl -sSL https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz -o go${GO_VERSION}.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && \
     rm go${GO_VERSION}.linux-amd64.tar.gz

--- a/test/canaries/deploy_macos_canaries.yml
+++ b/test/canaries/deploy_macos_canaries.yml
@@ -30,7 +30,7 @@
             vars:
               self_instrumentation: true
               target_agent_version: "{{ current_version }}"
-              go_version: 1.26.4
+              go_version: 1.26.5
               display_name: "{{ inventory_hostname }}-current"
 
 - hosts: macos_previous
@@ -50,6 +50,6 @@
             vars:
               self_instrumentation: true
               target_agent_version: "{{ previous_version }}"
-              go_version: 1.26.4
+              go_version: 1.26.5
               display_name: "{{ inventory_hostname }}-previous"
 ...

--- a/test/databind/fargate/Dockerfile_test
+++ b/test/databind/fargate/Dockerfile_test
@@ -1,4 +1,4 @@
-FROM golang:1.26.4
+FROM golang:1.26.5
 
 WORKDIR /go/src/github.com/newrelic/infrastructure-agent/
 

--- a/test/proxy/Dockerfile_agent
+++ b/test/proxy/Dockerfile_agent
@@ -1,4 +1,4 @@
-FROM golang:1.26.4 as builder
+FROM golang:1.26.5 as builder
 
 ARG CGO_ENABLED=0
 WORKDIR /go/src/github.com/newrelic/infrastructure-agent

--- a/test/proxy/Dockerfile_collector
+++ b/test/proxy/Dockerfile_collector
@@ -1,4 +1,4 @@
-FROM golang:1.26.4 as builder
+FROM golang:1.26.5 as builder
 ARG CGO_ENABLED=0
 WORKDIR /go/src/github.com/newrelic/infrastructure-agent
 COPY . .

--- a/tools/cdn-purge/go.mod
+++ b/tools/cdn-purge/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/infrastructure-agent/tools/cdn-purge
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.39.0

--- a/tools/spin-ec2/go.mod
+++ b/tools/spin-ec2/go.mod
@@ -1,6 +1,6 @@
 module spin-ec2
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/spf13/cobra v1.10.1

--- a/tools/yamlgen/go.mod
+++ b/tools/yamlgen/go.mod
@@ -1,6 +1,6 @@
 module yamlgen
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
## What
bump go version to 1.26.5

## Why
[go1.26.5](https://go.dev/doc/devel/release#go1.26.5) ships standard-library security fixes.