### PR TITLE
ci: enable NRIA_DISABLE_PLUGIN_DEFAULT_DIR_SCAN by default for ac managed agent

### DIFF
--- a/.fleetControl/agentControl/linux.yml
+++ b/.fleetControl/agentControl/linux.yml
@@ -104,6 +104,9 @@ deployment:
           NRIA_AGENT_TEMP_DIR: "${nr-sub:filesystem_agent_dir}/newrelic-infra/tmp"
           NRIA_CUSTOM_PLUGIN_INSTALLATION_DIR: "${nr-sub:packages.infra-agent.dir}/integrations"
           NRIA_SAFE_BIN_DIR: "${nr-sub:packages.infra-agent.dir}/integrations"
+          # Only loads integrations from the explicitly configured locations (custom_plugin_installation_dir and
+          # plugin_dir), ignoring the default/standalone dirs so stale integrations are not loaded.
+          NRIA_DISABLE_PLUGIN_DEFAULT_DIR_SCAN: true
           # Config folders where integrations and logging configs parsed from local/remote values are stored and looked for.
           NRIA_PLUGIN_DIR: "${nr-sub:filesystem_agent_dir}/integrations.d"
           NRIA_LOGGING_CONFIGS_DIR: "${nr-sub:filesystem_agent_dir}/logging.d"

--- a/.fleetControl/agentControl/windows.yml
+++ b/.fleetControl/agentControl/windows.yml
@@ -107,6 +107,9 @@ deployment:
           NRIA_LOG_ROTATE_MAX_FILES: "5"
           NRIA_CUSTOM_PLUGIN_INSTALLATION_DIR: "${nr-sub:packages.infra-agent.dir}\\integrations"
           NRIA_SAFE_BIN_DIR: "${nr-sub:packages.infra-agent.dir}\\integrations"
+          # Only loads integrations from the explicitly configured locations (custom_plugin_installation_dir and
+          # plugin_dir), ignoring the default/standalone dirs so stale integrations are not loaded.
+          NRIA_DISABLE_PLUGIN_DEFAULT_DIR_SCAN: true
           # Config folders where integrations and logging configs parsed from local/remote values are stored and looked for.
           NRIA_PLUGIN_DIR: "${nr-sub:filesystem_agent_dir}\\integrations.d"
           NRIA_LOGGING_CONFIGS_DIR: "${nr-sub:filesystem_agent_dir}\\logging.d"


### PR DESCRIPTION
### Why

We need to enable the flag `NRIA_DISABLE_PLUGIN_DEFAULT_DIR_SCAN` so that stale integration configs in the default path are not scanned by the infra-agent when it is managed by Agent Control