### PR TITLE
chore: bump embedded OHI versions to fix CVEs (nri-docker, nri-flex, …

### DIFF
--- a/build/embed/integrations.version
+++ b/build/embed/integrations.version
@@ -1,5 +1,5 @@
 #ohi-repo-name,version
-nri-docker,v2.8.1
-nri-flex,v1.18.8
+nri-docker,v2.8.2
+nri-flex,v1.18.10
 nri-winservices,v1.5.3
-nri-prometheus,v2.29.4
+nri-prometheus,v2.30.2


### PR DESCRIPTION
Updated the following dependencies:

nri-docker v2.8.1 -> v2.8.2: fixes CVE-2026-46600 (golang.org/x/net)
nri-flex v1.18.8 -> v1.18.10: fixes CVE-2026-56852 (golang.org/x/text) and CVE-2026-46600 (x/net)
nri-prometheus v2.29.4 -> v2.30.2: fixes CVE-2026-56852 (x/text) and CVE-2026-46600 (x/net)


