### PR TITLE
feat: Ignore default integration repository when Agent Control manages integrations

### DIFF
--- a/cmd/newrelic-infra/newrelic-infra.go
+++ b/cmd/newrelic-infra/newrelic-infra.go
@@ -280,6 +280,13 @@ var aslog = wlog.WithComponent("AgentService").WithFields(logrus.Fields{
 func initializeAgentAndRun(c *config.Config, logFwCfg config.LogForward) error {
 	pluginSourceDirs := getPluginSourceDirs(c)
 
+	integrationsMode := "standalone"
+	if c.DisablePluginDefaultDirScan {
+		integrationsMode = "agent-control-managed"
+	}
+
+	aslog.WithField("mode", integrationsMode).Info("Integration management mode")
+
 	v4ManagerConfig := v4.NewManagerConfig(
 		c.Log.VerboseEnabled(),
 		c.DefaultIntegrationsTempDir,
@@ -688,11 +695,18 @@ func getPluginSourceDirs(ac *config.Config) []string {
 		filepath.Join(ac.SafeBinDir, config.DefaultIntegrationsDir),
 		filepath.Join(ac.SafeBinDir, "custom-integrations"),
 		ac.CustomPluginInstallationDir,
-		filepath.Join(ac.AgentDir, "custom-integrations"),
-		filepath.Join(ac.AgentDir, config.DefaultIntegrationsDir),
-		filepath.Join(ac.AgentDir, "bundled-plugins"),
-		filepath.Join(ac.AgentDir, "plugins"),
 	}
+
+	// Default locations under agent_dir. These are skipped when DisablePluginDefaultDirScan is set.
+	if !ac.DisablePluginDefaultDirScan {
+		pluginSourceDirs = append(pluginSourceDirs,
+			filepath.Join(ac.AgentDir, "custom-integrations"),
+			filepath.Join(ac.AgentDir, config.DefaultIntegrationsDir),
+			filepath.Join(ac.AgentDir, "bundled-plugins"),
+			filepath.Join(ac.AgentDir, "plugins"),
+		)
+	}
+
 	return helpers.RemoveEmptyAndDuplicateEntries(pluginSourceDirs)
 }
 

--- a/cmd/newrelic-infra/newrelicinfra_test.go
+++ b/cmd/newrelic-infra/newrelicinfra_test.go
@@ -1,9 +1,12 @@
 // Copyright 2020 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+
+//nolint:exhaustruct
 package main
 
 import (
 	"io/ioutil"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,4 +37,72 @@ func Test_configureLogRedirection(t *testing.T) {
 	dat, err := ioutil.ReadFile(logFile.Name())
 	require.NoError(t, err)
 	assert.Equal(t, "example logs here", string(dat))
+}
+
+func Test_getPluginSourceDirs(t *testing.T) {
+	t.Parallel()
+
+	const (
+		safeBinDir = "/opt/newrelic-infra"
+		agentDir   = "/var/db/newrelic-infra"
+		customDir  = "/custom/integrations"
+	)
+
+	// Explicitly configured source dirs, always scanned.
+	safeBinNRI := filepath.Join(safeBinDir, config.DefaultIntegrationsDir)
+	safeBinCustom := filepath.Join(safeBinDir, "custom-integrations")
+	// Default source dirs under agent_dir, skipped when the flag is set.
+	agentCustom := filepath.Join(agentDir, "custom-integrations")
+	agentNRI := filepath.Join(agentDir, config.DefaultIntegrationsDir)
+	agentBundled := filepath.Join(agentDir, "bundled-plugins")
+	agentPlugins := filepath.Join(agentDir, "plugins")
+
+	cases := []struct {
+		name            string
+		disableScan     bool
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name:        "standalone mode scans the default integration dirs",
+			disableScan: false,
+			wantContains: []string{
+				safeBinNRI, safeBinCustom, customDir,
+				agentCustom, agentNRI, agentBundled, agentPlugins,
+			},
+		},
+		{
+			name:        "flag enabled scans only the explicitly configured source dirs",
+			disableScan: true,
+			wantContains: []string{
+				safeBinNRI, safeBinCustom, customDir,
+			},
+			wantNotContains: []string{
+				agentCustom, agentNRI, agentBundled, agentPlugins,
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &config.Config{
+				SafeBinDir:                  safeBinDir,
+				AgentDir:                    agentDir,
+				CustomPluginInstallationDir: customDir,
+				DisablePluginDefaultDirScan: testCase.disableScan,
+			}
+
+			got := getPluginSourceDirs(cfg)
+
+			for _, dir := range testCase.wantContains {
+				assert.Contains(t, got, dir)
+			}
+
+			for _, dir := range testCase.wantNotContains {
+				assert.NotContains(t, got, dir)
+			}
+		})
+	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -872,6 +872,17 @@ type Config struct {
 	// Public: No
 	CustomPluginInstallationDir string `yaml:"custom_plugin_installation_dir" envconfig:"custom_plugin_installation_dir" public:"false"`
 
+	// DisablePluginDefaultDirScan, when enabled, stops the agent from scanning the default integration
+	// locations, so it only loads integrations from the explicitly configured locations (safe_bin_dir,
+	// custom_plugin_installation_dir and plugin_dir). This avoids loading stale or conflicting integrations
+	// from the default locations. It skips, under agent_dir: custom-integrations, newrelic-integrations,
+	// bundled-plugins and plugins (integration binaries and v3 definitions); the default integration config
+	// dirs (e.g. /etc/newrelic-infra/integrations.d and agent_dir/integrations.d); and the legacy
+	// newrelic-infra-plugins.yml files.
+	// Default: false
+	// Public: No
+	DisablePluginDefaultDirScan bool `envconfig:"disable_plugin_default_dir_scan" public:"false" yaml:"disable_plugin_default_dir_scan"` //nolint:lll
+
 	// PluginDir Directory containing integrations configuration files of the integrations. Each integration has his
 	// own configuration file, named by default <integration_name>-config.yml, placed in a predefined location from
 	// which the agent will load on initialization.
@@ -2325,8 +2336,15 @@ func NormalizeConfig(cfg *Config, cfgMetadata config_loader.YAMLMetadata) (err e
 		cfg.FluentBitNRLibPath = filepath.Join(cfg.LoggingHomeDir, defaultFluentBitNRLib)
 	}
 
-	cfg.PluginInstanceDirs = helpers.RemoveEmptyAndDuplicateEntries(
-		[]string{cfg.PluginDir, defaultPluginInstanceDir, filepath.Join(cfg.AgentDir, defaultPluginActiveConfigsDir)})
+	// plugin_dir is the explicitly configured integration config dir and is always scanned. The default
+	// config dirs are skipped when DisablePluginDefaultDirScan is set.
+	pluginInstanceDirs := []string{cfg.PluginDir}
+	if !cfg.DisablePluginDefaultDirScan {
+		pluginInstanceDirs = append(pluginInstanceDirs,
+			defaultPluginInstanceDir, filepath.Join(cfg.AgentDir, defaultPluginActiveConfigsDir))
+	}
+
+	cfg.PluginInstanceDirs = helpers.RemoveEmptyAndDuplicateEntries(pluginInstanceDirs)
 
 	if cfg.Log.File == "" && runtime.GOOS == "windows" {
 		cfg.Log.File = "true"
@@ -2337,8 +2355,13 @@ func NormalizeConfig(cfg *Config, cfgMetadata config_loader.YAMLMetadata) (err e
 		nlog.WithField("LogFile", cfg.Log.File).Debug("Logging to file.")
 	}
 
-	// Caution: PluginConfigFiles is ALWAYS defined with the default value. Is this right? Be aware any change could affect backwards compatibilities.
-	cfg.PluginConfigFiles = defaultPluginConfigFiles
+	// PluginConfigFiles defaults to the standard newrelic-infra-plugins.yml locations.
+	// When DisablePluginDefaultDirScan is set these files are skipped.
+	if cfg.DisablePluginDefaultDirScan {
+		cfg.PluginConfigFiles = []string{}
+	} else {
+		cfg.PluginConfigFiles = defaultPluginConfigFiles
+	}
 
 	if cfg.PayloadCompressionLevel < gzip.NoCompression || cfg.PayloadCompressionLevel > gzip.BestCompression {
 		nlog.WithFields(logrus.Fields{

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"testing"
@@ -729,6 +730,104 @@ verbose: 0
 	assert.Equal(t, "xxx", cfg.License)
 	assert.Equal(t, "10.0.2.2:8888", cfg.Proxy)
 	assert.Equal(t, LogLevelInfo, cfg.Log.Level)
+}
+
+func TestLoadYamlConfig_disablePluginDefaultDirScan(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{
+			// Customer does not set the option: it must default to false so the agent keeps scanning
+			// the default integration dirs (backward compatible).
+			name: "omitted defaults to false",
+			yaml: `license_key: "xxx"`,
+			want: false,
+		},
+		{
+			name: "explicitly enabled",
+			yaml: "license_key: \"xxx\"\ndisable_plugin_default_dir_scan: true",
+			want: true,
+		},
+		{
+			name: "explicitly disabled",
+			yaml: "license_key: \"xxx\"\ndisable_plugin_default_dir_scan: false",
+			want: false,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmp, err := createTestFile([]byte(testCase.yaml))
+			require.NoError(t, err)
+
+			defer os.Remove(tmp.Name())
+
+			cfg, err := LoadConfig(tmp.Name())
+			require.NoError(t, err)
+
+			assert.Equal(t, testCase.want, cfg.DisablePluginDefaultDirScan)
+		})
+	}
+}
+
+// TestNormalizeConfig_disablePluginDefaultDirScan verifies the flag drops the default (standalone)
+// integration config dirs and the legacy newrelic-infra-plugins.yml files, keeping only plugin_dir.
+func TestNormalizeConfig_disablePluginDefaultDirScan(t *testing.T) {
+	t.Parallel()
+
+	const (
+		pluginDir = "/ac/integrations.d"
+		agentDir  = "/var/db/newrelic-infra"
+	)
+
+	agentConfigDir := filepath.Join(agentDir, defaultPluginActiveConfigsDir)
+
+	loadWith := func(t *testing.T, disable bool) *Config {
+		t.Helper()
+
+		yamlData := fmt.Sprintf(
+			"license_key: \"xxx\"\nagent_dir: %q\nplugin_dir: %q\ndisable_plugin_default_dir_scan: %t",
+			agentDir, pluginDir, disable)
+
+		tmp, err := createTestFile([]byte(yamlData))
+		require.NoError(t, err)
+
+		defer os.Remove(tmp.Name())
+
+		cfg, err := LoadConfig(tmp.Name())
+		require.NoError(t, err)
+
+		return cfg
+	}
+
+	t.Run("standalone scans default config dirs and legacy plugin files", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := loadWith(t, false)
+
+		// agentConfigDir (agent_dir/integrations.d) is platform-independent and always appended in
+		// standalone mode; defaultPluginInstanceDir is only set on Linux/Windows, so we don't assert it here.
+		assert.Contains(t, cfg.PluginInstanceDirs, pluginDir)
+		assert.Contains(t, cfg.PluginInstanceDirs, agentConfigDir)
+		assert.Equal(t, defaultPluginConfigFiles, cfg.PluginConfigFiles)
+	})
+
+	t.Run("managed mode keeps only plugin_dir and drops legacy plugin files", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := loadWith(t, true)
+
+		assert.Equal(t, []string{pluginDir}, cfg.PluginInstanceDirs)
+		assert.NotContains(t, cfg.PluginInstanceDirs, defaultPluginInstanceDir)
+		assert.NotContains(t, cfg.PluginInstanceDirs, agentConfigDir)
+		assert.Empty(t, cfg.PluginConfigFiles)
+	})
 }
 
 func TestLoadYamlConfig_withLogVariables(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds an `agent_control_managed` config option (env: `NRIA_AGENT_CONTROL_MANAGED`) that, when enabled, stops the agent from scanning the default custom-integrations repository under `agent_dir` (e.g. `/var/db/newrelic-infra/custom-integrations`).

This avoids loading stale or conflicting integrations from the old path when Agent Control manages integrations via `NRIA_CUSTOM_PLUGIN_INSTALLATION_DIR` / `NRIA_SAFE_BIN_DIR`.

## Changes

- **`pkg/config/config.go`** — new public config field `AgentControlManaged` (`agent_control_managed` / `NRIA_AGENT_CONTROL_MANAGED`), default `false`.
- **`cmd/newrelic-infra/newrelic-infra.go`** — `getPluginSourceDirs` skips `agent_dir/custom-integrations` when the option is enabled. The `SafeBinDir`-rooted directories and `CustomPluginInstallationDir` (the AC-managed locations) remain scanned.
- **Startup logging** — the integration management mode (`standalone` or `agent-control-managed`) is logged at INFO on agent startup.

## Behavior

- **Default (`false`)** — no change; the agent keeps scanning the default repository. Fully backward-compatible.
- **Enabled (`true`)** — the default `agent_dir/custom-integrations` path is excluded from integration discovery.

## Testing

- `Test_getPluginSourceDirs` — asserts the default path is scanned in standalone mode and excluded in AC-managed mode.
- `TestLoadYamlConfig_agentControlManaged` — asserts the option defaults to `false` when omitted and parses explicit `true`/`false`.
- `gofmt -s` clean.