### PR TITLE
feat: remove nri-flex from agent-control artifacts

### DIFF
--- a/.github/workflows/agent_control_artifact.yml
+++ b/.github/workflows/agent_control_artifact.yml
@@ -322,7 +322,7 @@ jobs:
             rm -f debian-binary control.tar.gz data.tar.gz _gpgbuilder
 
             # Verify integrations exist
-            for INTEGRATION in nri-docker nri-prometheus nri-flex; do
+            for INTEGRATION in nri-docker nri-prometheus; do
               if [ ! -f "opt/newrelic-infra/newrelic-integrations/bin/${INTEGRATION}" ]; then
                 echo "::error::Integration not found: ${INTEGRATION}"
                 exit 1
@@ -365,7 +365,6 @@ jobs:
           # Copy integrations
           cp "${SRC}/newrelic-integrations/nri-winservices.exe" "${DEST}/integrations/"
           cp "${SRC}/newrelic-integrations/windows_exporter.exe" "${DEST}/integrations/"
-          cp "${SRC}/newrelic-integrations/nri-flex.exe" "${DEST}/integrations/"
           cp "${SRC}/newrelic-integrations/nri-prometheus.exe" "${DEST}/integrations/"
           cp "${SRC}/newrelic-integrations/nr-winpkg.exe" "${DEST}/integrations/"
 
@@ -415,7 +414,6 @@ jobs:
             # Copy integrations
             cp "${DEB_SRC}/opt/newrelic-infra/newrelic-integrations/bin/nri-docker" "${DEST}/integrations/"
             cp "${DEB_SRC}/opt/newrelic-infra/newrelic-integrations/bin/nri-prometheus" "${DEST}/integrations/"
-            cp "${DEB_SRC}/opt/newrelic-infra/newrelic-integrations/bin/nri-flex" "${DEST}/integrations/"
 
             # Copy logging components
             cp "${DEB_SRC}/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so" "${DEST}/logging/"


### PR DESCRIPTION
Why:

We are starting to support `nri-flex` as an OHI that you can install and doesn't need to be part of the infrastructure-agent artifact anymore.