### PR TITLE
security: fix rce with path traversal

### DIFF
--- a/internal/agent/delta/store.go
+++ b/internal/agent/delta/store.go
@@ -6,6 +6,7 @@ package delta
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -972,9 +973,39 @@ func (s *Store) UpdatePluginsInventoryCache(entityKey string) (err error) {
 	return
 }
 
+// ErrInvalidPluginPathComponent is returned when a plugin category or term cannot be used
+// safely as a filesystem path segment (e.g. it contains a path separator or is a bare "."/"..").
+var ErrInvalidPluginPathComponent = errors.New("invalid inventory plugin path component")
+
+// ErrPluginPathEscape is returned when the computed plugin output path would fall outside
+// the expected plugin data directory.
+var ErrPluginPathEscape = errors.New("plugin data path escapes data directory")
+
+// isValidPathComponent reports whether s is safe to use as a single filesystem
+// path segment: non-empty, not "." or "..", and unchanged by SanitizeFileName
+// (i.e. it contains none of the characters that function strips).
+func isValidPathComponent(s string) bool {
+	if s == "" || s == "." || s == ".." {
+		return false
+	}
+
+	return helpers.SanitizeFileName(s) == s
+}
+
 // StorePluginOutput will take a PluginOutput blob and write it to the
 // data directory in JSON format
 func (s *Store) SavePluginSource(entityKey, category, term string, source map[string]interface{}) (err error) {
+	// category and term can originate from an untrusted integration payload
+	// (e.g. the HTTP/TCP ingest endpoints); reject anything that isn't a plain
+	// path segment to prevent directory traversal.
+	if !isValidPathComponent(category) {
+		return fmt.Errorf("%w: category %q", ErrInvalidPluginPathComponent, category) //nolint:wrapcheck
+	}
+
+	if !isValidPathComponent(term) {
+		return fmt.Errorf("%w: term %q", ErrInvalidPluginPathComponent, term) //nolint:wrapcheck
+	}
+
 	// construct the plugin data directory and ensure it exists
 	outputDir := s.PluginDirPath(category, entityKey)
 	if err = disk.MkdirAll(outputDir, DATA_DIR_MODE); err != nil {
@@ -982,7 +1013,13 @@ func (s *Store) SavePluginSource(entityKey, category, term string, source map[st
 	}
 
 	// construct the output file path
-	outputFile := fmt.Sprintf("%s/%s.json", outputDir, term)
+	outputFile := filepath.Join(outputDir, term+".json")
+
+	// Defense in depth: ensure the resulting path is still within outputDir.
+	cleanOutputDir := filepath.Clean(outputDir) + string(os.PathSeparator)
+	if !strings.HasPrefix(filepath.Clean(outputFile), cleanOutputDir) {
+		return fmt.Errorf("%w: category %q term %q", ErrPluginPathEscape, category, term) //nolint:wrapcheck
+	}
 
 	sourceB, err := json.Marshal(source)
 	if err != nil {

--- a/internal/agent/delta/store_test.go
+++ b/internal/agent/delta/store_test.go
@@ -1162,3 +1162,65 @@ func TestStore_Path_PermissionDenied(t *testing.T) {
 	// THEN should return that exists as a bool
 	assert.True(t, exists)
 }
+
+func TestStore_SavePluginSource(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		category string
+		term     string
+		wantErr  bool
+	}{
+		{"valid category and term", "integration", "com.newrelic.nginx", false},
+		{"traversal in term", "integration", "../../../../../../etc/nr_pwned", true},
+		{"traversal in category", "../../../../../../etc", "nr_pwned", true},
+		{"term is dot-dot", "integration", "..", true},
+		{"category is dot-dot", "..", "nr_pwned", true},
+		{"term is dot", "integration", ".", true},
+		{"empty term", "integration", "", true},
+		{"empty category", "", "nr_pwned", true},
+		{"slash in term", "integration", "foo/bar", true},
+		{"backslash in term", "integration", `foo\bar`, true},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			dataDir, err := TempDeltaStoreDir()
+			require.NoError(t, err)
+
+			defer os.RemoveAll(dataDir)
+
+			ds := NewStore(dataDir, "default", maxInventorySize, true)
+
+			err = ds.SavePluginSource("", testCase.category, testCase.term, map[string]any{"a": "b"})
+
+			if testCase.wantErr {
+				require.Error(t, err)
+
+				// Validation must happen before anything is written to disk.
+				var files []string
+
+				err = filepath.Walk(dataDir, func(path string, info os.FileInfo, walkErr error) error {
+					if walkErr == nil && !info.IsDir() {
+						files = append(files, path)
+					}
+
+					return nil
+				})
+
+				require.NoError(t, err)
+				assert.Empty(t, files, "no file should be written when category/term is rejected")
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			expected := filepath.Join(dataDir, testCase.category, "__nria_localentity", testCase.term+".json")
+			assert.FileExists(t, expected)
+		})
+	}
+}

--- a/internal/agent/delta/store_test.go
+++ b/internal/agent/delta/store_test.go
@@ -1167,21 +1167,29 @@ func TestStore_SavePluginSource(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name     string
-		category string
-		term     string
-		wantErr  bool
+		name      string
+		category  string
+		term      string
+		wantErr   bool
+		wantErrIs error
 	}{
-		{"valid category and term", "integration", "com.newrelic.nginx", false},
-		{"traversal in term", "integration", "../../../../../../etc/nr_pwned", true},
-		{"traversal in category", "../../../../../../etc", "nr_pwned", true},
-		{"term is dot-dot", "integration", "..", true},
-		{"category is dot-dot", "..", "nr_pwned", true},
-		{"term is dot", "integration", ".", true},
-		{"empty term", "integration", "", true},
-		{"empty category", "", "nr_pwned", true},
-		{"slash in term", "integration", "foo/bar", true},
-		{"backslash in term", "integration", `foo\bar`, true},
+		{"valid category and term", "integration", "com.newrelic.nginx", false, nil},
+		{"traversal in term", "integration", "../../../../../../etc/nr_pwned", true, ErrInvalidPluginPathComponent},
+		{"traversal in category", "../../../../../../etc", "nr_pwned", true, ErrInvalidPluginPathComponent},
+		{"term is dot-dot", "integration", "..", true, ErrInvalidPluginPathComponent},
+		{"category is dot-dot", "..", "nr_pwned", true, ErrInvalidPluginPathComponent},
+		{"term is dot", "integration", ".", true, ErrInvalidPluginPathComponent},
+		{"empty term", "integration", "", true, ErrInvalidPluginPathComponent},
+		{"empty category", "", "nr_pwned", true, ErrInvalidPluginPathComponent},
+		{"slash in term", "integration", "foo/bar", true, ErrInvalidPluginPathComponent},
+		{"backslash in term", "integration", `foo\bar`, true, ErrInvalidPluginPathComponent},
+		{"term with embedded dots", "integration", "foo.bar.baz", false, nil},
+		{"term with leading and trailing dots", "integration", "..foo..", false, nil},
+		{"category with leading dot", ".hidden", "term", false, nil},
+		{"term with internal whitespace", "integration", "foo bar", false, nil},
+		{"term with leading and trailing whitespace", "integration", "  term  ", false, nil},
+		{"term is only whitespace", "integration", "   ", false, nil},
+		{"category with whitespace", "inte gration", "term", false, nil},
 	}
 
 	for _, testCase := range cases {
@@ -1199,6 +1207,10 @@ func TestStore_SavePluginSource(t *testing.T) {
 
 			if testCase.wantErr {
 				require.Error(t, err)
+
+				if testCase.wantErrIs != nil {
+					require.ErrorIs(t, err, testCase.wantErrIs)
+				}
 
 				// Validation must happen before anything is written to disk.
 				var files []string

--- a/internal/agent/delta/store_test.go
+++ b/internal/agent/delta/store_test.go
@@ -1190,6 +1190,8 @@ func TestStore_SavePluginSource(t *testing.T) {
 		{"term with leading and trailing whitespace", "integration", "  term  ", false, nil},
 		{"term is only whitespace", "integration", "   ", false, nil},
 		{"category with whitespace", "inte gration", "term", false, nil},
+		{"whitespace-padded dot-slash", "integration", " ./ ", true, ErrInvalidPluginPathComponent},
+		{"whitespace-padded dot-dot-slash", "integration", " ../ ", true, ErrInvalidPluginPathComponent},
 	}
 
 	for _, testCase := range cases {

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -260,6 +260,14 @@ func SanitizeFileName(fileName string) string {
 	}
 	result := string(sanitized[:i])
 
+	// A result of exactly "." or ".." is still a path-traversal component even
+	// though it contains no separator characters: filepath.Join/Clean treat it
+	// specially. Neutralize it so callers building paths from this value can't
+	// escape a directory via a bare "." or "..".
+	if result == "." || result == ".." {
+		result = ""
+	}
+
 	// Store it to cache and prevent cache growing too big.
 	sanitizeFileNameCache.RemoveUntilLen(SanitizeFileNameCacheSize)
 	sanitizeFileNameCache.Add(fileName, result)

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -189,19 +189,21 @@ func TestSanitizeFileName(t *testing.T) {
 		{"id<ent>if|||ier.txt", "identifier.txt"},
 		{"|<*identifier.txt::**?", "identifier.txt"},
 		{"identifier.txt", "identifier.txt"},
+		{".", ""},
+		{"..", ""},
 	}
 
 	for _, tt := range cases {
 		assert.Equal(t, tt.expected, SanitizeFileName(tt.input))
 	}
 	cacheLen := sanitizeFileNameCache.Len()
-	assert.Equal(t, cacheLen, 8, "sanitizeFileNameCache length assert failed")
+	assert.Equal(t, 10, cacheLen, "sanitizeFileNameCache length assert failed")
 
 	// Sanitize again the same value to assert that the SanitizeFileName cache correctly.
 	Case := cases[len(cases)-1]
 	assert.Equal(t, Case.expected, SanitizeFileName(Case.input))
 	cacheLen = sanitizeFileNameCache.Len()
-	assert.Equal(t, cacheLen, 8, "sanitizeFileNameCache length assert failed")
+	assert.Equal(t, 10, cacheLen, "sanitizeFileNameCache length assert failed")
 }
 
 func TestRemoveEmptyAndDuplicateEntries(t *testing.T) {


### PR DESCRIPTION
Unauthenticated TCP Integration Ingest Allows Root Arbitrary File Write via Path Traversal