### PR TITLE
chore(deps): bump newrelic-fluent-bit-output to 3.7.0 (linux)

### DIFF
--- a/build/embed/fluent-bit.version
+++ b/build/embed/fluent-bit.version
@@ -5,7 +5,7 @@
 #
 # OS, newrelic_plugin_version, fluent-bit
 
-linux,3.6.0
+linux,3.7.0
 windows,3.6.0,5.0.6
 #To be removed on removal of the ff fluent_bit_19
 windows-legacy,1.19.1,1.9.3


### PR DESCRIPTION
## What
Bump the embedded New Relic fluent-bit output plugin (**linux**) from `3.6.0` → `3.7.0`.

## Why
`3.6.0` ships `out_newrelic.so` built with **go1.25.9**, which JFrog Xray flags in infra-agent 1.77.1 for 13 High/Medium Go-stdlib CVEs. `3.7.0` is rebuilt with **go1.26.4**, clearing all 13.

```shell
┌────────────────┬────────────┬─────────────────────────────────┬─────────────────────┐
│      CVE       │ Sev / CVSS │      Root (Go stdlib area)      │      Fixed in       │
├────────────────┼────────────┼─────────────────────────────────┼─────────────────────┤
│ CVE-2026-39820 │ High 7.5   │ net/mail ParseAddress DoS       │ go 1.25.10 / 1.26.3 │
├────────────────┼────────────┼─────────────────────────────────┼─────────────────────┤
│ CVE-2026-42499 │ High 7.5   │ net/mail consumePhrase DoS      │ 1.25.10 / 1.26.3    │
├────────────────┼────────────┼─────────────────────────────────┼─────────────────────┤
│ CVE-2026-33814 │ High 7.5   │ HTTP/2 CONTINUATION loop        │ 1.25.10 / 1.26.3    │
├────────────────┼────────────┼─────────────────────────────────┼─────────────────────┤
│ CVE-2026-42501 │ High 7.5   │ go cmd checksum bypass          │ 1.25.10 / 1.26.3    │
├────────────────┼────────────┼─────────────────────────────────┼─────────────────────┤
│ CVE-2026-33811 │ High 7.5   │ cgo LookupCNAME double-free     │ 1.25.10 / 1.26.3    │
├────────────────┼────────────┼─────────────────────────────────┼─────────────────────┤
│ CVE-2026-42504 │ High 7.5   │ mime DecodeHeader DoS           │ 1.25.11 / 1.26.4    │
├────────────────┼────────────┼─────────────────────────────────┼─────────────────────┤
│ CVE-2026-39817 │ Med 5.9    │ go tool pack path traversal     │ 1.25.10 / 1.26.3    │
├────────────────┼────────────┼─────────────────────────────────┼─────────────────────┤
│ CVE-2026-39819 │ Med 5.3    │ go bug symlink                  │ 1.25.10 / 1.26.3    │
├────────────────┼────────────┼─────────────────────────────────┼─────────────────────┤
│ CVE-2026-39823 │ Med 6.1    │ html/template XSS               │ 1.25.10 / 1.26.3    │
├────────────────┼────────────┼─────────────────────────────────┼─────────────────────┤
│ CVE-2026-39825 │ Med 5.3    │ ReverseProxy query leak         │ 1.25.10 / 1.26.3    │
├────────────────┼────────────┼─────────────────────────────────┼─────────────────────┤
│ CVE-2026-39826 │ Med 6.1    │ html/template escaping          │ 1.25.10 / 1.26.3    │
├────────────────┼────────────┼─────────────────────────────────┼─────────────────────┤
│ CVE-2026-27145 │ Med 6.5    │ x509 VerifyHostname quadratic   │ 1.25.11 / 1.26.4    │
├────────────────┼────────────┼─────────────────────────────────┼─────────────────────┤
│ CVE-2026-42507 │ Med 5.3    │ net/textproto error injection   │ 1.25.11 / 1.26.4    │
├────────────────┼────────────┼─────────────────────────────────┼─────────────────────┤
```