### PR TITLE
Ignore default integration locations via disable_plugin_default_dir_scan

### DIFF
--- a/cmd/newrelic-infra/newrelic-infra.go
+++ b/cmd/newrelic-infra/newrelic-infra.go
@@ -280,6 +280,13 @@ var aslog = wlog.WithComponent("AgentService").WithFields(logrus.Fields{
 func initializeAgentAndRun(c *config.Config, logFwCfg config.LogForward) error {
 	pluginSourceDirs := getPluginSourceDirs(c)
 
+	integrationsMode := "standalone"
+	if c.DisablePluginDefaultDirScan {
+		integrationsMode = "agent-control-managed"
+	}
+
+	aslog.WithField("mode", integrationsMode).Info("Integration management mode")
+
 	v4ManagerConfig := v4.NewManagerConfig(
 		c.Log.VerboseEnabled(),
 		c.DefaultIntegrationsTempDir,
@@ -684,15 +691,19 @@ func checkEndpointReachable(
 }
 
 func getPluginSourceDirs(ac *config.Config) []string {
-	pluginSourceDirs := []string{
-		filepath.Join(ac.SafeBinDir, config.DefaultIntegrationsDir),
-		filepath.Join(ac.SafeBinDir, "custom-integrations"),
-		ac.CustomPluginInstallationDir,
-		filepath.Join(ac.AgentDir, "custom-integrations"),
-		filepath.Join(ac.AgentDir, config.DefaultIntegrationsDir),
-		filepath.Join(ac.AgentDir, "bundled-plugins"),
-		filepath.Join(ac.AgentDir, "plugins"),
+	pluginSourceDirs := []string{ac.CustomPluginInstallationDir}
+
+	if !ac.DisablePluginDefaultDirScan {
+		pluginSourceDirs = append(pluginSourceDirs,
+			filepath.Join(ac.SafeBinDir, config.DefaultIntegrationsDir),
+			filepath.Join(ac.SafeBinDir, "custom-integrations"),
+			filepath.Join(ac.AgentDir, "custom-integrations"),
+			filepath.Join(ac.AgentDir, config.DefaultIntegrationsDir),
+			filepath.Join(ac.AgentDir, "bundled-plugins"),
+			filepath.Join(ac.AgentDir, "plugins"),
+		)
 	}
+
 	return helpers.RemoveEmptyAndDuplicateEntries(pluginSourceDirs)
 }
 

--- a/cmd/newrelic-infra/newrelicinfra_test.go
+++ b/cmd/newrelic-infra/newrelicinfra_test.go
@@ -1,9 +1,12 @@
 // Copyright 2020 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+
+//nolint:exhaustruct
 package main
 
 import (
 	"io/ioutil"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,4 +37,73 @@ func Test_configureLogRedirection(t *testing.T) {
 	dat, err := ioutil.ReadFile(logFile.Name())
 	require.NoError(t, err)
 	assert.Equal(t, "example logs here", string(dat))
+}
+
+func Test_getPluginSourceDirs(t *testing.T) {
+	t.Parallel()
+
+	const (
+		safeBinDir = "/opt/newrelic-infra"
+		agentDir   = "/var/db/newrelic-infra"
+		customDir  = "/custom/integrations"
+	)
+
+	// custom_plugin_installation_dir is the only source dir kept when the flag is set.
+	// Default source dirs under safe_bin_dir and agent_dir are skipped when the flag is set.
+	safeBinNRI := filepath.Join(safeBinDir, config.DefaultIntegrationsDir)
+	safeBinCustom := filepath.Join(safeBinDir, "custom-integrations")
+	agentCustom := filepath.Join(agentDir, "custom-integrations")
+	agentNRI := filepath.Join(agentDir, config.DefaultIntegrationsDir)
+	agentBundled := filepath.Join(agentDir, "bundled-plugins")
+	agentPlugins := filepath.Join(agentDir, "plugins")
+
+	cases := []struct {
+		name            string
+		disableScan     bool
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name:        "standalone mode scans the default integration dirs",
+			disableScan: false,
+			wantContains: []string{
+				safeBinNRI, safeBinCustom, customDir,
+				agentCustom, agentNRI, agentBundled, agentPlugins,
+			},
+		},
+		{
+			name:        "flag enabled scans only custom_plugin_installation_dir",
+			disableScan: true,
+			wantContains: []string{
+				customDir,
+			},
+			wantNotContains: []string{
+				safeBinNRI, safeBinCustom,
+				agentCustom, agentNRI, agentBundled, agentPlugins,
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &config.Config{
+				SafeBinDir:                  safeBinDir,
+				AgentDir:                    agentDir,
+				CustomPluginInstallationDir: customDir,
+				DisablePluginDefaultDirScan: testCase.disableScan,
+			}
+
+			got := getPluginSourceDirs(cfg)
+
+			for _, dir := range testCase.wantContains {
+				assert.Contains(t, got, dir)
+			}
+
+			for _, dir := range testCase.wantNotContains {
+				assert.NotContains(t, got, dir)
+			}
+		})
+	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -872,6 +872,18 @@ type Config struct {
 	// Public: No
 	CustomPluginInstallationDir string `yaml:"custom_plugin_installation_dir" envconfig:"custom_plugin_installation_dir" public:"false"`
 
+	// DisablePluginDefaultDirScan, when enabled, stops the agent from scanning the default integration
+	// locations, so it only loads integrations from the explicitly configured locations
+	// (custom_plugin_installation_dir for binaries and plugin_dir for configs). This avoids loading stale or
+	// conflicting integrations from the default locations. It skips the integration binary/definition dirs
+	// under safe_bin_dir (newrelic-integrations, custom-integrations) and agent_dir (custom-integrations,
+	// newrelic-integrations, bundled-plugins, plugins); the default integration config dirs (e.g.
+	// /etc/newrelic-infra/integrations.d and agent_dir/integrations.d); and the legacy
+	// newrelic-infra-plugins.yml files.
+	// Default: false
+	// Public: No
+	DisablePluginDefaultDirScan bool `envconfig:"disable_plugin_default_dir_scan" public:"false" yaml:"disable_plugin_default_dir_scan"` //nolint:lll
+
 	// PluginDir Directory containing integrations configuration files of the integrations. Each integration has his
 	// own configuration file, named by default <integration_name>-config.yml, placed in a predefined location from
 	// which the agent will load on initialization.
@@ -2325,8 +2337,15 @@ func NormalizeConfig(cfg *Config, cfgMetadata config_loader.YAMLMetadata) (err e
 		cfg.FluentBitNRLibPath = filepath.Join(cfg.LoggingHomeDir, defaultFluentBitNRLib)
 	}
 
-	cfg.PluginInstanceDirs = helpers.RemoveEmptyAndDuplicateEntries(
-		[]string{cfg.PluginDir, defaultPluginInstanceDir, filepath.Join(cfg.AgentDir, defaultPluginActiveConfigsDir)})
+	// plugin_dir is the explicitly configured integration config dir and is always scanned. The default
+	// config dirs are skipped when DisablePluginDefaultDirScan is set.
+	pluginInstanceDirs := []string{cfg.PluginDir}
+	if !cfg.DisablePluginDefaultDirScan {
+		pluginInstanceDirs = append(pluginInstanceDirs,
+			defaultPluginInstanceDir, filepath.Join(cfg.AgentDir, defaultPluginActiveConfigsDir))
+	}
+
+	cfg.PluginInstanceDirs = helpers.RemoveEmptyAndDuplicateEntries(pluginInstanceDirs)
 
 	if cfg.Log.File == "" && runtime.GOOS == "windows" {
 		cfg.Log.File = "true"
@@ -2337,8 +2356,13 @@ func NormalizeConfig(cfg *Config, cfgMetadata config_loader.YAMLMetadata) (err e
 		nlog.WithField("LogFile", cfg.Log.File).Debug("Logging to file.")
 	}
 
-	// Caution: PluginConfigFiles is ALWAYS defined with the default value. Is this right? Be aware any change could affect backwards compatibilities.
-	cfg.PluginConfigFiles = defaultPluginConfigFiles
+	// PluginConfigFiles defaults to the standard newrelic-infra-plugins.yml locations.
+	// When DisablePluginDefaultDirScan is set these files are skipped.
+	if cfg.DisablePluginDefaultDirScan {
+		cfg.PluginConfigFiles = []string{}
+	} else {
+		cfg.PluginConfigFiles = defaultPluginConfigFiles
+	}
 
 	if cfg.PayloadCompressionLevel < gzip.NoCompression || cfg.PayloadCompressionLevel > gzip.BestCompression {
 		nlog.WithFields(logrus.Fields{

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"testing"
@@ -729,6 +730,104 @@ verbose: 0
 	assert.Equal(t, "xxx", cfg.License)
 	assert.Equal(t, "10.0.2.2:8888", cfg.Proxy)
 	assert.Equal(t, LogLevelInfo, cfg.Log.Level)
+}
+
+func TestLoadYamlConfig_disablePluginDefaultDirScan(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{
+			// Customer does not set the option: it must default to false so the agent keeps scanning
+			// the default integration dirs (backward compatible).
+			name: "omitted defaults to false",
+			yaml: `license_key: "xxx"`,
+			want: false,
+		},
+		{
+			name: "explicitly enabled",
+			yaml: "license_key: \"xxx\"\ndisable_plugin_default_dir_scan: true",
+			want: true,
+		},
+		{
+			name: "explicitly disabled",
+			yaml: "license_key: \"xxx\"\ndisable_plugin_default_dir_scan: false",
+			want: false,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmp, err := createTestFile([]byte(testCase.yaml))
+			require.NoError(t, err)
+
+			defer os.Remove(tmp.Name())
+
+			cfg, err := LoadConfig(tmp.Name())
+			require.NoError(t, err)
+
+			assert.Equal(t, testCase.want, cfg.DisablePluginDefaultDirScan)
+		})
+	}
+}
+
+// TestNormalizeConfig_disablePluginDefaultDirScan verifies the flag drops the default (standalone)
+// integration config dirs and the legacy newrelic-infra-plugins.yml files, keeping only plugin_dir.
+func TestNormalizeConfig_disablePluginDefaultDirScan(t *testing.T) {
+	t.Parallel()
+
+	const (
+		pluginDir = "/ac/integrations.d"
+		agentDir  = "/var/db/newrelic-infra"
+	)
+
+	agentConfigDir := filepath.Join(agentDir, defaultPluginActiveConfigsDir)
+
+	loadWith := func(t *testing.T, disable bool) *Config {
+		t.Helper()
+
+		yamlData := fmt.Sprintf(
+			"license_key: \"xxx\"\nagent_dir: %q\nplugin_dir: %q\ndisable_plugin_default_dir_scan: %t",
+			agentDir, pluginDir, disable)
+
+		tmp, err := createTestFile([]byte(yamlData))
+		require.NoError(t, err)
+
+		defer os.Remove(tmp.Name())
+
+		cfg, err := LoadConfig(tmp.Name())
+		require.NoError(t, err)
+
+		return cfg
+	}
+
+	t.Run("standalone scans default config dirs and legacy plugin files", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := loadWith(t, false)
+
+		// agentConfigDir (agent_dir/integrations.d) is platform-independent and always appended in
+		// standalone mode; defaultPluginInstanceDir is only set on Linux/Windows, so we don't assert it here.
+		assert.Contains(t, cfg.PluginInstanceDirs, pluginDir)
+		assert.Contains(t, cfg.PluginInstanceDirs, agentConfigDir)
+		assert.Equal(t, defaultPluginConfigFiles, cfg.PluginConfigFiles)
+	})
+
+	t.Run("managed mode keeps only plugin_dir and drops legacy plugin files", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := loadWith(t, true)
+
+		assert.Equal(t, []string{pluginDir}, cfg.PluginInstanceDirs)
+		assert.NotContains(t, cfg.PluginInstanceDirs, defaultPluginInstanceDir)
+		assert.NotContains(t, cfg.PluginInstanceDirs, agentConfigDir)
+		assert.Empty(t, cfg.PluginConfigFiles)
+	})
 }
 
 func TestLoadYamlConfig_withLogVariables(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a `disable_plugin_default_dir_scan` config option (env: `NRIA_DISABLE_PLUGIN_DEFAULT_DIR_SCAN`, internal-only) that, when enabled, stops the agent from scanning the **default** integration locations. The agent then loads integrations **only** from the two explicitly configured locations:

- `custom_plugin_installation_dir` (`NRIA_CUSTOM_PLUGIN_INSTALLATION_DIR`) — integration **binaries** / v3 definitions
- `plugin_dir` (`NRIA_PLUGIN_DIR`) — integration **configs**

This avoids loading stale or conflicting integrations left over from a standalone install (or writable by other users) when integrations are managed from a specific set of folders.

## What gets skipped when enabled

| Category | Skipped (default locations) | Kept (explicitly configured) |
|---|---|---|
| Integration binaries + v3 definitions | `safe_bin_dir/{newrelic-integrations, custom-integrations}` and `agent_dir/{custom-integrations, newrelic-integrations, bundled-plugins, plugins}` | `custom_plugin_installation_dir` |
| Integration config dirs | default `integrations.d` (e.g. `/etc/newrelic-infra/integrations.d`) + `agent_dir/integrations.d` | `plugin_dir` |
| Legacy master config | `newrelic-infra-plugins.yml` files | — (cleared; cannot be redirected via config) |

Logging (`logging.d`) is intentionally not affected.

> Note on `safe_bin_dir`: the actual integration binaries live at the **top level** of the binaries dir, which is covered by `custom_plugin_installation_dir` (Agent Control sets `NRIA_SAFE_BIN_DIR` = `NRIA_CUSTOM_PLUGIN_INSTALLATION_DIR`). The `safe_bin_dir/*` entries are only ever empty sub-folders, so dropping them loses nothing and guarantees isolation even if `NRIA_SAFE_BIN_DIR` isn't overridden.

## Behavior

- **Default (`false`)** — unchanged; all default locations are scanned. Fully backward-compatible.
- **Enabled (`true`)** — only `custom_plugin_installation_dir` (binaries) and `plugin_dir` (configs) are scanned.
- The integration management mode is logged at INFO on startup.

## Testing

- `Test_getPluginSourceDirs` — standalone scans all default source dirs; enabled scans **only** `custom_plugin_installation_dir` (asserts `safe_bin_dir/*` and `agent_dir/*` are absent).
- `TestLoadYamlConfig_disablePluginDefaultDirScan` — parsing + default-false.
- `TestNormalizeConfig_disablePluginDefaultDirScan` — `PluginInstanceDirs` collapses to `plugin_dir` only and `PluginConfigFiles` clears when enabled.
- Verified against golangci-lint v2.5.0 (0 issues) and validated at runtime on Linux (agent + nri-flex via default `integrations.d/` vs nri-nginx via custom `NRIA_PLUGIN_DIR` + `NRIA_CUSTOM_PLUGIN_INSTALLATION_DIR`).
