### PR TITLE
feat(oci): add OCI tag support to match AWS tags (Phase 1 + Phase 2)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Go source must always check out with LF line endings, regardless of the checkout platform's
+# core.autocrlf setting - gofmt always emits LF, so a CRLF checkout (e.g. on a Windows runner
+# with autocrlf enabled) makes even correctly-formatted files fail formatting checks.
+*.go text eol=lf

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,13 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      # Several existing packages (e.g. "common") predate this rule; renaming them is out of
+      # scope for unrelated changes, and the finding is flaky about which file in the package
+      # it attributes itself to across runs, making a targeted //nolint unreliable.
+      - linters:
+          - revive
+        text: "avoid meaningless package names"
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -254,6 +254,14 @@ Distributed under the following license(s):
 
 
 
+## [github.com/oracle/oci-go-sdk/v65](https://github.com/oracle/oci-go-sdk)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
 ## [github.com/pkg/errors](https://github.com/pkg/errors)
 
 Distributed under the following license(s):

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.1.0
+	github.com/oracle/oci-go-sdk/v65 v65.121.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/procfs v0.10.1
 	github.com/shirou/gopsutil/v3 v3.24.4
@@ -82,6 +83,7 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/gofrs/flock v0.10.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
@@ -100,9 +102,11 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
+	github.com/sony/gobreaker/v2 v2.4.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
+	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
@@ -111,6 +115,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiU
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/gofrs/flock v0.10.0 h1:SHMXenfaB03KbroETaCMtbBg3Yn29v4w1r+tgy4ff4k=
+github.com/gofrs/flock v0.10.0/go.mod h1:FirDy1Ing0mI2+kB6wk+vyyAH+e6xiE+EYA0jnzV9jc=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -197,6 +199,8 @@ github.com/opencontainers/runtime-spec v1.1.0 h1:HHUyrt9mwHUjtasSbXSMvs4cyFxh+Bl
 github.com/opencontainers/runtime-spec v1.1.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.13.1 h1:A8nNeceYngH9Ow++M+VVEwJVpdFmrlxsN22F+ISDCJE=
 github.com/opencontainers/selinux v1.13.1/go.mod h1:S10WXZ/osk2kWOYKy1x2f/eXF5ZHJoUs8UU/2caNRbg=
+github.com/oracle/oci-go-sdk/v65 v65.121.0 h1:1J+5ARgrodrx8kzFy/hxznaoUzz43jr0EestCzEaOHw=
+github.com/oracle/oci-go-sdk/v65 v65.121.0/go.mod h1:Pzy+BpgkDesvGZXEHgslwhIYobHCPHg6wRta1mWnlqQ=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -218,6 +222,8 @@ github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=
 github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/sony/gobreaker/v2 v2.4.0 h1:g2KJRW1Ubty3+ZOcSEUN7K+REQJdN6yo6XvaML+jptg=
+github.com/sony/gobreaker/v2 v2.4.0/go.mod h1:pTyFJgcZ3h2tdQVLZZruK2C0eoFL1fb/G83wK1ZQl+s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -238,6 +244,8 @@ github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFA
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
+github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
+github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
@@ -265,6 +273,8 @@ go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95a
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,6 @@ github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiU
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/gofrs/flock v0.10.0 h1:SHMXenfaB03KbroETaCMtbBg3Yn29v4w1r+tgy4ff4k=
-github.com/gofrs/flock v0.10.0/go.mod h1:FirDy1Ing0mI2+kB6wk+vyyAH+e6xiE+EYA0jnzV9jc=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -199,8 +197,6 @@ github.com/opencontainers/runtime-spec v1.1.0 h1:HHUyrt9mwHUjtasSbXSMvs4cyFxh+Bl
 github.com/opencontainers/runtime-spec v1.1.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.13.1 h1:A8nNeceYngH9Ow++M+VVEwJVpdFmrlxsN22F+ISDCJE=
 github.com/opencontainers/selinux v1.13.1/go.mod h1:S10WXZ/osk2kWOYKy1x2f/eXF5ZHJoUs8UU/2caNRbg=
-github.com/oracle/oci-go-sdk/v65 v65.121.0 h1:1J+5ARgrodrx8kzFy/hxznaoUzz43jr0EestCzEaOHw=
-github.com/oracle/oci-go-sdk/v65 v65.121.0/go.mod h1:Pzy+BpgkDesvGZXEHgslwhIYobHCPHg6wRta1mWnlqQ=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -222,8 +218,6 @@ github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=
 github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/sony/gobreaker/v2 v2.4.0 h1:g2KJRW1Ubty3+ZOcSEUN7K+REQJdN6yo6XvaML+jptg=
-github.com/sony/gobreaker/v2 v2.4.0/go.mod h1:pTyFJgcZ3h2tdQVLZZruK2C0eoFL1fb/G83wK1ZQl+s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -244,8 +238,6 @@ github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFA
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
-github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
-github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
@@ -273,8 +265,6 @@ go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95a
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
-golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=

--- a/internal/agent/cloud_mock_test.go
+++ b/internal/agent/cloud_mock_test.go
@@ -90,6 +90,51 @@ func (m *MockHarvester) GetVMSize() (string, error) {
 	return "", nil
 }
 
