### PR TITLE
feat: make env variables used by AC public

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1793,6 +1793,58 @@ func (c *Config) PublicFields() (map[string]string, error) {
 	return result, nil
 }
 
+// knownEnvVarNames returns the set of NRIA_* environment variable names (uppercased,
+// including the prefix) that map to a Config field, recursing into nested config
+// structs (e.g. Log, Http) the same way envconfig.Process does.
+func knownEnvVarNames(t reflect.Type, prefix string) map[string]struct{} {
+	names := make(map[string]struct{})
+	if t.Kind() != reflect.Struct {
+		return names
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag.Get("envconfig")
+		if tag == "" || tag == "ignored" {
+			continue
+		}
+
+		key := prefix + "_" + strings.ToUpper(tag)
+
+		fieldType := t.Field(i).Type
+		if fieldType.Kind() == reflect.Struct {
+			for name := range knownEnvVarNames(fieldType, key) {
+				names[name] = struct{}{}
+			}
+			continue
+		}
+
+		names[key] = struct{}{}
+	}
+
+	return names
+}
+
+// warnUnrecognizedEnvVars logs a warning for every NRIA_* environment variable that
+// doesn't correspond to a known Config field, so a mistyped or stale var (e.g. one set
+// by Agent Control when it launches the agent) doesn't get silently dropped.
+func warnUnrecognizedEnvVars(cfg *Config) {
+	known := knownEnvVarNames(reflect.TypeOf(*cfg), strings.ToUpper(envPrefix))
+	prefix := strings.ToUpper(envPrefix) + "_"
+
+	for _, kv := range os.Environ() {
+		name := strings.SplitN(kv, "=", 2)[0]
+		upperName := strings.ToUpper(name)
+
+		if !strings.HasPrefix(upperName, prefix) {
+			continue
+		}
+
+		if _, ok := known[upperName]; !ok {
+			clog.WithField("envVar", name).Warn("unrecognized NRIA_* environment variable, ignoring")
+		}
+	}
+}
+
 func LoadConfig(configFile string) (*Config, error) {
 	var filesToCheck []string
 	if configFile != "" {
@@ -1838,6 +1890,7 @@ func LoadConfig(configFile string) (*Config, error) {
 
 	// After the config file has loaded, override via any environment variables
 	configOverride(cfg)
+	warnUnrecognizedEnvVars(cfg)
 
 	cfg.RunMode, cfg.AgentUser, cfg.ExecutablePath = runtimeValues()
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1796,25 +1796,26 @@ func (c *Config) PublicFields() (map[string]string, error) {
 // knownEnvVarNames returns the set of NRIA_* environment variable names (uppercased,
 // including the prefix) that map to a Config field, recursing into nested config
 // structs (e.g. Log, Http) the same way envconfig.Process does.
-func knownEnvVarNames(t reflect.Type, prefix string) map[string]struct{} {
+func knownEnvVarNames(structType reflect.Type, prefix string) map[string]struct{} {
 	names := make(map[string]struct{})
-	if t.Kind() != reflect.Struct {
+	if structType.Kind() != reflect.Struct {
 		return names
 	}
 
-	for i := 0; i < t.NumField(); i++ {
-		tag := t.Field(i).Tag.Get("envconfig")
+	for fieldIdx := range structType.NumField() {
+		tag := structType.Field(fieldIdx).Tag.Get("envconfig")
 		if tag == "" || tag == "ignored" {
 			continue
 		}
 
 		key := prefix + "_" + strings.ToUpper(tag)
 
-		fieldType := t.Field(i).Type
+		fieldType := structType.Field(fieldIdx).Type
 		if fieldType.Kind() == reflect.Struct {
 			for name := range knownEnvVarNames(fieldType, key) {
 				names[name] = struct{}{}
 			}
+
 			continue
 		}
 
@@ -1828,11 +1829,12 @@ func knownEnvVarNames(t reflect.Type, prefix string) map[string]struct{} {
 // doesn't correspond to a known Config field, so a mistyped or stale var (e.g. one set
 // by Agent Control when it launches the agent) doesn't get silently dropped.
 func warnUnrecognizedEnvVars(cfg *Config) {
-	known := knownEnvVarNames(reflect.TypeOf(*cfg), strings.ToUpper(envPrefix))
+	known := knownEnvVarNames(reflect.TypeOf(cfg).Elem(), strings.ToUpper(envPrefix))
 	prefix := strings.ToUpper(envPrefix) + "_"
+	keyValuePairLen := 2
 
 	for _, kv := range os.Environ() {
-		name := strings.SplitN(kv, "=", 2)[0]
+		name := strings.SplitN(kv, "=", keyValuePairLen)[0]
 		upperName := strings.ToUpper(name)
 
 		if !strings.HasPrefix(upperName, prefix) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -917,8 +917,8 @@ type Config struct {
 
 	// LoggingBinDir folder containing binaries for the log forwarder.
 	// Default: /var/db/newrelic-infra/newrelic-integrations/logging/
-	// Public: No
-	LoggingBinDir string `yaml:"logging_bin_dir" envconfig:"logging_bin_dir" public:"false"`
+	// Public: Yes
+	LoggingBinDir string `envconfig:"logging_bin_dir" public:"true" yaml:"logging_bin_dir"`
 
 	// LoggingHomeDir folder containing plugins and other required files for the log forwarder.
 	// Default (Linux): /var/db/newrelic-infra/newrelic-integrations/logging/

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -869,8 +869,8 @@ type Config struct {
 	// allows to install integrations outside the agent_dir. It has the first priority when the agent is looking for
 	// installed integrations.
 	// Default: ""
-	// Public: No
-	CustomPluginInstallationDir string `yaml:"custom_plugin_installation_dir" envconfig:"custom_plugin_installation_dir" public:"false"`
+	// Public: Yes
+	CustomPluginInstallationDir string `envconfig:"custom_plugin_installation_dir" public:"true" yaml:"custom_plugin_installation_dir"` //nolint:lll
 
 	// DisablePluginDefaultDirScan, when enabled, stops the agent from scanning the default integration
 	// locations, so it only loads integrations from the explicitly configured locations
@@ -923,8 +923,8 @@ type Config struct {
 	// LoggingHomeDir folder containing plugins and other required files for the log forwarder.
 	// Default (Linux): /var/db/newrelic-infra/newrelic-integrations/logging/
 	// Default (Windows): C:\Program Files\New Relic\newrelic-infra\newrelic-integrations\logging\
-	// Public: No
-	LoggingHomeDir string `yaml:"logging_home_dir" envconfig:"logging_home_dir" public:"false"`
+	// Public: Yes
+	LoggingHomeDir string `envconfig:"logging_home_dir" public:"true" yaml:"logging_home_dir"`
 
 	// LoggingRetryLimit determines the value of the Retry_Limit for the New Relic fluent-bit output plugin.
 	// https://github.com/newrelic/newrelic-fluent-bit-output/blob/7cbb4393aa36e48bad783231182f707037ebf217/README.md#retry-logic
@@ -1326,7 +1326,7 @@ type Config struct {
 	// Default (MacOS AMD): /usr/local/var/db/newrelic-infra/tmp
 	// Default (MacOS ARM): /opt/homebrew/var/db/newrelic-infra/tmp
 	// Default (Windows): C:\ProgramData\New Relic\newrelic-infra\tmp
-	// Public: No
+	// Public: Yes
 	AgentTempDir string `envconfig:"agent_temp_dir" yaml:"agent_temp_dir"`
 
 	// ProcessContainerDecoration controls if the ProcessSample gets decorated with Container Information

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1793,60 +1793,6 @@ func (c *Config) PublicFields() (map[string]string, error) {
 	return result, nil
 }
 
-// knownEnvVarNames returns the set of NRIA_* environment variable names (uppercased,
-// including the prefix) that map to a Config field, recursing into nested config
-// structs (e.g. Log, Http) the same way envconfig.Process does.
-func knownEnvVarNames(structType reflect.Type, prefix string) map[string]struct{} {
-	names := make(map[string]struct{})
-	if structType.Kind() != reflect.Struct {
-		return names
-	}
-
-	for fieldIdx := range structType.NumField() {
-		tag := structType.Field(fieldIdx).Tag.Get("envconfig")
-		if tag == "" || tag == "ignored" {
-			continue
-		}
-
-		key := prefix + "_" + strings.ToUpper(tag)
-
-		fieldType := structType.Field(fieldIdx).Type
-		if fieldType.Kind() == reflect.Struct {
-			for name := range knownEnvVarNames(fieldType, key) {
-				names[name] = struct{}{}
-			}
-
-			continue
-		}
-
-		names[key] = struct{}{}
-	}
-
-	return names
-}
-
-// warnUnrecognizedEnvVars logs a warning for every NRIA_* environment variable that
-// doesn't correspond to a known Config field, so a mistyped or stale var (e.g. one set
-// by Agent Control when it launches the agent) doesn't get silently dropped.
-func warnUnrecognizedEnvVars(cfg *Config) {
-	known := knownEnvVarNames(reflect.TypeOf(cfg).Elem(), strings.ToUpper(envPrefix))
-	prefix := strings.ToUpper(envPrefix) + "_"
-	keyValuePairLen := 2
-
-	for _, kv := range os.Environ() {
-		name := strings.SplitN(kv, "=", keyValuePairLen)[0]
-		upperName := strings.ToUpper(name)
-
-		if !strings.HasPrefix(upperName, prefix) {
-			continue
-		}
-
-		if _, ok := known[upperName]; !ok {
-			clog.WithField("envVar", name).Warn("unrecognized NRIA_* environment variable, ignoring")
-		}
-	}
-}
-
 func LoadConfig(configFile string) (*Config, error) {
 	var filesToCheck []string
 	if configFile != "" {
@@ -1892,7 +1838,6 @@ func LoadConfig(configFile string) (*Config, error) {
 
 	// After the config file has loaded, override via any environment variables
 	configOverride(cfg)
-	warnUnrecognizedEnvVars(cfg)
 
 	cfg.RunMode, cfg.AgentUser, cfg.ExecutablePath = runtimeValues()
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -3,6 +3,7 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/newrelic/infrastructure-agent/pkg/helpers"
+	"github.com/newrelic/infrastructure-agent/pkg/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	. "gopkg.in/check.v1"
@@ -649,6 +651,45 @@ func TestPublicFields_Obfuscate(t *testing.T) {
 	actualVal, exists := actual["license_key"]
 	assert.True(t, exists)
 	assert.Equal(t, "<HIDDEN>", actualVal)
+}
+
+func TestKnownEnvVarNames_TopLevelAndNestedFields(t *testing.T) {
+	known := knownEnvVarNames(reflect.TypeOf(Config{}), "NRIA")
+
+	_, exists := known["NRIA_AGENT_DIR"]
+	assert.True(t, exists, "top-level field should be a known env var")
+
+	_, exists = known["NRIA_LOG_LEVEL"]
+	assert.True(t, exists, "field nested under a config struct should be a known env var")
+
+	_, exists = known["NRIA_LOG_ROTATE_MAX_SIZE_MB"]
+	assert.True(t, exists, "field nested two levels deep should be a known env var")
+}
+
+func TestKnownEnvVarNames_IgnoresIgnoredFields(t *testing.T) {
+	known := knownEnvVarNames(reflect.TypeOf(Config{}), "NRIA")
+
+	_, exists := known["NRIA_PLUGIN_INSTANCE_DIRS"]
+	assert.False(t, exists, "envconfig:\"ignored\" fields must not be treated as settable env vars")
+}
+
+func TestWarnUnrecognizedEnvVars(t *testing.T) {
+	var output bytes.Buffer
+	log.SetOutput(&output)
+	defer log.SetOutput(ioutil.Discard)
+
+	t.Setenv("NRIA_AGENT_DIR", "/tmp/agent")
+	t.Setenv("NRIA_LOG_LEVEL", "debug")
+	t.Setenv("NRIA_NOT_A_REAL_FIELD", "oops")
+	t.Setenv("SOME_OTHER_VAR", "ignored")
+
+	warnUnrecognizedEnvVars(NewConfig())
+
+	written := output.String()
+	assert.Contains(t, written, "NRIA_NOT_A_REAL_FIELD")
+	assert.NotContains(t, written, "NRIA_AGENT_DIR")
+	assert.NotContains(t, written, "NRIA_LOG_LEVEL")
+	assert.NotContains(t, written, "SOME_OTHER_VAR")
 }
 
 func TestConfig_SetBoolValueByYamlAttribute(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -654,7 +654,9 @@ func TestPublicFields_Obfuscate(t *testing.T) {
 }
 
 func TestKnownEnvVarNames_TopLevelAndNestedFields(t *testing.T) {
-	known := knownEnvVarNames(reflect.TypeOf(Config{}), "NRIA")
+	t.Parallel()
+
+	known := knownEnvVarNames(reflect.TypeOf((*Config)(nil)).Elem(), "NRIA")
 
 	_, exists := known["NRIA_AGENT_DIR"]
 	assert.True(t, exists, "top-level field should be a known env var")
@@ -667,7 +669,9 @@ func TestKnownEnvVarNames_TopLevelAndNestedFields(t *testing.T) {
 }
 
 func TestKnownEnvVarNames_IgnoresIgnoredFields(t *testing.T) {
-	known := knownEnvVarNames(reflect.TypeOf(Config{}), "NRIA")
+	t.Parallel()
+
+	known := knownEnvVarNames(reflect.TypeOf((*Config)(nil)).Elem(), "NRIA")
 
 	_, exists := known["NRIA_PLUGIN_INSTANCE_DIRS"]
 	assert.False(t, exists, "envconfig:\"ignored\" fields must not be treated as settable env vars")
@@ -675,6 +679,7 @@ func TestKnownEnvVarNames_IgnoresIgnoredFields(t *testing.T) {
 
 func TestWarnUnrecognizedEnvVars(t *testing.T) {
 	var output bytes.Buffer
+
 	log.SetOutput(&output)
 	defer log.SetOutput(ioutil.Discard)
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -3,7 +3,6 @@
 package config
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -14,7 +13,6 @@ import (
 	"time"
 
 	"github.com/newrelic/infrastructure-agent/pkg/helpers"
-	"github.com/newrelic/infrastructure-agent/pkg/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	. "gopkg.in/check.v1"
@@ -653,48 +651,86 @@ func TestPublicFields_Obfuscate(t *testing.T) {
 	assert.Equal(t, "<HIDDEN>", actualVal)
 }
 
-func TestKnownEnvVarNames_TopLevelAndNestedFields(t *testing.T) {
+func TestPublicFields_AgentControlManagedEnvVars(t *testing.T) {
 	t.Parallel()
 
-	known := knownEnvVarNames(reflect.TypeOf((*Config)(nil)).Elem(), "NRIA")
+	cases := []struct {
+		name       string
+		yamlOption string
+		setValue   func(cfg *Config)
+		expected   string
+	}{
+		{
+			name:       "agent_dir",
+			yamlOption: "agent_dir",
+			setValue:   func(cfg *Config) { cfg.AgentDir = "/opt/ac/newrelic-infra" },
+			expected:   "/opt/ac/newrelic-infra",
+		},
+		{
+			name:       "safe_bin_dir",
+			yamlOption: "safe_bin_dir",
+			setValue:   func(cfg *Config) { cfg.SafeBinDir = "/opt/ac/safe-bin" },
+			expected:   "/opt/ac/safe-bin",
+		},
+		{
+			name:       "plugin_dir",
+			yamlOption: "plugin_dir",
+			setValue:   func(cfg *Config) { cfg.PluginDir = "/opt/ac/integrations.d" },
+			expected:   "/opt/ac/integrations.d",
+		},
+		{
+			name:       "logging_configs_dir",
+			yamlOption: "logging_configs_dir",
+			setValue:   func(cfg *Config) { cfg.LoggingConfigsDir = "/opt/ac/logging.d" },
+			expected:   "/opt/ac/logging.d",
+		},
+		{
+			name:       "logging_home_dir",
+			yamlOption: "logging_home_dir",
+			setValue:   func(cfg *Config) { cfg.LoggingHomeDir = "/opt/ac/logging" },
+			expected:   "/opt/ac/logging",
+		},
+		{
+			name:       "custom_plugin_installation_dir",
+			yamlOption: "custom_plugin_installation_dir",
+			setValue:   func(cfg *Config) { cfg.CustomPluginInstallationDir = "/opt/ac/newrelic-integrations" },
+			expected:   "/opt/ac/newrelic-integrations",
+		},
+		{
+			name:       "agent_temp_dir",
+			yamlOption: "agent_temp_dir",
+			setValue:   func(cfg *Config) { cfg.AgentTempDir = "/opt/ac/tmp" },
+			expected:   "/opt/ac/tmp",
+		},
+		{
+			name:       "status_server_enabled",
+			yamlOption: "status_server_enabled",
+			setValue:   func(cfg *Config) { cfg.StatusServerEnabled = true },
+			expected:   "true",
+		},
+		{
+			name:       "status_server_port",
+			yamlOption: "status_server_port",
+			setValue:   func(cfg *Config) { cfg.StatusServerPort = 18003 },
+			expected:   "18003",
+		},
+	}
 
-	_, exists := known["NRIA_AGENT_DIR"]
-	assert.True(t, exists, "top-level field should be a known env var")
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-	_, exists = known["NRIA_LOG_LEVEL"]
-	assert.True(t, exists, "field nested under a config struct should be a known env var")
+			cfg := NewConfig()
+			testCase.setValue(cfg)
 
-	_, exists = known["NRIA_LOG_ROTATE_MAX_SIZE_MB"]
-	assert.True(t, exists, "field nested two levels deep should be a known env var")
-}
+			fields, err := cfg.PublicFields()
+			require.NoError(t, err)
 
-func TestKnownEnvVarNames_IgnoresIgnoredFields(t *testing.T) {
-	t.Parallel()
-
-	known := knownEnvVarNames(reflect.TypeOf((*Config)(nil)).Elem(), "NRIA")
-
-	_, exists := known["NRIA_PLUGIN_INSTANCE_DIRS"]
-	assert.False(t, exists, "envconfig:\"ignored\" fields must not be treated as settable env vars")
-}
-
-func TestWarnUnrecognizedEnvVars(t *testing.T) {
-	var output bytes.Buffer
-
-	log.SetOutput(&output)
-	defer log.SetOutput(ioutil.Discard)
-
-	t.Setenv("NRIA_AGENT_DIR", "/tmp/agent")
-	t.Setenv("NRIA_LOG_LEVEL", "debug")
-	t.Setenv("NRIA_NOT_A_REAL_FIELD", "oops")
-	t.Setenv("SOME_OTHER_VAR", "ignored")
-
-	warnUnrecognizedEnvVars(NewConfig())
-
-	written := output.String()
-	assert.Contains(t, written, "NRIA_NOT_A_REAL_FIELD")
-	assert.NotContains(t, written, "NRIA_AGENT_DIR")
-	assert.NotContains(t, written, "NRIA_LOG_LEVEL")
-	assert.NotContains(t, written, "SOME_OTHER_VAR")
+			actual, exists := fields[testCase.yamlOption]
+			assert.True(t, exists, "%s should be reported in inventory's public fields", testCase.yamlOption)
+			assert.Equal(t, testCase.expected, actual)
+		})
+	}
 }
 
 func TestConfig_SetBoolValueByYamlAttribute(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -691,6 +691,12 @@ func TestPublicFields_AgentControlManagedEnvVars(t *testing.T) {
 			expected:   "/opt/ac/logging",
 		},
 		{
+			name:       "logging_bin_dir",
+			yamlOption: "logging_bin_dir",
+			setValue:   func(cfg *Config) { cfg.LoggingBinDir = "/opt/ac/logging-bin" },
+			expected:   "/opt/ac/logging-bin",
+		},
+		{
 			name:       "custom_plugin_installation_dir",
 			yamlOption: "custom_plugin_installation_dir",
 			setValue:   func(cfg *Config) { cfg.CustomPluginInstallationDir = "/opt/ac/newrelic-integrations" },


### PR DESCRIPTION
Make [env variables](https://github.com/newrelic/newrelic-agent-control/blob/main/agent-control/agent-type-registry/newrelic/host-linux-com.newrelic.infrastructure-0.1.0.yaml) used by AC public.

doc changes - https://github.com/newrelic/docs-website/pull/25087