### PR TITLE
update fb garbage collection for non default location

### DIFF
--- a/cmd/newrelic-infra/initialize/initialize.go
+++ b/cmd/newrelic-infra/initialize/initialize.go
@@ -9,8 +9,10 @@ package initialize
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/newrelic/infrastructure-agent/pkg/config"
+	v4 "github.com/newrelic/infrastructure-agent/pkg/integrations/v4"
 )
 
 const tempFolderMode = 0o755
@@ -20,25 +22,26 @@ var (
 	mkdirFunc  = os.MkdirAll  // nolint:gochecknoglobals
 )
 
-// nolint:godot
-// emptyTemporaryFolder deletes all files inside the default agent's temporary folder,
-// only if configuration option matches the default value.
-//
-// Default (Linux): /var/db/newrelic-infra/tmp
-// Default (MacOS AMD): /usr/local/var/db/newrelic-infra/tmp
-// Default (MacOS ARM): /opt/homebrew/var/db/newrelic-infra/tmp
-// Default (Windows): c:\ProgramData\New Relic\newrelic-infra\tmp
-func emptyTemporaryFolder(cfg *config.Config) error {
-	if cfg.AgentTempDir == agentTemporaryFolder {
-		err := removeFunc(agentTemporaryFolder)
-		if err != nil {
-			return fmt.Errorf("can't empty agent temporary folder: %w", err)
-		}
+// emptyFbConfigTempFolder deletes all files inside the FluentBit config temp folder
+// (<AgentTempDir>/fb), regardless of whether AgentTempDir is set to its default value
+// or to a custom location via NRIA_AGENT_TEMP_DIR. It's scoped to the "fb" subfolder,
+// not the whole AgentTempDir, since the latter may point at a shared system temp
+// directory (e.g. the Linux/macOS default is os.TempDir()).
+func emptyFbConfigTempFolder(cfg *config.Config) error {
+	if cfg.AgentTempDir == "" {
+		return nil
+	}
 
-		err = mkdirFunc(agentTemporaryFolder, tempFolderMode)
-		if err != nil {
-			return fmt.Errorf("can't create agent temporary folder: %w", err)
-		}
+	fbTempFolder := filepath.Join(cfg.AgentTempDir, v4.FbConfTempFolderNameDefault)
+
+	err := removeFunc(fbTempFolder)
+	if err != nil {
+		return fmt.Errorf("can't empty fb temporary folder: %w", err) //nolint:wrapcheck
+	}
+
+	err = mkdirFunc(fbTempFolder, tempFolderMode)
+	if err != nil {
+		return fmt.Errorf("can't create fb temporary folder: %w", err) //nolint:wrapcheck
 	}
 
 	return nil

--- a/cmd/newrelic-infra/initialize/initialize_darwin_amd64.go
+++ b/cmd/newrelic-infra/initialize/initialize_darwin_amd64.go
@@ -8,14 +8,19 @@ package initialize
 
 import (
 	"github.com/newrelic/infrastructure-agent/pkg/config"
+	"github.com/newrelic/infrastructure-agent/pkg/log"
 )
-
-// only used in windows. it will be refactored.
-const agentTemporaryFolder = "/usr/local/var/db/newrelic-infra/tmp"
 
 // AgentService performs OS-specific initialization steps for the Agent service.
 // It is executed after the initialize.osProcess function.
 func AgentService(cfg *config.Config) error {
+	err := emptyFbConfigTempFolder(cfg)
+	if err != nil {
+		log.WithField("agentTempDir", cfg.AgentTempDir).
+			WithError(err).
+			Error("error emptying fb config temp folder")
+	}
+
 	return nil
 }
 

--- a/cmd/newrelic-infra/initialize/initialize_darwin_arm64.go
+++ b/cmd/newrelic-infra/initialize/initialize_darwin_arm64.go
@@ -8,14 +8,19 @@ package initialize
 
 import (
 	"github.com/newrelic/infrastructure-agent/pkg/config"
+	"github.com/newrelic/infrastructure-agent/pkg/log"
 )
-
-// only used in windows. it will be refactored.
-const agentTemporaryFolder = "/opt/homebrew/var/db/newrelic-infra/tmp"
 
 // AgentService performs OS-specific initialization steps for the Agent service.
 // It is executed after the initialize.osProcess function.
 func AgentService(cfg *config.Config) error {
+	err := emptyFbConfigTempFolder(cfg)
+	if err != nil {
+		log.WithField("agentTempDir", cfg.AgentTempDir).
+			WithError(err).
+			Error("error emptying fb config temp folder")
+	}
+
 	return nil
 }
 

--- a/cmd/newrelic-infra/initialize/initialize_linux.go
+++ b/cmd/newrelic-infra/initialize/initialize_linux.go
@@ -23,7 +23,6 @@ import (
 )
 
 const (
-	agentTemporaryFolder       = "/var/db/newrelic-infra/tmp"
 	pidFolderPermissions       = 0o755
 	pidFilePermissions         = 0o644
 	integrationsDirPermissions = 0o755
@@ -32,6 +31,13 @@ const (
 // AgentService performs OS-specific initialization steps for the Agent service.
 // It is executed after the initialize.osProcess function.
 func AgentService(cfg *config.Config) error {
+	err := emptyFbConfigTempFolder(cfg)
+	if err != nil {
+		log.WithField("agentTempDir", cfg.AgentTempDir).
+			WithError(err).
+			Error("error emptying fb config temp folder")
+	}
+
 	return nil
 }
 

--- a/cmd/newrelic-infra/initialize/initialize_test.go
+++ b/cmd/newrelic-infra/initialize/initialize_test.go
@@ -7,12 +7,14 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/newrelic/infrastructure-agent/pkg/config"
+	v4 "github.com/newrelic/infrastructure-agent/pkg/integrations/v4"
 	"github.com/newrelic/infrastructure-agent/pkg/log"
 	logHelper "github.com/newrelic/infrastructure-agent/test/log"
 )
@@ -23,7 +25,7 @@ var (
 )
 
 //nolint:tparallel
-func Test_emptyTemporaryFolder(t *testing.T) {
+func Test_emptyFbConfigTempFolder(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -38,35 +40,37 @@ func Test_emptyTemporaryFolder(t *testing.T) {
 			agentTempDir: "",
 		},
 		{
-			name:         "Some Random Existing Path should not be deleted",
-			agentTempDir: "/some/random/path",
+			name:         "Default path should be deleted",
+			agentTempDir: "/var/db/newrelic-infra/tmp",
+			removeFunc:   func(string) error { return nil },
+			mkdirFunc:    func(string, os.FileMode) error { return nil },
 		},
 		{
-			name:         "Default path should be deleted",
-			agentTempDir: agentTemporaryFolder,
+			name:         "Custom/non-default path should also be deleted",
+			agentTempDir: "/some/random/path",
 			removeFunc:   func(string) error { return nil },
 			mkdirFunc:    func(string, os.FileMode) error { return nil },
 		},
 		{
 			name:          "Error removing should log",
-			agentTempDir:  agentTemporaryFolder,
+			agentTempDir:  "/some/random/path",
 			removeFunc:    func(string) error { return errForRmdir },
 			mkdirFunc:     func(string, os.FileMode) error { return nil },
-			expectedError: fmt.Errorf("can't empty agent temporary folder: %w", errForRmdir),
+			expectedError: fmt.Errorf("can't empty fb temporary folder: %w", errForRmdir),
 		},
 		{
 			name:          "Error creating should log",
-			agentTempDir:  agentTemporaryFolder,
+			agentTempDir:  "/some/random/path",
 			removeFunc:    func(string) error { return nil },
 			mkdirFunc:     func(string, os.FileMode) error { return errForMkdir },
-			expectedError: fmt.Errorf("can't create agent temporary folder: %w", errForMkdir),
+			expectedError: fmt.Errorf("can't create fb temporary folder: %w", errForMkdir),
 		},
 		{
 			name:          "Error creating and removing should log both",
-			agentTempDir:  agentTemporaryFolder,
+			agentTempDir:  "/some/random/path",
 			removeFunc:    func(string) error { return errForRmdir },
 			mkdirFunc:     func(string, os.FileMode) error { return errForMkdir },
-			expectedError: fmt.Errorf("can't empty agent temporary folder: %w", errForRmdir),
+			expectedError: fmt.Errorf("can't empty fb temporary folder: %w", errForRmdir),
 		},
 	}
 
@@ -86,10 +90,39 @@ func Test_emptyTemporaryFolder(t *testing.T) {
 			hook := logHelper.NewInMemoryEntriesHook([]logrus.Level{logrus.FatalLevel, logrus.ErrorLevel})
 			log.AddHook(hook)
 
-			mkdirFunc = testCase.mkdirFunc
-			removeFunc = testCase.removeFunc
-			err := emptyTemporaryFolder(cfg)
+			var gotRemovePath, gotMkdirPath string
+
+			removeCalled, mkdirCalled := false, false
+
+			if testCase.removeFunc != nil {
+				removeFunc = func(path string) error {
+					removeCalled = true
+					gotRemovePath = path
+
+					return testCase.removeFunc(path)
+				}
+			}
+
+			if testCase.mkdirFunc != nil {
+				mkdirFunc = func(path string, mode os.FileMode) error {
+					mkdirCalled = true
+					gotMkdirPath = path
+
+					return testCase.mkdirFunc(path, mode)
+				}
+			}
+
+			err := emptyFbConfigTempFolder(cfg)
 			assert.Equal(t, testCase.expectedError, err)
+
+			expectedPath := filepath.Join(testCase.agentTempDir, v4.FbConfTempFolderNameDefault)
+			if removeCalled {
+				assert.Equal(t, expectedPath, gotRemovePath)
+			}
+
+			if mkdirCalled {
+				assert.Equal(t, expectedPath, gotMkdirPath)
+			}
 		})
 	}
 }

--- a/cmd/newrelic-infra/initialize/initialize_windows.go
+++ b/cmd/newrelic-infra/initialize/initialize_windows.go
@@ -27,7 +27,6 @@ const (
 	idlePriorityClass        = 0x00000040
 	normalPriorityClass      = 0x00000020
 	realtimePriorityClass    = 0x00000100
-	agentTemporaryFolder     = "C:\\ProgramData\\New Relic\\newrelic-infra\\tmp"
 )
 
 var priorityClasses = map[string]uint{
@@ -42,11 +41,11 @@ var priorityClasses = map[string]uint{
 // AgentService performs OS-specific initialization steps for the Agent service.
 // It is executed after the initialize.osProcess function
 func AgentService(cfg *config.Config) error {
-	err := emptyTemporaryFolder(cfg)
+	err := emptyFbConfigTempFolder(cfg)
 	if err != nil {
-		log.WithField("temporaryFolder", agentTemporaryFolder).
+		log.WithField("agentTempDir", cfg.AgentTempDir).
 			WithError(err).
-			Error("error emptying temporary folder")
+			Error("error emptying fb config temp folder")
 		os.Exit(1)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1319,12 +1319,12 @@ type Config struct {
 	// Public: Yes
 	Http HttpConfig `yaml:"http" envconfig:"http"`
 
-	// AgentTempDir is the directory where the agent stores temporary files (i.e. fb config, discovery...)
-	// It will be DELETED on every agent restart only if it matches default value
+	// AgentTempDir is the directory where the agent stores temporary files (i.e. fb config).
+	// Its "fb" subfolder is emptied on every agent restart, regardless of whether this is
+	// set to its default value or to a custom location.
 	//
-	// Default (Linux): /var/db/newrelic-infra/tmp
-	// Default (MacOS AMD): /usr/local/var/db/newrelic-infra/tmp
-	// Default (MacOS ARM): /opt/homebrew/var/db/newrelic-infra/tmp
+	// Default (Linux): result of os.TempDir()
+	// Default (MacOS): result of os.TempDir()
 	// Default (Windows): C:\ProgramData\New Relic\newrelic-infra\tmp
 	// Public: No
 	AgentTempDir string `envconfig:"agent_temp_dir" yaml:"agent_temp_dir"`


### PR DESCRIPTION
When `NRIA_AGENT_TEMP_DIR` is set to a non-default location, the agent does not clean up FluentBit-generated configuration files on startup. This can cause the directory to grow indefinitely. The agent must handle cleanup of `NRIA_AGENT_TEMP_DIR` when it points to a non-standard location.