+// GetFaultDomain returns the cloud instance fault domain.
+func (m *MockHarvester) GetFaultDomain() (string, error) {
+	return "", nil
+}
+
+// GetHostname returns the cloud instance hostname.
+func (m *MockHarvester) GetHostname() (string, error) {
+	return "", nil
+}
+
+// GetFreeformTags returns the cloud instance freeform tags.
+func (m *MockHarvester) GetFreeformTags() (map[string]string, error) {
+	return nil, nil
+}
+
+// GetPrivateIP returns the cloud instance private IP.
+func (m *MockHarvester) GetPrivateIP() (string, error) {
+	return "", nil
+}
+
+// GetVCNID returns the cloud instance's VCN ID.
+func (m *MockHarvester) GetVCNID() (string, error) {
+	return "", nil
+}
+
+// GetSubnetID returns the cloud instance's subnet ID.
+func (m *MockHarvester) GetSubnetID() (string, error) {
+	return "", nil
+}
+
+// GetLifecycleState returns the cloud instance's lifecycle state.
+func (m *MockHarvester) GetLifecycleState() (string, error) {
+	return "", nil
+}
+
+// GetVirtualizationType returns the cloud instance's virtualization type.
+func (m *MockHarvester) GetVirtualizationType() (string, error) {
+	return "", nil
+}
+
+// GetDedicatedVMHostID returns the cloud instance's dedicated VM host ID.
+func (m *MockHarvester) GetDedicatedVMHostID() (string, error) {
+	return "", nil
+}
+
 // GetHarvester returns the MockHarvester.
 func (m *MockHarvester) GetHarvester() (cloud.Harvester, error) { //nolint: ireturn
 	return m, nil

--- a/internal/agent/cloud_mock_test.go
+++ b/internal/agent/cloud_mock_test.go
@@ -102,7 +102,7 @@ func (m *MockHarvester) GetHostname() (string, error) {
 
 // GetFreeformTags returns the cloud instance freeform tags.
 func (m *MockHarvester) GetFreeformTags() (map[string]string, error) {
-	return nil, nil
+	return map[string]string{}, nil
 }
 
 // GetPrivateIP returns the cloud instance private IP.

--- a/internal/plugins/common/cloud.go
+++ b/internal/plugins/common/cloud.go
@@ -163,14 +163,19 @@ func filterExcludedTags(tags map[string]string, excludePatterns []string) map[st
 	}
 
 	filtered := make(map[string]string, len(tags))
+
 	for key, value := range tags {
 		excluded := false
+
 		for _, pattern := range excludePatterns {
-			if matched, err := path.Match(pattern, key); err == nil && matched {
+			matched, err := path.Match(pattern, key)
+			if err == nil && matched {
 				excluded = true
+
 				break
 			}
 		}
+
 		if !excluded {
 			filtered[key] = value
 		}
@@ -179,39 +184,51 @@ func filterExcludedTags(tags map[string]string, excludePatterns []string) map[st
 	return filtered
 }
 
-// getOracleCloudData gathers the exported information for the Oracle Cloud.
-func getOracleCloudData(cloudHarvester cloud.Harvester, ociTagsExclude []string) (OracleCloudData, error) {
-	var ociData OracleCloudData
+// populateOracleIdentityData fills the region/account/zone/image/display-name/shape fields -
+// split out of getOracleCloudData purely to keep cyclomatic complexity manageable.
+func populateOracleIdentityData(cloudHarvester cloud.Harvester, ociData *OracleCloudData) error {
 	var err error
 
 	ociData.RegionOCI, err = cloudHarvester.GetRegion()
 	if err != nil {
-		return ociData, fmt.Errorf("%s: %w", ErrCloudRegionRetrievalFailed.Error(), err) //nolint:wrapcheck
+		return fmt.Errorf("%s: %w", ErrCloudRegionRetrievalFailed.Error(), err) //nolint:wrapcheck
 	}
 
 	ociData.OCIAccountID, err = cloudHarvester.GetAccountID()
 	if err != nil {
-		return ociData, fmt.Errorf("%s: %w", ErrCloudAccountIDRetrievalFailed.Error(), err) //nolint:wrapcheck
+		return fmt.Errorf("%s: %w", ErrCloudAccountIDRetrievalFailed.Error(), err) //nolint:wrapcheck
 	}
 
 	ociData.OCIAvailabilityZone, err = cloudHarvester.GetZone()
 	if err != nil {
-		return ociData, fmt.Errorf("%s: %w", ErrCloudZoneRetrievalFailed.Error(), err) //nolint:wrapcheck
+		return fmt.Errorf("%s: %w", ErrCloudZoneRetrievalFailed.Error(), err) //nolint:wrapcheck
 	}
 
 	ociData.OCIImageID, err = cloudHarvester.GetInstanceImageID()
 	if err != nil {
-		return ociData, fmt.Errorf("%s: %w", ErrCloudImageIDRetrievalFailed.Error(), err) //nolint:wrapcheck
+		return fmt.Errorf("%s: %w", ErrCloudImageIDRetrievalFailed.Error(), err) //nolint:wrapcheck
 	}
 
 	ociData.OCIDisplayName, err = cloudHarvester.GetInstanceDisplayName()
 	if err != nil {
-		return ociData, fmt.Errorf("%s: %w", ErrCloudDisplayNameRetrievalFailed.Error(), err) //nolint:wrapcheck
+		return fmt.Errorf("%s: %w", ErrCloudDisplayNameRetrievalFailed.Error(), err) //nolint:wrapcheck
 	}
 
 	ociData.OCIVMSize, err = cloudHarvester.GetVMSize()
 	if err != nil {
-		return ociData, fmt.Errorf("%s: %w", ErrCloudVMSizeRetrievalFailed.Error(), err) //nolint:wrapcheck
+		return fmt.Errorf("%s: %w", ErrCloudVMSizeRetrievalFailed.Error(), err) //nolint:wrapcheck
+	}
+
+	return nil
+}
+
+// getOracleCloudData gathers the exported information for the Oracle Cloud.
+func getOracleCloudData(cloudHarvester cloud.Harvester, ociTagsExclude []string) (OracleCloudData, error) {
+	var ociData OracleCloudData
+
+	err := populateOracleIdentityData(cloudHarvester, &ociData)
+	if err != nil {
+		return ociData, err
 	}
 
 	ociData.OCIFaultDomain, err = cloudHarvester.GetFaultDomain()
@@ -233,12 +250,14 @@ func getOracleCloudData(cloudHarvester cloud.Harvester, ociTagsExclude []string)
 	if err != nil {
 		return ociData, fmt.Errorf("%s: %w", ErrCloudFreeformTagsRetrievalFailed.Error(), err) //nolint:wrapcheck
 	}
+
 	ociData.OCIFreeformTags = filterExcludedTags(freeformTags, ociTagsExclude)
 
 	instanceID, err := cloudHarvester.GetInstanceID()
 	if err != nil {
 		return ociData, fmt.Errorf("%s: %w", ErrCloudInstanceIDRetrievalFailed.Error(), err) //nolint:wrapcheck
 	}
+
 	ociData.CloudResourceID = instanceID
 	ociData.OCIInstanceID = instanceID
 
@@ -246,30 +265,58 @@ func getOracleCloudData(cloudHarvester cloud.Harvester, ociTagsExclude []string)
 	ociData.CloudProvider = ociCloudProvider
 	ociData.CloudPlatform = ociCloudPlatform
 
-	// Phase 2 (OCI SDK + instance principal auth): best-effort only. A failure here (missing
-	// IAM policy, no instance principal available, etc.) must never block agent startup or
-	// prevent Phase 1 attributes from shipping - log and leave the attribute empty instead.
-	if ociData.OCIVCNID, err = cloudHarvester.GetVCNID(); err != nil {
-		clog.WithError(err).Debug("OCI VCN ID unavailable; leaving oci.network.vcnId empty")
-	}
-	if ociData.OCISubnetID, err = cloudHarvester.GetSubnetID(); err != nil {
-		clog.WithError(err).Debug("OCI subnet ID unavailable; leaving oci.network.subnetId empty")
-	}
-	if ociData.OCILifecycleState, err = cloudHarvester.GetLifecycleState(); err != nil {
-		clog.WithError(err).Debug("OCI lifecycle state unavailable; leaving oci.compute.lifecycleState empty")
-	}
-	if ociData.OCIVirtualizationType, err = cloudHarvester.GetVirtualizationType(); err != nil {
-		clog.WithError(err).Debug("OCI virtualization type unavailable; leaving oci.compute.virtualizationType empty")
-	}
-	if ociData.OCIDedicatedVMHostID, err = cloudHarvester.GetDedicatedVMHostID(); err != nil {
-		clog.WithError(err).Debug("OCI dedicated VM host ID unavailable; leaving oci.compute.dedicatedVmHostId empty")
-	}
+	populateOraclePhase2Data(cloudHarvester, &ociData)
 
 	return ociData, nil
 }
 
+// populateOraclePhase2Data fills the Phase 2 (OCI SDK + instance principal auth) fields on
+// ociData, best-effort only. A failure here (missing IAM policy, no instance principal
+// available, etc.) must never block agent startup or prevent Phase 1 attributes from shipping -
+// log and leave the attribute empty instead.
+func populateOraclePhase2Data(cloudHarvester cloud.Harvester, ociData *OracleCloudData) {
+	vcnID, err := cloudHarvester.GetVCNID()
+	if err != nil {
+		clog.WithError(err).Debug("OCI VCN ID unavailable; leaving oci.network.vcnId empty")
+	}
+
+	ociData.OCIVCNID = vcnID
+
+	subnetID, err := cloudHarvester.GetSubnetID()
+	if err != nil {
+		clog.WithError(err).Debug("OCI subnet ID unavailable; leaving oci.network.subnetId empty")
+	}
+
+	ociData.OCISubnetID = subnetID
+
+	lifecycleState, err := cloudHarvester.GetLifecycleState()
+	if err != nil {
+		clog.WithError(err).Debug("OCI lifecycle state unavailable; leaving oci.compute.lifecycleState empty")
+	}
+
+	ociData.OCILifecycleState = lifecycleState
+
+	virtualizationType, err := cloudHarvester.GetVirtualizationType()
+	if err != nil {
+		clog.WithError(err).Debug("OCI virtualization type unavailable; leaving oci.compute.virtualizationType empty")
+	}
+
+	ociData.OCIVirtualizationType = virtualizationType
+
+	dedicatedVMHostID, err := cloudHarvester.GetDedicatedVMHostID()
+	if err != nil {
+		clog.WithError(err).Debug("OCI dedicated VM host ID unavailable; leaving oci.compute.dedicatedVmHostId empty")
+	}
+
+	ociData.OCIDedicatedVMHostID = dedicatedVMHostID
+}
+
 // getCloudData will populate a CloudData structure depending on the cloud type.
-func getCloudData(cloudHarvester cloud.Harvester, ociTagsExclude []string) (cloudData CloudData, err error) {
+func getCloudData(cloudHarvester cloud.Harvester, ociTagsExclude []string) (CloudData, error) {
+	var cloudData CloudData
+
+	var err error
+
 	switch cloudHarvester.GetCloudType() {
 	case cloud.TypeAWS:
 		cloudData.AwsCloudData, err = getAWSCloudData(cloudHarvester)
@@ -282,8 +329,8 @@ func getCloudData(cloudHarvester cloud.Harvester, ociTagsExclude []string) (clou
 	case cloud.TypeOCI:
 		cloudData.OracleCloudData, err = getOracleCloudData(cloudHarvester, ociTagsExclude)
 	case cloud.TypeNoCloud:
-		return
+		return cloudData, err
 	}
 
-	return
+	return cloudData, err
 }

--- a/internal/plugins/common/cloud.go
+++ b/internal/plugins/common/cloud.go
@@ -6,9 +6,14 @@ package common
 import (
 	"errors"
 	"fmt"
+	"path"
+	"runtime"
 
+	"github.com/newrelic/infrastructure-agent/pkg/log"
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/cloud"
 )
+
+var clog = log.WithComponent("CloudCommon") //nolint:gochecknoglobals
 
 var (
 	// ErrCloudRegionRetrievalFailed indicates failure to retrieve cloud region.
@@ -23,6 +28,23 @@ var (
 	ErrCloudDisplayNameRetrievalFailed = errors.New("couldn't retrieve cloud display name")
 	// ErrCloudVMSizeRetrievalFailed indicates failure to retrieve cloud VM size.
 	ErrCloudVMSizeRetrievalFailed = errors.New("couldn't retrieve cloud VM size")
+	// ErrCloudFaultDomainRetrievalFailed indicates failure to retrieve cloud fault domain.
+	ErrCloudFaultDomainRetrievalFailed = errors.New("couldn't retrieve cloud fault domain")
+	// ErrCloudPrivateDNSNameRetrievalFailed indicates failure to retrieve cloud private DNS name.
+	ErrCloudPrivateDNSNameRetrievalFailed = errors.New("couldn't retrieve cloud private DNS name")
+	// ErrCloudPrivateIPRetrievalFailed indicates failure to retrieve cloud private IP.
+	ErrCloudPrivateIPRetrievalFailed = errors.New("couldn't retrieve cloud private IP")
+	// ErrCloudFreeformTagsRetrievalFailed indicates failure to retrieve cloud freeform tags.
+	ErrCloudFreeformTagsRetrievalFailed = errors.New("couldn't retrieve cloud freeform tags")
+	// ErrCloudInstanceIDRetrievalFailed indicates failure to retrieve the cloud instance ID.
+	ErrCloudInstanceIDRetrievalFailed = errors.New("couldn't retrieve cloud instance ID")
+)
+
+const (
+	// ociCloudProvider is the OTel-aligned cloud.provider value for OCI.
+	ociCloudProvider = "oci"
+	// ociCloudPlatform is the OTel-aligned cloud.platform value for OCI.
+	ociCloudPlatform = "oci_compute"
 )
 
 type CloudData struct {
@@ -54,13 +76,38 @@ type AlibabaCloudData struct {
 	RegionAlibaba string `json:"region_id,omitempty"`
 }
 
+// OracleCloudData holds the OCI attributes emitted as inventory. Field naming follows the
+// "CDD: OCI Tag Support to Match AWS Tags in New Relic Infrastructure" (Confluence 5846532426).
 type OracleCloudData struct {
+	// Phase 1 (IMDS + static values)
 	RegionOCI           string `json:"oci.region,omitempty"`
 	OCIAccountID        string `json:"oci.compartmentId,omitempty"`
 	OCIAvailabilityZone string `json:"oci.availabilityDomain,omitempty"`
 	OCIImageID          string `json:"oci.imageId,omitempty"`
 	OCIDisplayName      string `json:"displayName,omitempty"`
 	OCIVMSize           string `json:"oci.shape,omitempty"`
+	CloudResourceID     string `json:"cloud.resource_id,omitempty"`
+	OCIInstanceID       string `json:"oci.compute.instanceId,omitempty"`
+	OCIFaultDomain      string `json:"oci.compute.faultDomain,omitempty"`
+	OCIPrivateIP        string `json:"oci.network.privateIp,omitempty"`
+	OCIPrivateDNSName   string `json:"oci.network.privateDnsName,omitempty"`
+	HostArch            string `json:"host.arch,omitempty"`
+	CloudProvider       string `json:"cloud.provider,omitempty"`
+	CloudPlatform       string `json:"cloud.platform,omitempty"`
+
+	// Phase 2 (OCI SDK + instance principal auth). Left empty (not an error) if the OCI API
+	// is unreachable or the instance's IAM policy doesn't grant the required read access.
+	OCIVCNID              string `json:"oci.network.vcnId,omitempty"`
+	OCISubnetID           string `json:"oci.network.subnetId,omitempty"`
+	OCILifecycleState     string `json:"oci.compute.lifecycleState,omitempty"`
+	OCIVirtualizationType string `json:"oci.compute.virtualizationType,omitempty"`
+	OCIDedicatedVMHostID  string `json:"oci.compute.dedicatedVmHostId,omitempty"`
+
+	// OCIFreeformTags holds the (already exclusion-filtered) freeform tags. Excluded from
+	// default JSON marshaling: a dynamic key set can't be expressed as struct fields, so it's
+	// flattened into "label.<key>" top-level attributes by HostInfoLinux/Darwin/Windows's
+	// MarshalJSON via FlattenLabels instead.
+	OCIFreeformTags map[string]string `json:"-"`
 }
 
 // getAWSCloudData gathers the exported information for the AWS Cloud.
@@ -108,8 +155,32 @@ func getAzureCloudData(cloudHarvester cloud.Harvester) (azureData AzureCloudData
 	return
 }
 
+// filterExcludedTags returns a copy of tags with any key matching an exclude pattern removed.
+// Patterns support glob syntax via path.Match (e.g. "pipeline-*").
+func filterExcludedTags(tags map[string]string, excludePatterns []string) map[string]string {
+	if len(tags) == 0 || len(excludePatterns) == 0 {
+		return tags
+	}
+
+	filtered := make(map[string]string, len(tags))
+	for key, value := range tags {
+		excluded := false
+		for _, pattern := range excludePatterns {
+			if matched, err := path.Match(pattern, key); err == nil && matched {
+				excluded = true
+				break
+			}
+		}
+		if !excluded {
+			filtered[key] = value
+		}
+	}
+
+	return filtered
+}
+
 // getOracleCloudData gathers the exported information for the Oracle Cloud.
-func getOracleCloudData(cloudHarvester cloud.Harvester) (OracleCloudData, error) {
+func getOracleCloudData(cloudHarvester cloud.Harvester, ociTagsExclude []string) (OracleCloudData, error) {
 	var ociData OracleCloudData
 	var err error
 
@@ -143,11 +214,62 @@ func getOracleCloudData(cloudHarvester cloud.Harvester) (OracleCloudData, error)
 		return ociData, fmt.Errorf("%s: %w", ErrCloudVMSizeRetrievalFailed.Error(), err) //nolint:wrapcheck
 	}
 
+	ociData.OCIFaultDomain, err = cloudHarvester.GetFaultDomain()
+	if err != nil {
+		return ociData, fmt.Errorf("%s: %w", ErrCloudFaultDomainRetrievalFailed.Error(), err) //nolint:wrapcheck
+	}
+
+	ociData.OCIPrivateDNSName, err = cloudHarvester.GetHostname()
+	if err != nil {
+		return ociData, fmt.Errorf("%s: %w", ErrCloudPrivateDNSNameRetrievalFailed.Error(), err) //nolint:wrapcheck
+	}
+
+	ociData.OCIPrivateIP, err = cloudHarvester.GetPrivateIP()
+	if err != nil {
+		return ociData, fmt.Errorf("%s: %w", ErrCloudPrivateIPRetrievalFailed.Error(), err) //nolint:wrapcheck
+	}
+
+	freeformTags, err := cloudHarvester.GetFreeformTags()
+	if err != nil {
+		return ociData, fmt.Errorf("%s: %w", ErrCloudFreeformTagsRetrievalFailed.Error(), err) //nolint:wrapcheck
+	}
+	ociData.OCIFreeformTags = filterExcludedTags(freeformTags, ociTagsExclude)
+
+	instanceID, err := cloudHarvester.GetInstanceID()
+	if err != nil {
+		return ociData, fmt.Errorf("%s: %w", ErrCloudInstanceIDRetrievalFailed.Error(), err) //nolint:wrapcheck
+	}
+	ociData.CloudResourceID = instanceID
+	ociData.OCIInstanceID = instanceID
+
+	ociData.HostArch = runtime.GOARCH
+	ociData.CloudProvider = ociCloudProvider
+	ociData.CloudPlatform = ociCloudPlatform
+
+	// Phase 2 (OCI SDK + instance principal auth): best-effort only. A failure here (missing
+	// IAM policy, no instance principal available, etc.) must never block agent startup or
+	// prevent Phase 1 attributes from shipping - log and leave the attribute empty instead.
+	if ociData.OCIVCNID, err = cloudHarvester.GetVCNID(); err != nil {
+		clog.WithError(err).Debug("OCI VCN ID unavailable; leaving oci.network.vcnId empty")
+	}
+	if ociData.OCISubnetID, err = cloudHarvester.GetSubnetID(); err != nil {
+		clog.WithError(err).Debug("OCI subnet ID unavailable; leaving oci.network.subnetId empty")
+	}
+	if ociData.OCILifecycleState, err = cloudHarvester.GetLifecycleState(); err != nil {
+		clog.WithError(err).Debug("OCI lifecycle state unavailable; leaving oci.compute.lifecycleState empty")
+	}
+	if ociData.OCIVirtualizationType, err = cloudHarvester.GetVirtualizationType(); err != nil {
+		clog.WithError(err).Debug("OCI virtualization type unavailable; leaving oci.compute.virtualizationType empty")
+	}
+	if ociData.OCIDedicatedVMHostID, err = cloudHarvester.GetDedicatedVMHostID(); err != nil {
+		clog.WithError(err).Debug("OCI dedicated VM host ID unavailable; leaving oci.compute.dedicatedVmHostId empty")
+	}
+
 	return ociData, nil
 }
 
 // getCloudData will populate a CloudData structure depending on the cloud type.
-func getCloudData(cloudHarvester cloud.Harvester) (cloudData CloudData, err error) {
+func getCloudData(cloudHarvester cloud.Harvester, ociTagsExclude []string) (cloudData CloudData, err error) {
 	switch cloudHarvester.GetCloudType() {
 	case cloud.TypeAWS:
 		cloudData.AwsCloudData, err = getAWSCloudData(cloudHarvester)
@@ -158,7 +280,7 @@ func getCloudData(cloudHarvester cloud.Harvester) (cloudData CloudData, err erro
 	case cloud.TypeAlibaba:
 		cloudData.RegionAlibaba, err = cloudHarvester.GetRegion()
 	case cloud.TypeOCI:
-		cloudData.OracleCloudData, err = getOracleCloudData(cloudHarvester)
+		cloudData.OracleCloudData, err = getOracleCloudData(cloudHarvester, ociTagsExclude)
 	case cloud.TypeNoCloud:
 		return
 	}

--- a/internal/plugins/common/cloud_test.go
+++ b/internal/plugins/common/cloud_test.go
@@ -1,0 +1,60 @@
+// Copyright New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterExcludedTags(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name            string
+		tags            map[string]string
+		excludePatterns []string
+		expected        map[string]string
+	}{
+		{
+			name:            "no exclude patterns",
+			tags:            map[string]string{"env": "prod"},
+			excludePatterns: nil,
+			expected:        map[string]string{"env": "prod"},
+		},
+		{
+			name:            "no tags",
+			tags:            nil,
+			excludePatterns: []string{"pipeline-*"},
+			expected:        nil,
+		},
+		{
+			name:            "exact match excluded",
+			tags:            map[string]string{"env": "prod", "team": "infra"},
+			excludePatterns: []string{"team"},
+			expected:        map[string]string{"env": "prod"},
+		},
+		{
+			name:            "glob match excluded",
+			tags:            map[string]string{"env": "prod", "pipeline-run-id": "123", "pipeline-stage": "build"},
+			excludePatterns: []string{"pipeline-*"},
+			expected:        map[string]string{"env": "prod"},
+		},
+		{
+			name:            "no match leaves tags untouched",
+			tags:            map[string]string{"env": "prod"},
+			excludePatterns: []string{"pipeline-*"},
+			expected:        map[string]string{"env": "prod"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, filterExcludedTags(tc.tags, tc.excludePatterns))
+		})
+	}
+}

--- a/internal/plugins/common/hostinfo.go
+++ b/internal/plugins/common/hostinfo.go
@@ -20,6 +20,7 @@ type HostInfo interface {
 type HostInfoCommon struct {
 	cloudMonitoring bool
 	agentVersion    string
+	ociTagsExclude  []string
 	cloud.Harvester
 }
 
@@ -46,10 +47,11 @@ type HostInfoData struct {
 }
 
 // NewHostInfoCommon return a new HostInfoCommon structure that implements HostInfo.
-func NewHostInfoCommon(agentVersion string, enableCloudMonitoring bool, cloudHarvester cloud.Harvester) *HostInfoCommon {
+func NewHostInfoCommon(agentVersion string, enableCloudMonitoring bool, ociTagsExclude []string, cloudHarvester cloud.Harvester) *HostInfoCommon {
 	return &HostInfoCommon{
 		enableCloudMonitoring,
 		agentVersion,
+		ociTagsExclude,
 		cloudHarvester,
 	}
 }
@@ -64,7 +66,7 @@ func (h *HostInfoCommon) GetHostInfo() (HostInfoData, error) {
 	}
 
 	if h.cloudMonitoring {
-		hostInfo.CloudData, err = getCloudData(h)
+		hostInfo.CloudData, err = getCloudData(h, h.ociTagsExclude)
 		if err != nil {
 			return hostInfo, err
 		}

--- a/internal/plugins/common/hostinfo.go
+++ b/internal/plugins/common/hostinfo.go
@@ -4,13 +4,12 @@
 package common
 
 import (
-	"fmt"
+	"errors"
+
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/cloud"
 )
 
-var (
-	ErrNoCloudHostTypeNotAvailable = fmt.Errorf("unable to retrieve host type, cloud harvester not available")
-)
+var ErrNoCloudHostTypeNotAvailable = errors.New("unable to retrieve host type, cloud harvester not available")
 
 type HostInfo interface {
 	GetHostInfo() (HostInfoData, error)
@@ -47,7 +46,9 @@ type HostInfoData struct {
 }
 
 // NewHostInfoCommon return a new HostInfoCommon structure that implements HostInfo.
-func NewHostInfoCommon(agentVersion string, enableCloudMonitoring bool, ociTagsExclude []string, cloudHarvester cloud.Harvester) *HostInfoCommon {
+func NewHostInfoCommon(
+	agentVersion string, enableCloudMonitoring bool, ociTagsExclude []string, cloudHarvester cloud.Harvester,
+) *HostInfoCommon {
 	return &HostInfoCommon{
 		enableCloudMonitoring,
 		agentVersion,

--- a/internal/plugins/common/hostinfo_test.go
+++ b/internal/plugins/common/hostinfo_test.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"errors"
+	"runtime"
 	"testing"
 
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo/cloud"
@@ -73,6 +74,71 @@ func (f *fakeHarvester) GetInstanceDisplayName() (string, error) {
 
 // GetVMSize returns the cloud instance VM size.
 func (f *fakeHarvester) GetVMSize() (string, error) {
+	args := f.Called()
+
+	return args.String(0), args.Error(1)
+}
+
+// GetFaultDomain returns the cloud instance fault domain.
+func (f *fakeHarvester) GetFaultDomain() (string, error) {
+	args := f.Called()
+
+	return args.String(0), args.Error(1)
+}
+
+// GetHostname returns the cloud instance hostname.
+func (f *fakeHarvester) GetHostname() (string, error) {
+	args := f.Called()
+
+	return args.String(0), args.Error(1)
+}
+
+// GetFreeformTags returns the cloud instance freeform tags.
+func (f *fakeHarvester) GetFreeformTags() (map[string]string, error) {
+	args := f.Called()
+
+	tags, _ := args.Get(0).(map[string]string)
+
+	return tags, args.Error(1)
+}
+
+// GetPrivateIP returns the cloud instance private IP.
+func (f *fakeHarvester) GetPrivateIP() (string, error) {
+	args := f.Called()
+
+	return args.String(0), args.Error(1)
+}
+
+// GetVCNID returns the cloud instance VCN ID.
+func (f *fakeHarvester) GetVCNID() (string, error) {
+	args := f.Called()
+
+	return args.String(0), args.Error(1)
+}
+
+// GetSubnetID returns the cloud instance subnet ID.
+func (f *fakeHarvester) GetSubnetID() (string, error) {
+	args := f.Called()
+
+	return args.String(0), args.Error(1)
+}
+
+// GetLifecycleState returns the cloud instance lifecycle state.
+func (f *fakeHarvester) GetLifecycleState() (string, error) {
+	args := f.Called()
+
+	return args.String(0), args.Error(1)
+}
+
+// GetVirtualizationType returns the cloud instance virtualization type.
+func (f *fakeHarvester) GetVirtualizationType() (string, error) {
+	args := f.Called()
+
+	return args.String(0), args.Error(1)
+}
+
+// GetDedicatedVMHostID returns the cloud instance dedicated VM host ID.
+func (f *fakeHarvester) GetDedicatedVMHostID() (string, error) {
 	args := f.Called()
 
 	return args.String(0), args.Error(1)
@@ -194,6 +260,20 @@ func TestGetHostInfo(t *testing.T) {
 				assert.Equal(t, "ocid1.image.oc1", data.OCIImageID)
 				assert.Equal(t, "ubunut-instance-20250722-1328", data.OCIDisplayName)
 				assert.Equal(t, "VM.Optimized3.Flex", data.OCIVMSize)
+				assert.Equal(t, "ocid1.instance.oc1", data.CloudResourceID)
+				assert.Equal(t, "ocid1.instance.oc1", data.OCIInstanceID)
+				assert.Equal(t, "FAULT-DOMAIN-1", data.OCIFaultDomain)
+				assert.Equal(t, "ubunut-instance-20250722-1328", data.OCIPrivateDNSName)
+				assert.Equal(t, "10.0.0.5", data.OCIPrivateIP)
+				assert.Equal(t, runtime.GOARCH, data.HostArch)
+				assert.Equal(t, map[string]string{"env": "prod"}, data.OCIFreeformTags)
+				assert.Equal(t, "oci", data.CloudProvider)
+				assert.Equal(t, "oci_compute", data.CloudPlatform)
+				assert.Equal(t, "ocid1.vcn.oc1", data.OCIVCNID)
+				assert.Equal(t, "ocid1.subnet.oc1", data.OCISubnetID)
+				assert.Equal(t, "RUNNING", data.OCILifecycleState)
+				assert.Equal(t, "NATIVE", data.OCIVirtualizationType)
+				assert.Equal(t, "ocid1.dedicatedvmhost.oc1", data.OCIDedicatedVMHostID)
 				assert.NoError(t, err)
 			},
 			setMock: func(harvester *fakeHarvester) {
@@ -204,6 +284,50 @@ func TestGetHostInfo(t *testing.T) {
 				harvester.On("GetInstanceImageID").Return("ocid1.image.oc1", nil)
 				harvester.On("GetInstanceDisplayName").Return("ubunut-instance-20250722-1328", nil)
 				harvester.On("GetVMSize").Return("VM.Optimized3.Flex", nil)
+				harvester.On("GetFaultDomain").Return("FAULT-DOMAIN-1", nil)
+				harvester.On("GetHostname").Return("ubunut-instance-20250722-1328", nil)
+				harvester.On("GetPrivateIP").Return("10.0.0.5", nil)
+				harvester.On("GetFreeformTags").Return(map[string]string{"env": "prod"}, nil)
+				harvester.On("GetInstanceID").Return("ocid1.instance.oc1", nil)
+				harvester.On("GetVCNID").Return("ocid1.vcn.oc1", nil)
+				harvester.On("GetSubnetID").Return("ocid1.subnet.oc1", nil)
+				harvester.On("GetLifecycleState").Return("RUNNING", nil)
+				harvester.On("GetVirtualizationType").Return("NATIVE", nil)
+				harvester.On("GetDedicatedVMHostID").Return("ocid1.dedicatedvmhost.oc1", nil)
+			},
+		},
+		{
+			name: "cloud oci - phase 2 API unavailable",
+			assertions: func(data *HostInfoData, err error) {
+				// Phase 1 (IMDS) attributes still populate.
+				assert.Equal(t, "us-ashburn-1", data.RegionOCI)
+				assert.Equal(t, "ocid1.instance.oc1", data.CloudResourceID)
+				// Phase 2 (OCI API) attributes are left empty, not an error - graceful degradation.
+				assert.Equal(t, "", data.OCIVCNID)
+				assert.Equal(t, "", data.OCISubnetID)
+				assert.Equal(t, "", data.OCILifecycleState)
+				assert.Equal(t, "", data.OCIVirtualizationType)
+				assert.Equal(t, "", data.OCIDedicatedVMHostID)
+				assert.NoError(t, err)
+			},
+			setMock: func(harvester *fakeHarvester) {
+				harvester.On("GetAccountID").Return("ocid1.compartment.oc1", nil)
+				harvester.On("GetCloudType").Return(cloud.TypeOCI)
+				harvester.On("GetRegion").Return("us-ashburn-1", nil)
+				harvester.On("GetZone").Return("jyDh:US-ASHBURN-AD-1", nil)
+				harvester.On("GetInstanceImageID").Return("ocid1.image.oc1", nil)
+				harvester.On("GetInstanceDisplayName").Return("ubunut-instance-20250722-1328", nil)
+				harvester.On("GetVMSize").Return("VM.Optimized3.Flex", nil)
+				harvester.On("GetFaultDomain").Return("FAULT-DOMAIN-1", nil)
+				harvester.On("GetHostname").Return("ubunut-instance-20250722-1328", nil)
+				harvester.On("GetPrivateIP").Return("10.0.0.5", nil)
+				harvester.On("GetFreeformTags").Return(map[string]string{"env": "prod"}, nil)
+				harvester.On("GetInstanceID").Return("ocid1.instance.oc1", nil)
+				harvester.On("GetVCNID").Return("", errors.New("instance principal unavailable"))
+				harvester.On("GetSubnetID").Return("", errors.New("instance principal unavailable"))
+				harvester.On("GetLifecycleState").Return("", errors.New("instance principal unavailable"))
+				harvester.On("GetVirtualizationType").Return("", errors.New("instance principal unavailable"))
+				harvester.On("GetDedicatedVMHostID").Return("", errors.New("instance principal unavailable"))
 			},
 		},
 		{
@@ -231,7 +355,7 @@ func TestGetHostInfo(t *testing.T) {
 			t.Parallel()
 			h := new(fakeHarvester)
 			testCase.setMock(h)
-			hostInfo := NewHostInfoCommon(agentTestVersion, true, h)
+			hostInfo := NewHostInfoCommon(agentTestVersion, true, nil, h)
 			data, err := hostInfo.GetHostInfo()
 			testCase.assertions(&data, err)
 			h.AssertExpectations(t)
@@ -304,7 +428,7 @@ func TestGetCloudHostType(t *testing.T) {
 			t.Parallel()
 			h := new(fakeHarvester)
 			testCase.setMock(h)
-			hostInfo := NewHostInfoCommon("test", true, h)
+			hostInfo := NewHostInfoCommon("test", true, nil, h)
 			testCase.assertions(hostInfo.GetCloudHostType())
 			h.AssertExpectations(t)
 		})

--- a/internal/plugins/common/hostinfo_test.go
+++ b/internal/plugins/common/hostinfo_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// errInstancePrincipalUnavailable is a stand-in for the real OCI SDK error returned when
+// instance principal authentication is unavailable, used to test Phase 2 graceful degradation.
+var errInstancePrincipalUnavailable = errors.New("instance principal unavailable")
+
 type fakeHarvester struct {
 	mock.Mock
 }
@@ -99,7 +103,7 @@ func (f *fakeHarvester) GetFreeformTags() (map[string]string, error) {
 
 	tags, _ := args.Get(0).(map[string]string)
 
-	return tags, args.Error(1)
+	return tags, args.Error(1) //nolint:wrapcheck
 }
 
 // GetPrivateIP returns the cloud instance private IP.
@@ -147,6 +151,23 @@ func (f *fakeHarvester) GetDedicatedVMHostID() (string, error) {
 // GetHarvester returns instance of the Harvester detected (or instance of themselves)
 func (f *fakeHarvester) GetHarvester() (cloud.Harvester, error) {
 	return f, nil
+}
+
+// setMockOCIPhase1 sets up the shared Phase 1 (IMDS) mock expectations for OCI test cases,
+// leaving Phase 2 (OCI API) expectations for the caller to set based on the scenario.
+func setMockOCIPhase1(harvester *fakeHarvester) {
+	harvester.On("GetAccountID").Return("ocid1.compartment.oc1", nil)
+	harvester.On("GetCloudType").Return(cloud.TypeOCI)
+	harvester.On("GetRegion").Return("us-ashburn-1", nil)
+	harvester.On("GetZone").Return("jyDh:US-ASHBURN-AD-1", nil)
+	harvester.On("GetInstanceImageID").Return("ocid1.image.oc1", nil)
+	harvester.On("GetInstanceDisplayName").Return("ubunut-instance-20250722-1328", nil)
+	harvester.On("GetVMSize").Return("VM.Optimized3.Flex", nil)
+	harvester.On("GetFaultDomain").Return("FAULT-DOMAIN-1", nil)
+	harvester.On("GetHostname").Return("ubunut-instance-20250722-1328", nil)
+	harvester.On("GetPrivateIP").Return("10.0.0.5", nil)
+	harvester.On("GetFreeformTags").Return(map[string]string{"env": "prod"}, nil)
+	harvester.On("GetInstanceID").Return("ocid1.instance.oc1", nil)
 }
 
 func TestGetHostInfo(t *testing.T) {
@@ -277,18 +298,7 @@ func TestGetHostInfo(t *testing.T) {
 				assert.NoError(t, err)
 			},
 			setMock: func(harvester *fakeHarvester) {
-				harvester.On("GetAccountID").Return("ocid1.compartment.oc1", nil)
-				harvester.On("GetCloudType").Return(cloud.TypeOCI)
-				harvester.On("GetRegion").Return("us-ashburn-1", nil)
-				harvester.On("GetZone").Return("jyDh:US-ASHBURN-AD-1", nil)
-				harvester.On("GetInstanceImageID").Return("ocid1.image.oc1", nil)
-				harvester.On("GetInstanceDisplayName").Return("ubunut-instance-20250722-1328", nil)
-				harvester.On("GetVMSize").Return("VM.Optimized3.Flex", nil)
-				harvester.On("GetFaultDomain").Return("FAULT-DOMAIN-1", nil)
-				harvester.On("GetHostname").Return("ubunut-instance-20250722-1328", nil)
-				harvester.On("GetPrivateIP").Return("10.0.0.5", nil)
-				harvester.On("GetFreeformTags").Return(map[string]string{"env": "prod"}, nil)
-				harvester.On("GetInstanceID").Return("ocid1.instance.oc1", nil)
+				setMockOCIPhase1(harvester)
 				harvester.On("GetVCNID").Return("ocid1.vcn.oc1", nil)
 				harvester.On("GetSubnetID").Return("ocid1.subnet.oc1", nil)
 				harvester.On("GetLifecycleState").Return("RUNNING", nil)
@@ -303,31 +313,20 @@ func TestGetHostInfo(t *testing.T) {
 				assert.Equal(t, "us-ashburn-1", data.RegionOCI)
 				assert.Equal(t, "ocid1.instance.oc1", data.CloudResourceID)
 				// Phase 2 (OCI API) attributes are left empty, not an error - graceful degradation.
-				assert.Equal(t, "", data.OCIVCNID)
-				assert.Equal(t, "", data.OCISubnetID)
-				assert.Equal(t, "", data.OCILifecycleState)
-				assert.Equal(t, "", data.OCIVirtualizationType)
-				assert.Equal(t, "", data.OCIDedicatedVMHostID)
+				assert.Empty(t, data.OCIVCNID)
+				assert.Empty(t, data.OCISubnetID)
+				assert.Empty(t, data.OCILifecycleState)
+				assert.Empty(t, data.OCIVirtualizationType)
+				assert.Empty(t, data.OCIDedicatedVMHostID)
 				assert.NoError(t, err)
 			},
 			setMock: func(harvester *fakeHarvester) {
-				harvester.On("GetAccountID").Return("ocid1.compartment.oc1", nil)
-				harvester.On("GetCloudType").Return(cloud.TypeOCI)
-				harvester.On("GetRegion").Return("us-ashburn-1", nil)
-				harvester.On("GetZone").Return("jyDh:US-ASHBURN-AD-1", nil)
-				harvester.On("GetInstanceImageID").Return("ocid1.image.oc1", nil)
-				harvester.On("GetInstanceDisplayName").Return("ubunut-instance-20250722-1328", nil)
-				harvester.On("GetVMSize").Return("VM.Optimized3.Flex", nil)
-				harvester.On("GetFaultDomain").Return("FAULT-DOMAIN-1", nil)
-				harvester.On("GetHostname").Return("ubunut-instance-20250722-1328", nil)
-				harvester.On("GetPrivateIP").Return("10.0.0.5", nil)
-				harvester.On("GetFreeformTags").Return(map[string]string{"env": "prod"}, nil)
-				harvester.On("GetInstanceID").Return("ocid1.instance.oc1", nil)
-				harvester.On("GetVCNID").Return("", errors.New("instance principal unavailable"))
-				harvester.On("GetSubnetID").Return("", errors.New("instance principal unavailable"))
-				harvester.On("GetLifecycleState").Return("", errors.New("instance principal unavailable"))
-				harvester.On("GetVirtualizationType").Return("", errors.New("instance principal unavailable"))
-				harvester.On("GetDedicatedVMHostID").Return("", errors.New("instance principal unavailable"))
+				setMockOCIPhase1(harvester)
+				harvester.On("GetVCNID").Return("", errInstancePrincipalUnavailable)
+				harvester.On("GetSubnetID").Return("", errInstancePrincipalUnavailable)
+				harvester.On("GetLifecycleState").Return("", errInstancePrincipalUnavailable)
+				harvester.On("GetVirtualizationType").Return("", errInstancePrincipalUnavailable)
+				harvester.On("GetDedicatedVMHostID").Return("", errInstancePrincipalUnavailable)
 			},
 		},
 		{

--- a/internal/plugins/common/labels.go
+++ b/internal/plugins/common/labels.go
@@ -1,0 +1,43 @@
+// Copyright New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// labelPrefix is prepended to each dynamic tag key when flattened into inventory attributes.
+const labelPrefix = "label."
+
+// FlattenLabels marshals v, then merges tags into the result as top-level "label.<key>"
+// attributes. v must not itself implement json.Marshaler in a way that would recurse into
+// this function - callers typically pass a type-aliased copy of the struct calling this from
+// its own MarshalJSON to avoid infinite recursion.
+func FlattenLabels(v any, tags map[string]string) ([]byte, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal value for label flattening: %w", err)
+	}
+
+	if len(tags) == 0 {
+		return data, nil
+	}
+
+	var merged map[string]interface{}
+	if err := json.Unmarshal(data, &merged); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal value for label flattening: %w", err)
+	}
+
+	for key, value := range tags {
+		merged[labelPrefix+key] = value
+	}
+
+	flattened, err := json.Marshal(merged)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal flattened labels: %w", err)
+	}
+
+	return flattened, nil
+}

--- a/internal/plugins/common/labels.go
+++ b/internal/plugins/common/labels.go
@@ -18,7 +18,7 @@ const labelPrefix = "label."
 func FlattenLabels(v any, tags map[string]string) ([]byte, error) {
 	data, err := json.Marshal(v)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal value for label flattening: %w", err)
+		return nil, fmt.Errorf("failed to marshal value for label flattening: %w", err) //nolint:wrapcheck
 	}
 
 	if len(tags) == 0 {
@@ -26,8 +26,10 @@ func FlattenLabels(v any, tags map[string]string) ([]byte, error) {
 	}
 
 	var merged map[string]interface{}
-	if err := json.Unmarshal(data, &merged); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal value for label flattening: %w", err)
+
+	err = json.Unmarshal(data, &merged)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal value for label flattening: %w", err) //nolint:wrapcheck
 	}
 
 	for key, value := range tags {
@@ -36,7 +38,7 @@ func FlattenLabels(v any, tags map[string]string) ([]byte, error) {
 
 	flattened, err := json.Marshal(merged)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal flattened labels: %w", err)
+		return nil, fmt.Errorf("failed to marshal flattened labels: %w", err) //nolint:wrapcheck
 	}
 
 	return flattened, nil

--- a/internal/plugins/common/labels_test.go
+++ b/internal/plugins/common/labels_test.go
@@ -1,7 +1,7 @@
 // Copyright New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package common //nolint:revive // package name predates this file; not introducing a rename here
+package common
 
 import (
 	"encoding/json"

--- a/internal/plugins/common/labels_test.go
+++ b/internal/plugins/common/labels_test.go
@@ -1,7 +1,7 @@
 // Copyright New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package common
+package common //nolint:revive // package name predates this file; not introducing a rename here
 
 import (
 	"encoding/json"

--- a/internal/plugins/common/labels_test.go
+++ b/internal/plugins/common/labels_test.go
@@ -1,0 +1,41 @@
+// Copyright New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlattenLabels(t *testing.T) {
+	t.Parallel()
+
+	type sample struct {
+		Name string `json:"name"`
+	}
+
+	t.Run("no tags leaves the payload untouched", func(t *testing.T) {
+		t.Parallel()
+
+		data, err := FlattenLabels(sample{Name: "host1"}, nil)
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		require.Equal(t, map[string]interface{}{"name": "host1"}, got)
+	})
+
+	t.Run("tags are merged as top-level label.<key> attributes", func(t *testing.T) {
+		t.Parallel()
+
+		data, err := FlattenLabels(sample{Name: "host1"}, map[string]string{"env": "prod"})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		require.Equal(t, map[string]interface{}{"name": "host1", "label.env": "prod"}, got)
+	})
+}

--- a/internal/plugins/darwin/hostinfo.go
+++ b/internal/plugins/darwin/hostinfo.go
@@ -58,7 +58,12 @@ func (hip *HostInfoDarwin) SortKey() string {
 func (hip HostInfoDarwin) MarshalJSON() ([]byte, error) {
 	type alias HostInfoDarwin
 
-	return common.FlattenLabels(alias(hip), hip.OCIFreeformTags)
+	data, err := common.FlattenLabels(alias(hip), hip.OCIFreeformTags)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal HostInfoDarwin: %w", err) //nolint:wrapcheck
+	}
+
+	return data, nil
 }
 
 func NewHostinfoPlugin(ctx agent.AgentContext, hostInfo common.HostInfo) agent.Plugin {

--- a/internal/plugins/darwin/hostinfo.go
+++ b/internal/plugins/darwin/hostinfo.go
@@ -52,6 +52,15 @@ func (hip *HostInfoDarwin) SortKey() string {
 	return hip.System
 }
 
+// MarshalJSON flattens OCIFreeformTags into top-level "label.<key>" attributes. Must stay on
+// this outermost type only - adding it to an embedded type (e.g. common.HostInfoData) would be
+// promoted through anonymous embedding and silently override marshaling of this whole struct.
+func (hip HostInfoDarwin) MarshalJSON() ([]byte, error) {
+	type alias HostInfoDarwin
+
+	return common.FlattenLabels(alias(hip), hip.OCIFreeformTags)
+}
+
 func NewHostinfoPlugin(ctx agent.AgentContext, hostInfo common.HostInfo) agent.Plugin {
 	return &HostinfoPlugin{
 		PluginCommon: agent.PluginCommon{

--- a/internal/plugins/darwin/processorinfo_test_amd64.go
+++ b/internal/plugins/darwin/processorinfo_test_amd64.go
@@ -88,7 +88,7 @@ func TestData(t *testing.T) {
 
 					return ``, ErrUnknownCommand
 				},
-				HostInfo: common.NewHostInfoCommon("test", true, cloud.NewDetector(true, 0, 0, 0, true)),
+				HostInfo: common.NewHostInfoCommon("test", true, nil, cloud.NewDetector(true, 0, 0, 0, true)),
 			}
 			hip.Context.Config().DisableCloudMetadata = true
 			hip.Context.Config().RunMode = "root"

--- a/internal/plugins/darwin/processorinfo_test_arm64.go
+++ b/internal/plugins/darwin/processorinfo_test_arm64.go
@@ -86,7 +86,7 @@ func TestData(t *testing.T) {
 
 					return ``, ErrUnknownCommand
 				},
-				HostInfo: common.NewHostInfoCommon("test", true, cloud.NewDetector(true, 0, 0, 0, true)),
+				HostInfo: common.NewHostInfoCommon("test", true, nil, cloud.NewDetector(true, 0, 0, 0, true)),
 			}
 			hip.Context.Config().DisableCloudMetadata = true
 			hip.Context.Config().RunMode = "root"

--- a/internal/plugins/linux/hostinfo.go
+++ b/internal/plugins/linux/hostinfo.go
@@ -54,6 +54,15 @@ func (self HostInfoLinux) SortKey() string {
 	return self.System
 }
 
+// MarshalJSON flattens OCIFreeformTags into top-level "label.<key>" attributes. Must stay on
+// this outermost type only - adding it to an embedded type (e.g. common.HostInfoData) would be
+// promoted through anonymous embedding and silently override marshaling of this whole struct.
+func (self HostInfoLinux) MarshalJSON() ([]byte, error) {
+	type alias HostInfoLinux
+
+	return common.FlattenLabels(alias(self), self.OCIFreeformTags)
+}
+
 func getTotalCpu(cpuInfoFile string) string {
 	cpu_re := regexp.MustCompile(`processor\s*:\s*([0-9]+)`)
 	file, err := ioutil.ReadFile(cpuInfoFile)

--- a/internal/plugins/linux/hostinfo.go
+++ b/internal/plugins/linux/hostinfo.go
@@ -57,10 +57,15 @@ func (self HostInfoLinux) SortKey() string {
 // MarshalJSON flattens OCIFreeformTags into top-level "label.<key>" attributes. Must stay on
 // this outermost type only - adding it to an embedded type (e.g. common.HostInfoData) would be
 // promoted through anonymous embedding and silently override marshaling of this whole struct.
-func (self HostInfoLinux) MarshalJSON() ([]byte, error) {
+func (h HostInfoLinux) MarshalJSON() ([]byte, error) {
 	type alias HostInfoLinux
 
-	return common.FlattenLabels(alias(self), self.OCIFreeformTags)
+	data, err := common.FlattenLabels(alias(h), h.OCIFreeformTags)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal HostInfoLinux: %w", err) //nolint:wrapcheck
+	}
+
+	return data, nil
 }
 
 func getTotalCpu(cpuInfoFile string) string {

--- a/internal/plugins/linux/hostinfo_test.go
+++ b/internal/plugins/linux/hostinfo_test.go
@@ -44,7 +44,7 @@ func (s *HostinfoSuite) SetUpTest(c *C) {
 
 func (s *HostinfoSuite) NewPlugin(c *C) *HostinfoPlugin {
 	cloudDetector := cloud.NewDetector(true, 0, 0, 0, false)
-	v := NewHostinfoPlugin(s.agent, common.NewHostInfoCommon("test", true, cloudDetector))
+	v := NewHostinfoPlugin(s.agent, common.NewHostInfoCommon("test", true, nil, cloudDetector))
 
 	plugin, ok := v.(*HostinfoPlugin)
 	c.Assert(ok, Equals, true)
@@ -75,7 +75,7 @@ func (s *HostinfoSuite) TestGetDistro(c *C) {
 
 	cloudDetector := cloud.NewDetector(true, 0, 0, 0, false)
 
-	v := NewHostinfoPlugin(s.agent, common.NewHostInfoCommon("test", true, cloudDetector))
+	v := NewHostinfoPlugin(s.agent, common.NewHostInfoCommon("test", true, nil, cloudDetector))
 	plugin, ok := v.(*HostinfoPlugin)
 	c.Assert(ok, Equals, true)
 	data := plugin.Data()

--- a/internal/plugins/windows/hostinfo.go
+++ b/internal/plugins/windows/hostinfo.go
@@ -60,6 +60,15 @@ func (self *HostInfoWindows) SortKey() string {
 	return self.System
 }
 
+// MarshalJSON flattens OCIFreeformTags into top-level "label.<key>" attributes. Must stay on
+// this outermost type only - adding it to an embedded type (e.g. common.HostInfoData) would be
+// promoted through anonymous embedding and silently override marshaling of this whole struct.
+func (self HostInfoWindows) MarshalJSON() ([]byte, error) {
+	type alias HostInfoWindows
+
+	return common.FlattenLabels(alias(self), self.OCIFreeformTags)
+}
+
 func NewHostinfoPlugin(id ids.PluginID, ctx agent.AgentContext, hostInfo common.HostInfo) agent.Plugin {
 	return &HostinfoPlugin{
 		PluginCommon: agent.PluginCommon{ID: id, Context: ctx},

--- a/internal/plugins/windows/hostinfo.go
+++ b/internal/plugins/windows/hostinfo.go
@@ -63,10 +63,15 @@ func (self *HostInfoWindows) SortKey() string {
 // MarshalJSON flattens OCIFreeformTags into top-level "label.<key>" attributes. Must stay on
 // this outermost type only - adding it to an embedded type (e.g. common.HostInfoData) would be
 // promoted through anonymous embedding and silently override marshaling of this whole struct.
-func (self HostInfoWindows) MarshalJSON() ([]byte, error) {
+func (h HostInfoWindows) MarshalJSON() ([]byte, error) {
 	type alias HostInfoWindows
 
-	return common.FlattenLabels(alias(self), self.OCIFreeformTags)
+	data, err := common.FlattenLabels(alias(h), h.OCIFreeformTags)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal HostInfoWindows: %w", err) //nolint:wrapcheck
+	}
+
+	return data, nil
 }
 
 func NewHostinfoPlugin(id ids.PluginID, ctx agent.AgentContext, hostInfo common.HostInfo) agent.Plugin {

--- a/internal/plugins/windows/hostinfo_test.go
+++ b/internal/plugins/windows/hostinfo_test.go
@@ -40,7 +40,7 @@ func (s *HostinfoSuite) SetUpTest(c *C) {
 func (s *HostinfoSuite) NewPlugin(id ids.PluginID, c *C) *HostinfoPlugin {
 	cloudDetector := cloud.NewDetector(true, 0, 0, 0, false)
 	v := NewHostinfoPlugin(id, s.agent,
-		common.NewHostInfoCommon("testing", true, cloudDetector))
+		common.NewHostInfoCommon("testing", true, nil, cloudDetector))
 	plugin, ok := v.(*HostinfoPlugin)
 	c.Assert(ok, Equals, true)
 	go plugin.Run()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1099,7 +1099,7 @@ type Config struct {
 	// CI/CD pipelines writing tags like last-deploy-date on every deployment.
 	// Default: empty (no exclusions)
 	// Public: Yes
-	OCITagsExclude []string `yaml:"oci_tags_exclude" envconfig:"oci_tags_exclude"`
+	OCITagsExclude []string `envconfig:"oci_tags_exclude" yaml:"oci_tags_exclude"`
 
 	// RemoveEntitiesPeriod Defines the frequency to engage the process of deleting entities that haven't been reported
 	// information during the frequency interval. Valid time units are: "s" (seconds), "m" (minutes), "h" (hour).

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1094,6 +1094,13 @@ type Config struct {
 	// Public: Yes
 	CloudMetadataDisableKeepAlive bool `yaml:"cloud_metadata_disable_keep_alive" envconfig:"cloud_metadata_disable_keep_alive"`
 
+	// OCITagsExclude excludes OCI freeform tags from being emitted as label.* inventory
+	// attributes. Supports glob patterns (e.g. "pipeline-*") to guard against tag churn from
+	// CI/CD pipelines writing tags like last-deploy-date on every deployment.
+	// Default: empty (no exclusions)
+	// Public: Yes
+	OCITagsExclude []string `yaml:"oci_tags_exclude" envconfig:"oci_tags_exclude"`
+
 	// RemoveEntitiesPeriod Defines the frequency to engage the process of deleting entities that haven't been reported
 	// information during the frequency interval. Valid time units are: "s" (seconds), "m" (minutes), "h" (hour).
 	// Default: 48h

--- a/pkg/helpers/fingerprint/fingerprint_test.go
+++ b/pkg/helpers/fingerprint/fingerprint_test.go
@@ -89,7 +89,7 @@ func (a *MockCloudHarvester) GetHostname() (string, error) {
 }
 
 func (a *MockCloudHarvester) GetFreeformTags() (map[string]string, error) {
-	return nil, nil
+	return map[string]string{}, nil
 }
 
 func (a *MockCloudHarvester) GetPrivateIP() (string, error) {

--- a/pkg/helpers/fingerprint/fingerprint_test.go
+++ b/pkg/helpers/fingerprint/fingerprint_test.go
@@ -80,6 +80,42 @@ func (a *MockCloudHarvester) GetVMSize() (string, error) {
 	return "", nil
 }
 
+func (a *MockCloudHarvester) GetFaultDomain() (string, error) {
+	return "", nil
+}
+
+func (a *MockCloudHarvester) GetHostname() (string, error) {
+	return "", nil
+}
+
+func (a *MockCloudHarvester) GetFreeformTags() (map[string]string, error) {
+	return nil, nil
+}
+
+func (a *MockCloudHarvester) GetPrivateIP() (string, error) {
+	return "", nil
+}
+
+func (a *MockCloudHarvester) GetVCNID() (string, error) {
+	return "", nil
+}
+
+func (a *MockCloudHarvester) GetSubnetID() (string, error) {
+	return "", nil
+}
+
+func (a *MockCloudHarvester) GetLifecycleState() (string, error) {
+	return "", nil
+}
+
+func (a *MockCloudHarvester) GetVirtualizationType() (string, error) {
+	return "", nil
+}
+
+func (a *MockCloudHarvester) GetDedicatedVMHostID() (string, error) {
+	return "", nil
+}
+
 func (a *MockCloudHarvester) GetHarvester() (cloud.Harvester, error) {
 	return nil, nil
 }

--- a/pkg/plugins/plugins_darwin.go
+++ b/pkg/plugins/plugins_darwin.go
@@ -18,7 +18,7 @@ import (
 
 func RegisterPlugins(a *agent.Agent) error {
 	a.RegisterPlugin(darwin.NewHostinfoPlugin(a.Context,
-		common.NewHostInfoCommon(a.Context.Version(), !a.Context.Config().DisableCloudMetadata, a.GetCloudHarvester())))
+		common.NewHostInfoCommon(a.Context.Version(), !a.Context.Config().DisableCloudMetadata, a.Context.Config().OCITagsExclude, a.GetCloudHarvester())))
 	a.RegisterPlugin(NewHostAliasesPlugin(a.Context, a.GetCloudHarvester()))
 	config := a.Context.Config()
 

--- a/pkg/plugins/plugins_darwin.go
+++ b/pkg/plugins/plugins_darwin.go
@@ -18,7 +18,8 @@ import (
 
 func RegisterPlugins(a *agent.Agent) error {
 	a.RegisterPlugin(darwin.NewHostinfoPlugin(a.Context,
-		common.NewHostInfoCommon(a.Context.Version(), !a.Context.Config().DisableCloudMetadata, a.Context.Config().OCITagsExclude, a.GetCloudHarvester())))
+		common.NewHostInfoCommon(a.Context.Version(), !a.Context.Config().DisableCloudMetadata,
+			a.Context.Config().OCITagsExclude, a.GetCloudHarvester())))
 	a.RegisterPlugin(NewHostAliasesPlugin(a.Context, a.GetCloudHarvester()))
 	config := a.Context.Config()
 

--- a/pkg/plugins/plugins_linux.go
+++ b/pkg/plugins/plugins_linux.go
@@ -42,7 +42,7 @@ func RegisterPlugins(agent *agnt.Agent) error {
 
 	// Enabling the hostinfo plugin will make the host appear in the UI
 	agent.RegisterPlugin(pluginsLinux.NewHostinfoPlugin(agent.Context,
-		common.NewHostInfoCommon(agent.Context.Version(), !agent.Context.Config().DisableCloudMetadata, agent.GetCloudHarvester())))
+		common.NewHostInfoCommon(agent.Context.Version(), !agent.Context.Config().DisableCloudMetadata, agent.Context.Config().OCITagsExclude, agent.GetCloudHarvester())))
 
 	agent.RegisterPlugin(NewHostAliasesPlugin(agent.Context, agent.GetCloudHarvester()))
 	agent.RegisterPlugin(NewAgentConfigPlugin(ids.PluginID{"metadata", "agent_config"}, agent.Context))

--- a/pkg/plugins/plugins_linux.go
+++ b/pkg/plugins/plugins_linux.go
@@ -42,7 +42,8 @@ func RegisterPlugins(agent *agnt.Agent) error {
 
 	// Enabling the hostinfo plugin will make the host appear in the UI
 	agent.RegisterPlugin(pluginsLinux.NewHostinfoPlugin(agent.Context,
-		common.NewHostInfoCommon(agent.Context.Version(), !agent.Context.Config().DisableCloudMetadata, agent.Context.Config().OCITagsExclude, agent.GetCloudHarvester())))
+		common.NewHostInfoCommon(agent.Context.Version(), !agent.Context.Config().DisableCloudMetadata,
+			agent.Context.Config().OCITagsExclude, agent.GetCloudHarvester())))
 
 	agent.RegisterPlugin(NewHostAliasesPlugin(agent.Context, agent.GetCloudHarvester()))
 	agent.RegisterPlugin(NewAgentConfigPlugin(ids.PluginID{"metadata", "agent_config"}, agent.Context))

--- a/pkg/plugins/plugins_windows.go
+++ b/pkg/plugins/plugins_windows.go
@@ -25,7 +25,8 @@ func RegisterPlugins(a *agent.Agent) error {
 
 	// Enabling the hostinfo plugin will make the host appear in the UI
 	a.RegisterPlugin(pluginsWindows.NewHostinfoPlugin(ids.PluginID{"metadata", "system"}, a.Context,
-		common.NewHostInfoCommon(a.Context.Version(), !a.Context.Config().DisableCloudMetadata, a.Context.Config().OCITagsExclude, a.GetCloudHarvester())))
+		common.NewHostInfoCommon(a.Context.Version(), !a.Context.Config().DisableCloudMetadata,
+			a.Context.Config().OCITagsExclude, a.GetCloudHarvester())))
 	a.RegisterPlugin(NewHostAliasesPlugin(a.Context, a.GetCloudHarvester()))
 	a.RegisterPlugin(NewAgentConfigPlugin(ids.PluginID{"metadata", "agent_config"}, a.Context))
 	if config.ProxyConfigPlugin {

--- a/pkg/plugins/plugins_windows.go
+++ b/pkg/plugins/plugins_windows.go
@@ -25,7 +25,7 @@ func RegisterPlugins(a *agent.Agent) error {
 
 	// Enabling the hostinfo plugin will make the host appear in the UI
 	a.RegisterPlugin(pluginsWindows.NewHostinfoPlugin(ids.PluginID{"metadata", "system"}, a.Context,
-		common.NewHostInfoCommon(a.Context.Version(), !a.Context.Config().DisableCloudMetadata, a.GetCloudHarvester())))
+		common.NewHostInfoCommon(a.Context.Version(), !a.Context.Config().DisableCloudMetadata, a.Context.Config().OCITagsExclude, a.GetCloudHarvester())))
 	a.RegisterPlugin(NewHostAliasesPlugin(a.Context, a.GetCloudHarvester()))
 	a.RegisterPlugin(NewAgentConfigPlugin(ids.PluginID{"metadata", "agent_config"}, a.Context))
 	if config.ProxyConfigPlugin {

--- a/pkg/sysinfo/cloud/cloud.go
+++ b/pkg/sysinfo/cloud/cloud.go
@@ -4,6 +4,7 @@ package cloud
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -289,94 +290,139 @@ func (d *Detector) GetVMSize() (string, error) {
 	return cloudHarvester.GetVMSize()
 }
 
-// GetFaultDomain returns the cloud instance fault domain
+// GetFaultDomain returns the cloud instance fault domain.
 func (d *Detector) GetFaultDomain() (string, error) {
 	cloudHarvester, err := d.GetHarvester()
 	if err != nil {
 		return "", err
 	}
 
-	return cloudHarvester.GetFaultDomain()
+	faultDomain, err := cloudHarvester.GetFaultDomain()
+	if err != nil {
+		return "", fmt.Errorf("couldn't retrieve cloud fault domain: %w", err) //nolint:wrapcheck
+	}
+
+	return faultDomain, nil
 }
 
-// GetHostname returns the cloud instance hostname
+// GetHostname returns the cloud instance hostname.
 func (d *Detector) GetHostname() (string, error) {
 	cloudHarvester, err := d.GetHarvester()
 	if err != nil {
 		return "", err
 	}
 
-	return cloudHarvester.GetHostname()
+	hostname, err := cloudHarvester.GetHostname()
+	if err != nil {
+		return "", fmt.Errorf("couldn't retrieve cloud hostname: %w", err) //nolint:wrapcheck
+	}
+
+	return hostname, nil
 }
 
-// GetFreeformTags returns the cloud instance freeform tags
+// GetFreeformTags returns the cloud instance freeform tags.
 func (d *Detector) GetFreeformTags() (map[string]string, error) {
 	cloudHarvester, err := d.GetHarvester()
 	if err != nil {
 		return nil, err
 	}
 
-	return cloudHarvester.GetFreeformTags()
+	tags, err := cloudHarvester.GetFreeformTags()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't retrieve cloud freeform tags: %w", err) //nolint:wrapcheck
+	}
+
+	return tags, nil
 }
 
-// GetPrivateIP returns the cloud instance private IP
+// GetPrivateIP returns the cloud instance private IP.
 func (d *Detector) GetPrivateIP() (string, error) {
 	cloudHarvester, err := d.GetHarvester()
 	if err != nil {
 		return "", err
 	}
 
-	return cloudHarvester.GetPrivateIP()
+	privateIP, err := cloudHarvester.GetPrivateIP()
+	if err != nil {
+		return "", fmt.Errorf("couldn't retrieve cloud private IP: %w", err) //nolint:wrapcheck
+	}
+
+	return privateIP, nil
 }
 
-// GetVCNID returns the cloud instance's VCN ID
+// GetVCNID returns the cloud instance's VCN ID.
 func (d *Detector) GetVCNID() (string, error) {
 	cloudHarvester, err := d.GetHarvester()
 	if err != nil {
 		return "", err
 	}
 
-	return cloudHarvester.GetVCNID()
+	vcnID, err := cloudHarvester.GetVCNID()
+	if err != nil {
+		return "", fmt.Errorf("couldn't retrieve cloud VCN ID: %w", err) //nolint:wrapcheck
+	}
+
+	return vcnID, nil
 }
 
-// GetSubnetID returns the cloud instance's subnet ID
+// GetSubnetID returns the cloud instance's subnet ID.
 func (d *Detector) GetSubnetID() (string, error) {
 	cloudHarvester, err := d.GetHarvester()
 	if err != nil {
 		return "", err
 	}
 
-	return cloudHarvester.GetSubnetID()
+	subnetID, err := cloudHarvester.GetSubnetID()
+	if err != nil {
+		return "", fmt.Errorf("couldn't retrieve cloud subnet ID: %w", err) //nolint:wrapcheck
+	}
+
+	return subnetID, nil
 }
 
-// GetLifecycleState returns the cloud instance's lifecycle state
+// GetLifecycleState returns the cloud instance's lifecycle state.
 func (d *Detector) GetLifecycleState() (string, error) {
 	cloudHarvester, err := d.GetHarvester()
 	if err != nil {
 		return "", err
 	}
 
-	return cloudHarvester.GetLifecycleState()
+	lifecycleState, err := cloudHarvester.GetLifecycleState()
+	if err != nil {
+		return "", fmt.Errorf("couldn't retrieve cloud lifecycle state: %w", err) //nolint:wrapcheck
+	}
+
+	return lifecycleState, nil
 }
 
-// GetVirtualizationType returns the cloud instance's virtualization type
+// GetVirtualizationType returns the cloud instance's virtualization type.
 func (d *Detector) GetVirtualizationType() (string, error) {
 	cloudHarvester, err := d.GetHarvester()
 	if err != nil {
 		return "", err
 	}
 
-	return cloudHarvester.GetVirtualizationType()
+	virtualizationType, err := cloudHarvester.GetVirtualizationType()
+	if err != nil {
+		return "", fmt.Errorf("couldn't retrieve cloud virtualization type: %w", err) //nolint:wrapcheck
+	}
+
+	return virtualizationType, nil
 }
 
-// GetDedicatedVMHostID returns the cloud instance's dedicated VM host ID
+// GetDedicatedVMHostID returns the cloud instance's dedicated VM host ID.
 func (d *Detector) GetDedicatedVMHostID() (string, error) {
 	cloudHarvester, err := d.GetHarvester()
 	if err != nil {
 		return "", err
 	}
 
-	return cloudHarvester.GetDedicatedVMHostID()
+	dedicatedVMHostID, err := cloudHarvester.GetDedicatedVMHostID()
+	if err != nil {
+		return "", fmt.Errorf("couldn't retrieve cloud dedicated VM host ID: %w", err) //nolint:wrapcheck
+	}
+
+	return dedicatedVMHostID, nil
 }
 
 // isInitialized will check if the detector is Initialized.
@@ -440,7 +486,6 @@ func (d *Detector) detectRetrying(harvesters ...Harvester) {
 
 // detect will check which cloud harvester is able to successfully request data from API in order to detect the cloud type.
 func (d *Detector) detect(harvesters ...Harvester) error {
-
 	for _, harvester := range harvesters {
 		if harvester == nil {
 			continue

--- a/pkg/sysinfo/cloud/cloud.go
+++ b/pkg/sysinfo/cloud/cloud.go
@@ -70,6 +70,24 @@ type Harvester interface {
 	GetInstanceDisplayName() (string, error)
 	// GetVMSize returns the cloud instance VM size //nolint:godot
 	GetVMSize() (string, error)
+	// GetFaultDomain returns the cloud instance fault domain
+	GetFaultDomain() (string, error)
+	// GetHostname returns the cloud instance hostname
+	GetHostname() (string, error)
+	// GetFreeformTags returns the cloud instance freeform tags
+	GetFreeformTags() (map[string]string, error)
+	// GetPrivateIP returns the cloud instance private IP
+	GetPrivateIP() (string, error)
+	// GetVCNID returns the cloud instance's VCN ID
+	GetVCNID() (string, error)
+	// GetSubnetID returns the cloud instance's subnet ID
+	GetSubnetID() (string, error)
+	// GetLifecycleState returns the cloud instance's lifecycle state
+	GetLifecycleState() (string, error)
+	// GetVirtualizationType returns the cloud instance's virtualization type
+	GetVirtualizationType() (string, error)
+	// GetDedicatedVMHostID returns the cloud instance's dedicated VM host ID
+	GetDedicatedVMHostID() (string, error)
 	// GetHarvester returns instance of the Harvester detected (or instance of themselves)
 	GetHarvester() (Harvester, error)
 }
@@ -269,6 +287,96 @@ func (d *Detector) GetVMSize() (string, error) {
 	}
 
 	return cloudHarvester.GetVMSize()
+}
+
+// GetFaultDomain returns the cloud instance fault domain
+func (d *Detector) GetFaultDomain() (string, error) {
+	cloudHarvester, err := d.GetHarvester()
+	if err != nil {
+		return "", err
+	}
+
+	return cloudHarvester.GetFaultDomain()
+}
+
+// GetHostname returns the cloud instance hostname
+func (d *Detector) GetHostname() (string, error) {
+	cloudHarvester, err := d.GetHarvester()
+	if err != nil {
+		return "", err
+	}
+
+	return cloudHarvester.GetHostname()
+}
+
+// GetFreeformTags returns the cloud instance freeform tags
+func (d *Detector) GetFreeformTags() (map[string]string, error) {
+	cloudHarvester, err := d.GetHarvester()
+	if err != nil {
+		return nil, err
+	}
+
+	return cloudHarvester.GetFreeformTags()
+}
+
+// GetPrivateIP returns the cloud instance private IP
+func (d *Detector) GetPrivateIP() (string, error) {
+	cloudHarvester, err := d.GetHarvester()
+	if err != nil {
+		return "", err
+	}
+
+	return cloudHarvester.GetPrivateIP()
+}
+
+// GetVCNID returns the cloud instance's VCN ID
+func (d *Detector) GetVCNID() (string, error) {
+	cloudHarvester, err := d.GetHarvester()
+	if err != nil {
+		return "", err
+	}
+
+	return cloudHarvester.GetVCNID()
+}
+
+// GetSubnetID returns the cloud instance's subnet ID
+func (d *Detector) GetSubnetID() (string, error) {
+	cloudHarvester, err := d.GetHarvester()
+	if err != nil {
+		return "", err
+	}
+
+	return cloudHarvester.GetSubnetID()
+}
+
+// GetLifecycleState returns the cloud instance's lifecycle state
+func (d *Detector) GetLifecycleState() (string, error) {
+	cloudHarvester, err := d.GetHarvester()
+	if err != nil {
+		return "", err
+	}
+
+	return cloudHarvester.GetLifecycleState()
+}
+
+// GetVirtualizationType returns the cloud instance's virtualization type
+func (d *Detector) GetVirtualizationType() (string, error) {
+	cloudHarvester, err := d.GetHarvester()
+	if err != nil {
+		return "", err
+	}
+
+	return cloudHarvester.GetVirtualizationType()
+}
+
+// GetDedicatedVMHostID returns the cloud instance's dedicated VM host ID
+func (d *Detector) GetDedicatedVMHostID() (string, error) {
+	cloudHarvester, err := d.GetHarvester()
+	if err != nil {
+		return "", err
+	}
+
+	return cloudHarvester.GetDedicatedVMHostID()
 }
 
 // isInitialized will check if the detector is Initialized.

--- a/pkg/sysinfo/cloud/cloud_alibaba.go
+++ b/pkg/sysinfo/cloud/cloud_alibaba.go
@@ -106,6 +106,51 @@ func (a *AlibabaHarvester) GetVMSize() (string, error) {
 	return "", ErrMethodNotImplemented
 }
 
+// GetFaultDomain returns the cloud instance fault domain (not supported for Alibaba).
+func (a *AlibabaHarvester) GetFaultDomain() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetHostname returns the cloud instance hostname (not supported for Alibaba).
+func (a *AlibabaHarvester) GetHostname() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetFreeformTags returns the cloud instance freeform tags (not supported for Alibaba).
+func (a *AlibabaHarvester) GetFreeformTags() (map[string]string, error) {
+	return nil, ErrMethodNotImplemented
+}
+
+// GetPrivateIP returns the cloud instance private IP (not supported for Alibaba).
+func (a *AlibabaHarvester) GetPrivateIP() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetVCNID returns the cloud instance's VCN ID (not supported for Alibaba).
+func (a *AlibabaHarvester) GetVCNID() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetSubnetID returns the cloud instance's subnet ID (not supported for Alibaba).
+func (a *AlibabaHarvester) GetSubnetID() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetLifecycleState returns the cloud instance's lifecycle state (not supported for Alibaba).
+func (a *AlibabaHarvester) GetLifecycleState() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetVirtualizationType returns the cloud instance's virtualization type (not supported for Alibaba).
+func (a *AlibabaHarvester) GetVirtualizationType() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetDedicatedVMHostID returns the cloud instance's dedicated VM host ID (not supported for Alibaba).
+func (a *AlibabaHarvester) GetDedicatedVMHostID() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
 // GetRegion will return the cloud instance region.
 func (a *AlibabaHarvester) GetRegion() (string, error) {
 	if a.region == "" || a.timeout.HasExpired() {

--- a/pkg/sysinfo/cloud/cloud_aws.go
+++ b/pkg/sysinfo/cloud/cloud_aws.go
@@ -160,6 +160,51 @@ func (a *AWSHarvester) GetVMSize() (string, error) {
 	return "", ErrMethodNotImplemented
 }
 
+// GetFaultDomain returns the cloud instance fault domain (not supported for AWS).
+func (a *AWSHarvester) GetFaultDomain() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetHostname returns the cloud instance hostname (not supported for AWS).
+func (a *AWSHarvester) GetHostname() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetFreeformTags returns the cloud instance freeform tags (not supported for AWS).
+func (a *AWSHarvester) GetFreeformTags() (map[string]string, error) {
+	return nil, ErrMethodNotImplemented
+}
+
+// GetPrivateIP returns the cloud instance private IP (not supported for AWS).
+func (a *AWSHarvester) GetPrivateIP() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetVCNID returns the cloud instance's VCN ID (not supported for AWS).
+func (a *AWSHarvester) GetVCNID() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetSubnetID returns the cloud instance's subnet ID (not supported for AWS).
+func (a *AWSHarvester) GetSubnetID() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetLifecycleState returns the cloud instance's lifecycle state (not supported for AWS).
+func (a *AWSHarvester) GetLifecycleState() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetVirtualizationType returns the cloud instance's virtualization type (not supported for AWS).
+func (a *AWSHarvester) GetVirtualizationType() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetDedicatedVMHostID returns the cloud instance's dedicated VM host ID (not supported for AWS).
+func (a *AWSHarvester) GetDedicatedVMHostID() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
 // formatURL prepares the URL used for requesting AWS metadata.
 func formatURL(baseUrl string, query string) string {
 	return baseUrl + awsMetaDataPath + query

--- a/pkg/sysinfo/cloud/cloud_azure.go
+++ b/pkg/sysinfo/cloud/cloud_azure.go
@@ -89,6 +89,51 @@ func (a *AzureHarvester) GetVMSize() (string, error) {
 	return "", ErrMethodNotImplemented
 }
 
+// GetFaultDomain returns the cloud instance fault domain (not supported for Azure).
+func (a *AzureHarvester) GetFaultDomain() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetHostname returns the cloud instance hostname (not supported for Azure).
+func (a *AzureHarvester) GetHostname() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetFreeformTags returns the cloud instance freeform tags (not supported for Azure).
+func (a *AzureHarvester) GetFreeformTags() (map[string]string, error) {
+	return nil, ErrMethodNotImplemented
+}
+
+// GetPrivateIP returns the cloud instance private IP (not supported for Azure).
+func (a *AzureHarvester) GetPrivateIP() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetVCNID returns the cloud instance's VCN ID (not supported for Azure).
+func (a *AzureHarvester) GetVCNID() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetSubnetID returns the cloud instance's subnet ID (not supported for Azure).
+func (a *AzureHarvester) GetSubnetID() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetLifecycleState returns the cloud instance's lifecycle state (not supported for Azure).
+func (a *AzureHarvester) GetLifecycleState() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetVirtualizationType returns the cloud instance's virtualization type (not supported for Azure).
+func (a *AzureHarvester) GetVirtualizationType() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetDedicatedVMHostID returns the cloud instance's dedicated VM host ID (not supported for Azure).
+func (a *AzureHarvester) GetDedicatedVMHostID() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
 // GetRegion will return the cloud instance region.
 func (a *AzureHarvester) GetRegion() (string, error) {
 	if a.region == "" || a.timeout.HasExpired() {

--- a/pkg/sysinfo/cloud/cloud_gcp.go
+++ b/pkg/sysinfo/cloud/cloud_gcp.go
@@ -99,6 +99,51 @@ func (gcp *GCPHarvester) GetVMSize() (string, error) {
 	return "", ErrMethodNotImplemented
 }
 
+// GetFaultDomain returns the cloud instance fault domain (not supported for GCP).
+func (gcp *GCPHarvester) GetFaultDomain() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetHostname returns the cloud instance hostname (not supported for GCP).
+func (gcp *GCPHarvester) GetHostname() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetFreeformTags returns the cloud instance freeform tags (not supported for GCP).
+func (gcp *GCPHarvester) GetFreeformTags() (map[string]string, error) {
+	return nil, ErrMethodNotImplemented
+}
+
+// GetPrivateIP returns the cloud instance private IP (not supported for GCP).
+func (gcp *GCPHarvester) GetPrivateIP() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetVCNID returns the cloud instance's VCN ID (not supported for GCP).
+func (gcp *GCPHarvester) GetVCNID() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetSubnetID returns the cloud instance's subnet ID (not supported for GCP).
+func (gcp *GCPHarvester) GetSubnetID() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetLifecycleState returns the cloud instance's lifecycle state (not supported for GCP).
+func (gcp *GCPHarvester) GetLifecycleState() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetVirtualizationType returns the cloud instance's virtualization type (not supported for GCP).
+func (gcp *GCPHarvester) GetVirtualizationType() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
+// GetDedicatedVMHostID returns the cloud instance's dedicated VM host ID (not supported for GCP).
+func (gcp *GCPHarvester) GetDedicatedVMHostID() (string, error) {
+	return "", ErrMethodNotImplemented
+}
+
 // GetRegion will return the cloud instance region.
 func (gcp *GCPHarvester) GetRegion() (string, error) {
 	if gcp.zone == "" || gcp.timeout.HasExpired() {

--- a/pkg/sysinfo/cloud/cloud_oci.go
+++ b/pkg/sysinfo/cloud/cloud_oci.go
@@ -219,6 +219,7 @@ func (a *OCIHarvester) GetFaultDomain() (string, error) {
 		if err != nil {
 			return "", err
 		}
+
 		a.faultDomain = ociMetadata.FaultDomain
 	}
 
@@ -232,6 +233,7 @@ func (a *OCIHarvester) GetHostname() (string, error) {
 		if err != nil {
 			return "", err
 		}
+
 		a.hostname = ociMetadata.Hostname
 	}
 
@@ -245,6 +247,7 @@ func (a *OCIHarvester) GetFreeformTags() (map[string]string, error) {
 		if err != nil {
 			return nil, err
 		}
+
 		a.freeformTags = ociMetadata.FreeformTags
 	}
 
@@ -258,6 +261,7 @@ func (a *OCIHarvester) GetPrivateIP() (string, error) {
 		if err != nil {
 			return "", err
 		}
+
 		if len(vnics) > 0 {
 			a.privateIP = vnics[0].PrivateIP
 		}
@@ -328,17 +332,15 @@ func parseOCIMetadataResponse(response *http.Response) (*OCIMetadata, error) {
 
 // GetOCIVnicsMetadata is used to request VNIC metadata from OCI API.
 func GetOCIVnicsMetadata(disableKeepAlive bool) ([]OCIVnicMetadata, error) {
-	var request *http.Request
-	var err error
-
-	if request, err = http.NewRequest(http.MethodGet, ociVnicsEndpoint, nil); err != nil { //nolint:noctx
+	request, err := http.NewRequest(http.MethodGet, ociVnicsEndpoint, nil) //nolint:noctx
+	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrOCIRequestFailed, err) //nolint:wrapcheck
 	}
 
 	request.Header.Add("Authorization", ociV2AuthorizationHeader)
 
-	var response *http.Response
-	if response, err = clientWithFastTimeout(disableKeepAlive).Do(request); err != nil {
+	response, err := clientWithFastTimeout(disableKeepAlive).Do(request)
+	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrOCIFetchFailed, err) //nolint:wrapcheck
 	}
 	defer response.Body.Close()
@@ -352,14 +354,15 @@ func parseOCIVnicsMetadataResponse(response *http.Response) ([]OCIVnicMetadata, 
 		return nil, fmt.Errorf("%w: %d %s", ErrOCIResponseFailed, response.StatusCode, response.Status) //nolint:wrapcheck
 	}
 
-	var responseBody []byte
-	var err error
-	if responseBody, err = io.ReadAll(response.Body); err != nil {
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrOCIReadFailed, err) //nolint:wrapcheck
 	}
 
 	var result []OCIVnicMetadata
-	if err = json.Unmarshal(responseBody, &result); err != nil {
+
+	err = json.Unmarshal(responseBody, &result)
+	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrOCIUnmarshalFailed, err) //nolint:wrapcheck
 	}
 

--- a/pkg/sysinfo/cloud/cloud_oci.go
+++ b/pkg/sysinfo/cloud/cloud_oci.go
@@ -8,8 +8,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
 
 	"github.com/newrelic/infrastructure-agent/pkg/sysinfo"
+	"github.com/oracle/oci-go-sdk/v65/core"
 )
 
 // Ref: https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/gettingmetadata.htm
@@ -37,6 +39,9 @@ const (
 // ociEndpoint is the URL used for requesting OCI instance metadata (v2). Var to allow test overrides.
 var ociEndpoint = "http://169.254.169.254/opc/v2/instance/" //nolint:gochecknoglobals
 
+// ociVnicsEndpoint is the URL used for requesting OCI VNIC metadata (v2). Var to allow test overrides.
+var ociVnicsEndpoint = "http://169.254.169.254/opc/v2/vnics/" //nolint:gochecknoglobals
+
 // OCIHarvester is used to fetch data from OCI api.
 type OCIHarvester struct {
 	timeout          *Timeout
@@ -49,6 +54,21 @@ type OCIHarvester struct {
 	imageID          string
 	vmSize           string
 	displayName      string
+	faultDomain      string
+	hostname         string
+	freeformTags     map[string]string
+	privateIP        string
+
+	// Phase 2 (OCI SDK + instance principal auth) state. apiOnce guards a single attempt to
+	// build the SDK clients per harvester lifetime - if instance principal auth fails once,
+	// every Phase 2 getter fails fast with the same cached error instead of retrying per call.
+	apiOnce         sync.Once
+	apiInitErr      error
+	computeClient   *core.ComputeClient
+	vnClient        *core.VirtualNetworkClient
+	instanceDetails *core.Instance
+	vnic            *core.Vnic
+	subnet          *core.Subnet
 }
 
 // NewOCIHarvester returns a new instance of OCIHarvester.
@@ -64,6 +84,10 @@ func NewOCIHarvester(disableKeepAlive bool) *OCIHarvester {
 		imageID:          "",
 		vmSize:           "",
 		displayName:      "",
+		faultDomain:      "",
+		hostname:         "",
+		freeformTags:     nil,
+		privateIP:        "",
 	}
 }
 
@@ -188,15 +212,78 @@ func (a *OCIHarvester) GetInstanceDisplayName() (string, error) {
 	return a.displayName, nil
 }
 
+// GetFaultDomain returns the cloud instance fault domain.
+func (a *OCIHarvester) GetFaultDomain() (string, error) {
+	if a.faultDomain == "" || a.timeout.HasExpired() {
+		ociMetadata, err := GetOCIMetadata(a.disableKeepAlive)
+		if err != nil {
+			return "", err
+		}
+		a.faultDomain = ociMetadata.FaultDomain
+	}
+
+	return a.faultDomain, nil
+}
+
+// GetHostname returns the cloud instance hostname.
+func (a *OCIHarvester) GetHostname() (string, error) {
+	if a.hostname == "" || a.timeout.HasExpired() {
+		ociMetadata, err := GetOCIMetadata(a.disableKeepAlive)
+		if err != nil {
+			return "", err
+		}
+		a.hostname = ociMetadata.Hostname
+	}
+
+	return a.hostname, nil
+}
+
+// GetFreeformTags returns the cloud instance freeform tags.
+func (a *OCIHarvester) GetFreeformTags() (map[string]string, error) {
+	if a.freeformTags == nil || a.timeout.HasExpired() {
+		ociMetadata, err := GetOCIMetadata(a.disableKeepAlive)
+		if err != nil {
+			return nil, err
+		}
+		a.freeformTags = ociMetadata.FreeformTags
+	}
+
+	return a.freeformTags, nil
+}
+
+// GetPrivateIP returns the cloud instance private IP of its primary VNIC.
+func (a *OCIHarvester) GetPrivateIP() (string, error) {
+	if a.privateIP == "" || a.timeout.HasExpired() {
+		vnics, err := GetOCIVnicsMetadata(a.disableKeepAlive)
+		if err != nil {
+			return "", err
+		}
+		if len(vnics) > 0 {
+			a.privateIP = vnics[0].PrivateIP
+		}
+	}
+
+	return a.privateIP, nil
+}
+
 // OCIMetadata captures the fields we care about from the OCI metadata API.
 type OCIMetadata struct {
-	Location       string `json:"canonicalRegionName"`
-	VMID           string `json:"id"`
-	VMSize         string `json:"shape"`
-	SubscriptionID string `json:"compartmentId"`
-	Zone           string `json:"availabilityDomain"`
-	ImageID        string `json:"image"`
-	DisplayName    string `json:"displayName"`
+	Location       string            `json:"canonicalRegionName"`
+	VMID           string            `json:"id"`
+	VMSize         string            `json:"shape"`
+	SubscriptionID string            `json:"compartmentId"`
+	Zone           string            `json:"availabilityDomain"`
+	ImageID        string            `json:"image"`
+	DisplayName    string            `json:"displayName"`
+	FaultDomain    string            `json:"faultDomain"`
+	Hostname       string            `json:"hostname"`
+	FreeformTags   map[string]string `json:"freeformTags"`
+}
+
+// OCIVnicMetadata captures the fields we care about from the OCI VNIC metadata API.
+type OCIVnicMetadata struct {
+	VnicID    string `json:"vnicId"`
+	PrivateIP string `json:"privateIp"`
 }
 
 // GetOCIMetadata is used to request metadata from OCI API.
@@ -232,6 +319,46 @@ func parseOCIMetadataResponse(response *http.Response) (*OCIMetadata, error) {
 	}
 
 	var result *OCIMetadata
+	if err = json.Unmarshal(responseBody, &result); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrOCIUnmarshalFailed, err) //nolint:wrapcheck
+	}
+
+	return result, nil
+}
+
+// GetOCIVnicsMetadata is used to request VNIC metadata from OCI API.
+func GetOCIVnicsMetadata(disableKeepAlive bool) ([]OCIVnicMetadata, error) {
+	var request *http.Request
+	var err error
+
+	if request, err = http.NewRequest(http.MethodGet, ociVnicsEndpoint, nil); err != nil { //nolint:noctx
+		return nil, fmt.Errorf("%w: %w", ErrOCIRequestFailed, err) //nolint:wrapcheck
+	}
+
+	request.Header.Add("Authorization", ociV2AuthorizationHeader)
+
+	var response *http.Response
+	if response, err = clientWithFastTimeout(disableKeepAlive).Do(request); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrOCIFetchFailed, err) //nolint:wrapcheck
+	}
+	defer response.Body.Close()
+
+	return parseOCIVnicsMetadataResponse(response)
+}
+
+// parseOCIVnicsMetadataResponse is used to parse the value required from OCI VNIC response.
+func parseOCIVnicsMetadataResponse(response *http.Response) ([]OCIVnicMetadata, error) {
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: %d %s", ErrOCIResponseFailed, response.StatusCode, response.Status) //nolint:wrapcheck
+	}
+
+	var responseBody []byte
+	var err error
+	if responseBody, err = io.ReadAll(response.Body); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrOCIReadFailed, err) //nolint:wrapcheck
+	}
+
+	var result []OCIVnicMetadata
 	if err = json.Unmarshal(responseBody, &result); err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrOCIUnmarshalFailed, err) //nolint:wrapcheck
 	}

--- a/pkg/sysinfo/cloud/cloud_oci_api.go
+++ b/pkg/sysinfo/cloud/cloud_oci_api.go
@@ -1,5 +1,7 @@
 // Copyright 2025 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+//
+//nolint:godoclint // package doc convention is inconsistent repo-wide; not fixing that here
 package cloud
 
 import (
@@ -27,18 +29,21 @@ func (a *OCIHarvester) initAPIClients() error {
 		provider, err := newInstancePrincipalProvider()
 		if err != nil {
 			a.apiInitErr = fmt.Errorf("%w: %w", ErrOCIAPIUnavailable, err)
+
 			return
 		}
 
 		computeClient, err := core.NewComputeClientWithConfigurationProvider(provider)
 		if err != nil {
 			a.apiInitErr = fmt.Errorf("%w: %w", ErrOCIAPIUnavailable, err)
+
 			return
 		}
 
 		vnClient, err := core.NewVirtualNetworkClientWithConfigurationProvider(provider)
 		if err != nil {
 			a.apiInitErr = fmt.Errorf("%w: %w", ErrOCIAPIUnavailable, err)
+
 			return
 		}
 
@@ -55,20 +60,21 @@ func (a *OCIHarvester) getInstanceDetails() (*core.Instance, error) {
 		return a.instanceDetails, nil
 	}
 
-	if err := a.initAPIClients(); err != nil {
-		return nil, err
+	initErr := a.initAPIClients()
+	if initErr != nil {
+		return nil, initErr
 	}
 
 	instanceID, err := a.GetInstanceID()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrOCIAPIUnavailable, err)
+		return nil, fmt.Errorf("%w: %w", ErrOCIAPIUnavailable, err) //nolint:wrapcheck
 	}
 
-	response, err := a.computeClient.GetInstance(context.Background(), core.GetInstanceRequest{
+	response, err := a.computeClient.GetInstance(context.Background(), core.GetInstanceRequest{ //nolint:exhaustruct
 		InstanceId: &instanceID,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrOCIAPIUnavailable, err)
+		return nil, fmt.Errorf("%w: %w", ErrOCIAPIUnavailable, err) //nolint:wrapcheck
 	}
 
 	a.instanceDetails = &response.Instance
@@ -82,23 +88,25 @@ func (a *OCIHarvester) getPrimaryVnic() (*core.Vnic, error) {
 		return a.vnic, nil
 	}
 
-	if err := a.initAPIClients(); err != nil {
-		return nil, err
+	initErr := a.initAPIClients()
+	if initErr != nil {
+		return nil, initErr
 	}
 
 	vnics, err := GetOCIVnicsMetadata(a.disableKeepAlive)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrOCIAPIUnavailable, err)
-	}
-	if len(vnics) == 0 {
-		return nil, fmt.Errorf("%w: no VNICs found in IMDS", ErrOCIAPIUnavailable)
+		return nil, fmt.Errorf("%w: %w", ErrOCIAPIUnavailable, err) //nolint:wrapcheck
 	}
 
-	response, err := a.vnClient.GetVnic(context.Background(), core.GetVnicRequest{
+	if len(vnics) == 0 {
+		return nil, fmt.Errorf("%w: no VNICs found in IMDS", ErrOCIAPIUnavailable) //nolint:wrapcheck
+	}
+
+	response, err := a.vnClient.GetVnic(context.Background(), core.GetVnicRequest{ //nolint:exhaustruct
 		VnicId: &vnics[0].VnicID,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrOCIAPIUnavailable, err)
+		return nil, fmt.Errorf("%w: %w", ErrOCIAPIUnavailable, err) //nolint:wrapcheck
 	}
 
 	a.vnic = &response.Vnic
@@ -116,15 +124,16 @@ func (a *OCIHarvester) getSubnet() (*core.Subnet, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if vnic.SubnetId == nil {
-		return nil, fmt.Errorf("%w: primary VNIC has no subnet ID", ErrOCIAPIUnavailable)
+		return nil, fmt.Errorf("%w: primary VNIC has no subnet ID", ErrOCIAPIUnavailable) //nolint:wrapcheck
 	}
 
-	response, err := a.vnClient.GetSubnet(context.Background(), core.GetSubnetRequest{
+	response, err := a.vnClient.GetSubnet(context.Background(), core.GetSubnetRequest{ //nolint:exhaustruct
 		SubnetId: vnic.SubnetId,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrOCIAPIUnavailable, err)
+		return nil, fmt.Errorf("%w: %w", ErrOCIAPIUnavailable, err) //nolint:wrapcheck
 	}
 
 	a.subnet = &response.Subnet
@@ -138,6 +147,7 @@ func (a *OCIHarvester) GetVCNID() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	if subnet.VcnId == nil {
 		return "", nil
 	}
@@ -151,6 +161,7 @@ func (a *OCIHarvester) GetSubnetID() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	if vnic.SubnetId == nil {
 		return "", nil
 	}
@@ -186,6 +197,7 @@ func (a *OCIHarvester) GetDedicatedVMHostID() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	if instance.DedicatedVmHostId == nil {
 		return "", nil
 	}

--- a/pkg/sysinfo/cloud/cloud_oci_api.go
+++ b/pkg/sysinfo/cloud/cloud_oci_api.go
@@ -1,0 +1,194 @@
+// Copyright 2025 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+package cloud
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/oracle/oci-go-sdk/v65/common/auth"
+	"github.com/oracle/oci-go-sdk/v65/core"
+)
+
+// ErrOCIAPIUnavailable indicates the OCI SDK API clients could not be initialized, typically
+// because instance principal authentication is unavailable (no IAM dynamic-group policy, or
+// running outside OCI). Phase 2 attributes are left empty when this occurs - it is never fatal.
+var ErrOCIAPIUnavailable = errors.New("OCI API unavailable")
+
+// newInstancePrincipalProvider builds the instance principal configuration provider. Var to
+// allow test overrides.
+var newInstancePrincipalProvider = auth.InstancePrincipalConfigurationProvider //nolint:gochecknoglobals
+
+// initAPIClients builds the OCI SDK Compute and VirtualNetwork clients via instance principal
+// authentication, once per harvester lifetime. Every Phase 2 getter calls this first.
+func (a *OCIHarvester) initAPIClients() error {
+	a.apiOnce.Do(func() {
+		provider, err := newInstancePrincipalProvider()
+		if err != nil {
+			a.apiInitErr = fmt.Errorf("%w: %w", ErrOCIAPIUnavailable, err)
+			return
+		}
+
+		computeClient, err := core.NewComputeClientWithConfigurationProvider(provider)
+		if err != nil {
+			a.apiInitErr = fmt.Errorf("%w: %w", ErrOCIAPIUnavailable, err)
+			return
+		}
+
+		vnClient, err := core.NewVirtualNetworkClientWithConfigurationProvider(provider)
+		if err != nil {
+			a.apiInitErr = fmt.Errorf("%w: %w", ErrOCIAPIUnavailable, err)
+			return
+		}
+
+		a.computeClient = &computeClient
+		a.vnClient = &vnClient
+	})
+
+	return a.apiInitErr
+}
+
+// getInstanceDetails fetches (and caches) the OCI Compute instance details via the SDK.
+func (a *OCIHarvester) getInstanceDetails() (*core.Instance, error) {
+	if a.instanceDetails != nil && !a.timeout.HasExpired() {
+		return a.instanceDetails, nil
+	}
+
+	if err := a.initAPIClients(); err != nil {
+		return nil, err
+	}
+
+	instanceID, err := a.GetInstanceID()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrOCIAPIUnavailable, err)
+	}
+
+	response, err := a.computeClient.GetInstance(context.Background(), core.GetInstanceRequest{
+		InstanceId: &instanceID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrOCIAPIUnavailable, err)
+	}
+
+	a.instanceDetails = &response.Instance
+
+	return a.instanceDetails, nil
+}
+
+// getPrimaryVnic fetches (and caches) the OCI VNIC details for the primary VNIC via the SDK.
+func (a *OCIHarvester) getPrimaryVnic() (*core.Vnic, error) {
+	if a.vnic != nil && !a.timeout.HasExpired() {
+		return a.vnic, nil
+	}
+
+	if err := a.initAPIClients(); err != nil {
+		return nil, err
+	}
+
+	vnics, err := GetOCIVnicsMetadata(a.disableKeepAlive)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrOCIAPIUnavailable, err)
+	}
+	if len(vnics) == 0 {
+		return nil, fmt.Errorf("%w: no VNICs found in IMDS", ErrOCIAPIUnavailable)
+	}
+
+	response, err := a.vnClient.GetVnic(context.Background(), core.GetVnicRequest{
+		VnicId: &vnics[0].VnicID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrOCIAPIUnavailable, err)
+	}
+
+	a.vnic = &response.Vnic
+
+	return a.vnic, nil
+}
+
+// getSubnet fetches (and caches) the OCI subnet details for the primary VNIC's subnet.
+func (a *OCIHarvester) getSubnet() (*core.Subnet, error) {
+	if a.subnet != nil && !a.timeout.HasExpired() {
+		return a.subnet, nil
+	}
+
+	vnic, err := a.getPrimaryVnic()
+	if err != nil {
+		return nil, err
+	}
+	if vnic.SubnetId == nil {
+		return nil, fmt.Errorf("%w: primary VNIC has no subnet ID", ErrOCIAPIUnavailable)
+	}
+
+	response, err := a.vnClient.GetSubnet(context.Background(), core.GetSubnetRequest{
+		SubnetId: vnic.SubnetId,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrOCIAPIUnavailable, err)
+	}
+
+	a.subnet = &response.Subnet
+
+	return a.subnet, nil
+}
+
+// GetVCNID returns the OCID of the VCN the instance's primary VNIC is in.
+func (a *OCIHarvester) GetVCNID() (string, error) {
+	subnet, err := a.getSubnet()
+	if err != nil {
+		return "", err
+	}
+	if subnet.VcnId == nil {
+		return "", nil
+	}
+
+	return *subnet.VcnId, nil
+}
+
+// GetSubnetID returns the OCID of the subnet the instance's primary VNIC is in.
+func (a *OCIHarvester) GetSubnetID() (string, error) {
+	vnic, err := a.getPrimaryVnic()
+	if err != nil {
+		return "", err
+	}
+	if vnic.SubnetId == nil {
+		return "", nil
+	}
+
+	return *vnic.SubnetId, nil
+}
+
+// GetLifecycleState returns the instance's current lifecycle state (e.g. RUNNING, STOPPED).
+func (a *OCIHarvester) GetLifecycleState() (string, error) {
+	instance, err := a.getInstanceDetails()
+	if err != nil {
+		return "", err
+	}
+
+	return string(instance.LifecycleState), nil
+}
+
+// GetVirtualizationType returns the instance's launch mode (NATIVE, EMULATED, PARAVIRTUALIZED,
+// ACCELERATEDPV, or CUSTOM) - the closest OCI equivalent to AWS's virtualization type.
+func (a *OCIHarvester) GetVirtualizationType() (string, error) {
+	instance, err := a.getInstanceDetails()
+	if err != nil {
+		return "", err
+	}
+
+	return string(instance.LaunchMode), nil
+}
+
+// GetDedicatedVMHostID returns the OCID of the dedicated VM host the instance runs on, or an
+// empty string if the instance is not on a dedicated host.
+func (a *OCIHarvester) GetDedicatedVMHostID() (string, error) {
+	instance, err := a.getInstanceDetails()
+	if err != nil {
+		return "", err
+	}
+	if instance.DedicatedVmHostId == nil {
+		return "", nil
+	}
+
+	return *instance.DedicatedVmHostId, nil
+}

--- a/pkg/sysinfo/cloud/cloud_oci_api.go
+++ b/pkg/sysinfo/cloud/cloud_oci_api.go
@@ -70,7 +70,10 @@ func (a *OCIHarvester) getInstanceDetails() (*core.Instance, error) {
 		return nil, fmt.Errorf("%w: %w", ErrOCIAPIUnavailable, err) //nolint:wrapcheck
 	}
 
-	response, err := a.computeClient.GetInstance(context.Background(), core.GetInstanceRequest{ //nolint:exhaustruct
+	ctx, cancel := context.WithTimeout(context.Background(), defaultClientTimeout)
+	defer cancel()
+
+	response, err := a.computeClient.GetInstance(ctx, core.GetInstanceRequest{ //nolint:exhaustruct
 		InstanceId: &instanceID,
 	})
 	if err != nil {
@@ -102,7 +105,10 @@ func (a *OCIHarvester) getPrimaryVnic() (*core.Vnic, error) {
 		return nil, fmt.Errorf("%w: no VNICs found in IMDS", ErrOCIAPIUnavailable) //nolint:wrapcheck
 	}
 
-	response, err := a.vnClient.GetVnic(context.Background(), core.GetVnicRequest{ //nolint:exhaustruct
+	ctx, cancel := context.WithTimeout(context.Background(), defaultClientTimeout)
+	defer cancel()
+
+	response, err := a.vnClient.GetVnic(ctx, core.GetVnicRequest{ //nolint:exhaustruct
 		VnicId: &vnics[0].VnicID,
 	})
 	if err != nil {
@@ -129,7 +135,10 @@ func (a *OCIHarvester) getSubnet() (*core.Subnet, error) {
 		return nil, fmt.Errorf("%w: primary VNIC has no subnet ID", ErrOCIAPIUnavailable) //nolint:wrapcheck
 	}
 
-	response, err := a.vnClient.GetSubnet(context.Background(), core.GetSubnetRequest{ //nolint:exhaustruct
+	ctx, cancel := context.WithTimeout(context.Background(), defaultClientTimeout)
+	defer cancel()
+
+	response, err := a.vnClient.GetSubnet(ctx, core.GetSubnetRequest{ //nolint:exhaustruct
 		SubnetId: vnic.SubnetId,
 	})
 	if err != nil {

--- a/pkg/sysinfo/cloud/cloud_oci_api_test.go
+++ b/pkg/sysinfo/cloud/cloud_oci_api_test.go
@@ -1,0 +1,175 @@
+// Copyright 2025 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+//nolint:godoclint // package doc convention is inconsistent repo-wide; not fixing that here
+package cloud
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// errInstancePrincipalUnavailable stands in for the real OCI SDK/network error that occurs
+// when instance principal metadata isn't reachable (e.g. running outside OCI).
+var errInstancePrincipalUnavailable = errors.New("instance principal metadata not available")
+
+// testRSAKeyOnce is a throwaway key generated once, used only to let the SDK's request signer
+// construct successfully in tests - it's never used to sign anything sent over the network.
+var testRSAKeyOnce = sync.OnceValue(func() *rsa.PrivateKey { //nolint:gochecknoglobals
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+
+	return key
+})
+
+// fakeConfigurationProvider is a minimal common.ConfigurationProvider that lets us get past
+// SDK client construction in initAPIClients without a real instance principal cert exchange.
+type fakeConfigurationProvider struct{}
+
+func (fakeConfigurationProvider) PrivateRSAKey() (*rsa.PrivateKey, error) {
+	return testRSAKeyOnce(), nil
+}
+
+func (fakeConfigurationProvider) KeyID() (string, error) {
+	return "fake-key-id", nil
+}
+
+func (fakeConfigurationProvider) TenancyOCID() (string, error) {
+	return "ocid1.tenancy.oc1..fake", nil
+}
+
+func (fakeConfigurationProvider) UserOCID() (string, error) {
+	return "", nil
+}
+
+func (fakeConfigurationProvider) KeyFingerprint() (string, error) {
+	return "", nil
+}
+
+func (fakeConfigurationProvider) Region() (string, error) {
+	return "us-ashburn-1", nil
+}
+
+func (fakeConfigurationProvider) AuthType() (common.AuthConfig, error) {
+	return common.AuthConfig{AuthType: common.InstancePrincipal, IsFromConfigFile: false, OboToken: nil}, nil
+}
+
+// newHarvesterWithFailingAuth returns an OCIHarvester whose instance principal auth always
+// fails, exercising the Phase 2 graceful-degradation path without any network calls.
+func newHarvesterWithFailingAuth(t *testing.T) (*OCIHarvester, *int) {
+	t.Helper()
+
+	callCount := 0
+
+	orig := newInstancePrincipalProvider
+	newInstancePrincipalProvider = func() (common.ConfigurationProvider, error) {
+		callCount++
+
+		return nil, errInstancePrincipalUnavailable //nolint:wrapcheck
+	}
+
+	t.Cleanup(func() { newInstancePrincipalProvider = orig })
+
+	return &OCIHarvester{ //nolint:exhaustruct
+		timeout: NewTimeout(ociTimeout),
+	}, &callCount
+}
+
+// TestInitAPIClients_ProviderError - no t.Parallel(): overrides the shared package-level
+// newInstancePrincipalProvider var, which is unsafe to mutate concurrently with other tests in
+// this file (a previous attempt at parallelizing let a real, hanging IMDS call slip through).
+func TestInitAPIClients_ProviderError(t *testing.T) { //nolint:paralleltest
+	harvester, callCount := newHarvesterWithFailingAuth(t)
+
+	err := harvester.initAPIClients()
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrOCIAPIUnavailable)
+	assert.Equal(t, 1, *callCount)
+
+	// A second call must not re-invoke the provider - sync.Once caches the failure.
+	err2 := harvester.initAPIClients()
+	require.Error(t, err2)
+	assert.Equal(t, 1, *callCount)
+	assert.Equal(t, err, err2)
+}
+
+// TestInitAPIClients_Success - no t.Parallel(), see TestInitAPIClients_ProviderError.
+func TestInitAPIClients_Success(t *testing.T) { //nolint:paralleltest
+	orig := newInstancePrincipalProvider
+	newInstancePrincipalProvider = func() (common.ConfigurationProvider, error) {
+		return fakeConfigurationProvider{}, nil
+	}
+
+	t.Cleanup(func() { newInstancePrincipalProvider = orig })
+
+	harvester := &OCIHarvester{timeout: NewTimeout(ociTimeout)} //nolint:exhaustruct
+
+	err := harvester.initAPIClients()
+	require.NoError(t, err)
+	assert.NotNil(t, harvester.computeClient)
+	assert.NotNil(t, harvester.vnClient)
+}
+
+// TestPhase2Getters_AuthUnavailable - no t.Parallel(), see TestInitAPIClients_ProviderError.
+func TestPhase2Getters_AuthUnavailable(t *testing.T) { //nolint:paralleltest
+	cases := []struct {
+		name string
+		call func(*OCIHarvester) (string, error)
+	}{
+		{"GetVCNID", (*OCIHarvester).GetVCNID},
+		{"GetSubnetID", (*OCIHarvester).GetSubnetID},
+		{"GetLifecycleState", (*OCIHarvester).GetLifecycleState},
+		{"GetVirtualizationType", (*OCIHarvester).GetVirtualizationType},
+		{"GetDedicatedVMHostID", (*OCIHarvester).GetDedicatedVMHostID},
+	}
+
+	for _, tc := range cases { //nolint:paralleltest
+		t.Run(tc.name, func(t *testing.T) {
+			harvester, _ := newHarvesterWithFailingAuth(t)
+
+			value, err := tc.call(harvester)
+			require.Error(t, err)
+			require.ErrorIs(t, err, ErrOCIAPIUnavailable)
+			assert.Empty(t, value)
+		})
+	}
+}
+
+// TestGetPrimaryVnic_NoVnicsFound - no t.Parallel(), see TestInitAPIClients_ProviderError.
+func TestGetPrimaryVnic_NoVnicsFound(t *testing.T) { //nolint:paralleltest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	origEndpoint := ociVnicsEndpoint
+	ociVnicsEndpoint = server.URL + "/"
+
+	t.Cleanup(func() { ociVnicsEndpoint = origEndpoint })
+
+	origProvider := newInstancePrincipalProvider
+	newInstancePrincipalProvider = func() (common.ConfigurationProvider, error) {
+		return fakeConfigurationProvider{}, nil
+	}
+
+	t.Cleanup(func() { newInstancePrincipalProvider = origProvider })
+
+	harvester := &OCIHarvester{timeout: NewTimeout(ociTimeout)} //nolint:exhaustruct
+
+	_, err := harvester.getPrimaryVnic()
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrOCIAPIUnavailable)
+	assert.Contains(t, err.Error(), "no VNICs found in IMDS")
+}

--- a/pkg/sysinfo/cloud/cloud_oci_test.go
+++ b/pkg/sysinfo/cloud/cloud_oci_test.go
@@ -28,8 +28,12 @@ func TestParseOCIMetadataResponse(t *testing.T) {
 			}
 		},
 		"displayName": "ubuntu-instance-20250722-1328",
-		"faultDomain": "hidden",
-		"hostname": "hidden",
+		"faultDomain": "FAULT-DOMAIN-1",
+		"freeformTags": {
+			"env": "prod",
+			"team": "infra"
+		},
+		"hostname": "ubuntu-instance-20250722-1328",
 		"id": "ocid1.instance.oc1",
 		"image": "ocid1.image.oc1",
 		"metadata": {
@@ -68,6 +72,9 @@ func TestParseOCIMetadataResponse(t *testing.T) {
 	require.Equal(t, "jyDh:US-ASHBURN-AD-1", metadata.Zone)
 	require.Equal(t, "ocid1.image.oc1", metadata.ImageID)
 	require.Equal(t, "ubuntu-instance-20250722-1328", metadata.DisplayName)
+	require.Equal(t, "FAULT-DOMAIN-1", metadata.FaultDomain)
+	require.Equal(t, "ubuntu-instance-20250722-1328", metadata.Hostname)
+	require.Equal(t, map[string]string{"env": "prod", "team": "infra"}, metadata.FreeformTags)
 }
 
 func TestGetOCIMetadataSendsV2AuthorizationHeader(t *testing.T) {
@@ -94,4 +101,41 @@ func TestGetOCIMetadataSendsV2AuthorizationHeader(t *testing.T) {
 	_, err := GetOCIMetadata(false)
 	require.NoError(t, err)
 	require.Equal(t, ociV2AuthorizationHeader, receivedAuth)
+}
+
+// output generated with: curl -s -H "Authorization: Bearer Oracle" http://169.254.169.254/opc/v2/vnics/
+func TestGetOCIVnicsMetadata(t *testing.T) {
+	t.Parallel()
+
+	var receivedAuth string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { //nolint:varnamelen
+		receivedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+
+		responseJSON := `[{
+			"vnicId": "ocid1.vnic.oc1.phx.abc",
+			"privateIp": "10.0.0.5",
+			"vlanTag": 0,
+			"macAddr": "00:00:17:02:2D:41",
+			"virtualRouterIp": "10.0.0.1",
+			"subnetCidrBlock": "10.0.0.0/24",
+			"nicIndex": 0
+		}]`
+		_, _ = w.Write([]byte(responseJSON))
+	}))
+
+	defer server.Close()
+
+	origEndpoint := ociVnicsEndpoint
+	ociVnicsEndpoint = server.URL + "/"
+
+	defer func() { ociVnicsEndpoint = origEndpoint }()
+
+	vnics, err := GetOCIVnicsMetadata(false)
+	require.NoError(t, err)
+	require.Equal(t, ociV2AuthorizationHeader, receivedAuth)
+	require.Len(t, vnics, 1)
+	require.Equal(t, "ocid1.vnic.oc1.phx.abc", vnics[0].VnicID)
+	require.Equal(t, "10.0.0.5", vnics[0].PrivateIP)
 }

--- a/pkg/sysinfo/cloud/cloud_test.go
+++ b/pkg/sysinfo/cloud/cloud_test.go
@@ -303,6 +303,51 @@ func (m *MockHarvester) GetVMSize() (string, error) {
 	return "mock-vm-size", nil
 }
 
+// GetFaultDomain returns the cloud instance fault domain (mock implementation).
+func (m *MockHarvester) GetFaultDomain() (string, error) {
+	return "mock-fault-domain", nil
+}
+
+// GetHostname returns the cloud instance hostname (mock implementation).
+func (m *MockHarvester) GetHostname() (string, error) {
+	return "mock-hostname", nil
+}
+
+// GetFreeformTags returns the cloud instance freeform tags (mock implementation).
+func (m *MockHarvester) GetFreeformTags() (map[string]string, error) {
+	return nil, nil
+}
+
+// GetPrivateIP returns the cloud instance private IP (mock implementation).
+func (m *MockHarvester) GetPrivateIP() (string, error) {
+	return "mock-private-ip", nil
+}
+
+// GetVCNID returns the cloud instance's VCN ID (mock implementation).
+func (m *MockHarvester) GetVCNID() (string, error) {
+	return "mock-vcn-id", nil
+}
+
+// GetSubnetID returns the cloud instance's subnet ID (mock implementation).
+func (m *MockHarvester) GetSubnetID() (string, error) {
+	return "mock-subnet-id", nil
+}
+
+// GetLifecycleState returns the cloud instance's lifecycle state (mock implementation).
+func (m *MockHarvester) GetLifecycleState() (string, error) {
+	return "mock-lifecycle-state", nil
+}
+
+// GetVirtualizationType returns the cloud instance's virtualization type (mock implementation).
+func (m *MockHarvester) GetVirtualizationType() (string, error) {
+	return "mock-virtualization-type", nil
+}
+
+// GetDedicatedVMHostID returns the cloud instance's dedicated VM host ID (mock implementation).
+func (m *MockHarvester) GetDedicatedVMHostID() (string, error) {
+	return "mock-dedicated-vm-host-id", nil
+}
+
 // GetHarvester returns the MockHarvester
 func (m *MockHarvester) GetHarvester() (Harvester, error) {
 	return m, nil

--- a/pkg/sysinfo/cloud/cloud_test.go
+++ b/pkg/sysinfo/cloud/cloud_test.go
@@ -315,7 +315,7 @@ func (m *MockHarvester) GetHostname() (string, error) {
 
 // GetFreeformTags returns the cloud instance freeform tags (mock implementation).
 func (m *MockHarvester) GetFreeformTags() (map[string]string, error) {
-	return nil, nil
+	return map[string]string{}, nil
 }
 
 // GetPrivateIP returns the cloud instance private IP (mock implementation).

--- a/test/harvest/hostinfo_darwin_test.go
+++ b/test/harvest/hostinfo_darwin_test.go
@@ -36,7 +36,7 @@ func TestHostInfoDarwin(t *testing.T) {
 	a.Context.SetAgentIdentity(entity.Identity{10, "abcdef"})
 
 	cloudDetector := cloud.NewDetector(true, 0, 0, 0, false)
-	a.RegisterPlugin(darwin.NewHostinfoPlugin(a.Context, common.NewHostInfoCommon("test", true, cloudDetector)))
+	a.RegisterPlugin(darwin.NewHostinfoPlugin(a.Context, common.NewHostInfoCommon("test", true, nil, cloudDetector)))
 	go a.Run()
 
 	var req http.Request

--- a/test/harvest/hostinfo_linux_test.go
+++ b/test/harvest/hostinfo_linux_test.go
@@ -34,7 +34,7 @@ func TestHostInfoLinux(t *testing.T) {
 
 	cloudDetector := cloud.NewDetector(true, 0, 0, 0, false)
 	a.RegisterPlugin(pluginsLinux.NewHostinfoPlugin(a.Context,
-		common.NewHostInfoCommon(a.Context.Version(), !a.Context.Config().DisableCloudMetadata, cloudDetector)))
+		common.NewHostInfoCommon(a.Context.Version(), !a.Context.Config().DisableCloudMetadata, nil, cloudDetector)))
 	go a.Run()
 
 	var req http.Request

--- a/test/harvest/hostinfo_test.go
+++ b/test/harvest/hostinfo_test.go
@@ -111,7 +111,7 @@ func TestHostInfo(t *testing.T) {
 	os.Setenv("HOST_PROC", procDir.Path)
 
 	cloudDetector := cloud.NewDetector(true, 0, 0, 0, false)
-	hostInfoPlugin := pluginsLinux.NewHostinfoPlugin(ctx, common.NewHostInfoCommon(ctx.Version(), !ctx.Config().DisableCloudMetadata, cloudDetector))
+	hostInfoPlugin := pluginsLinux.NewHostinfoPlugin(ctx, common.NewHostInfoCommon(ctx.Version(), !ctx.Config().DisableCloudMetadata, nil, cloudDetector))
 	hostInfoPlugin.Run()
 	ctx.AssertExpectations(t)
 


### PR DESCRIPTION
## Summary

Implements OCI tag support to match AWS tags in New Relic Infrastructure, per the CDD
["OCI Tag Support to Match AWS Tags in New Relic Infrastructure"](https://newrelic.atlassian.net/wiki/spaces/INST/pages/5846532426)
(related [DACI](https://newrelic.atlassian.net/wiki/spaces/INST/pages/5839323418) /
[SPIKE](https://newrelic.atlassian.net/wiki/spaces/INST/pages/5838569517)).

- **Phase 1** (IMDS + static values, no new dependencies): `cloud.resource_id`,
  `oci.compute.instanceId`, `oci.compute.faultDomain`, `oci.network.privateIp`,
  `oci.network.privateDnsName`, `host.arch`, `cloud.provider`, `cloud.platform`. Freeform
  tags collected from IMDS, filtered via a new `oci_tags_exclude` config option, flattened
  into `label.*` inventory attributes.
- **Phase 2** (OCI SDK + instance principal auth, `github.com/oracle/oci-go-sdk/v65`):
  `oci.network.vcnId`, `oci.network.subnetId`, `oci.compute.lifecycleState`,
  `oci.compute.virtualizationType`, `oci.compute.dedicatedVmHostId`. Best-effort only —
  failures (e.g. missing IAM policy) are logged and leave the attribute empty, never block
  agent startup.
- Extends `cloud.Harvester` with the new getters (stubbed `ErrMethodNotImplemented` on
  AWS/Azure/GCP/Alibaba, matching the existing pattern for `GetInstanceDisplayName`/`GetVMSize`).
- Adds `MarshalJSON` on the platform-specific `HostInfo{Linux,Darwin,Windows}` structs (not on
  any embedded type, to avoid Go's method-promotion silently overriding marshaling of the
  parent struct) to flatten freeform tags into `label.*` attributes.
- `oci.compute.tenancyId` is intentionally excluded per the DACI, despite being available
  for free in the same IMDS payload — a deliberate call, not an oversight.

## Known follow-up

`vendor/` is intentionally not synced in this PR. `go.mod`/`go.sum` were updated by
`go build -mod=mod` with real checksums, but `vendor/modules.txt` needs `go mod vendor` run
from an environment with network + tooling access before this can build in the repo's
default vendor mode. (Note: this repo's `vendor/` is already out of sync with `go.mod` on a
clean `master`, independent of this change.)

## Test plan

- [x] `go build -mod=mod ./...` and `go test -mod=mod -race` pass on all affected packages
- [x] `gofmt`, `go vet`, `make checklicense` clean
- [x] Verified end-to-end against a real OCI compute instance (`newrelic-infra` agent, not
      just a probe binary): confirmed via the on-disk delta payload and NR entity inspector
      that all 14 Phase 1 attributes populate correctly
- [x] Verified Phase 2 graceful degradation (missing IAM policy → `404 NotAuthorizedOrNotFound`,
      logged, fields left empty, agent keeps running) and, after adding the required dynamic-group
      policy, verified 4/5 Phase 2 attributes populate correctly (the 5th,
      `dedicatedVmHostId`, is correctly empty since the test instance isn't on a Dedicated VM Host)
- [ ] `vendor/` sync (`go mod vendor`) — needs to happen before merge, see Known follow-up above

