### PR TITLE
ci: restore missing job permissions for release/canary workflows

### DIFF
--- a/.github/workflows/create_a2Q_canaries.yml
+++ b/.github/workflows/create_a2Q_canaries.yml
@@ -25,6 +25,9 @@ permissions:
 jobs:
   A2Q-canaries-windows:
     if: ${{ github.event.inputs.windows == 'true' }}
+    permissions:
+      contents: read
+      id-token: write # calls component_canaries.yml which needs AWS OIDC auth
     uses: ./.github/workflows/component_canaries.yml
     with:
       PLATFORM: "windows"
@@ -34,6 +37,9 @@ jobs:
       AWS_VPC_SUBNET: ${{secrets.AWS_VPC_SUBNET}}
   A2Q-canaries-linux:
     if: ${{ github.event.inputs.linux == 'true' }}
+    permissions:
+      contents: read
+      id-token: write # calls component_canaries.yml which needs AWS OIDC auth
     uses: ./.github/workflows/component_canaries.yml
     with:
       PLATFORM: "linux"

--- a/.github/workflows/prerelease_linux.yml
+++ b/.github/workflows/prerelease_linux.yml
@@ -135,6 +135,9 @@ jobs:
 
   docker-trivy-critical:
     needs: [packaging-docker]
+    permissions:
+      contents: read
+      security-events: write # calls component_trivy.yml which uploads SARIF results
     uses: ./.github/workflows/component_trivy.yml
     with:
       tag: "${{ github.event.release.tag_name }}-rc"
@@ -156,6 +159,9 @@ jobs:
 
   docker-fips-trivy-critical:
     needs: [packaging-docker-fips]
+    permissions:
+      contents: read
+      security-events: write # calls component_trivy.yml which uploads SARIF results
     uses: ./.github/workflows/component_trivy.yml
     with:
       tag: "${{ github.event.release.tag_name }}-rc"
@@ -194,6 +200,9 @@ jobs:
 
   test-prerelease-linux:
     needs: [molecule-packaging-tests]
+    permissions:
+      contents: read
+      id-token: write # calls component_prerelease_testing.yml which needs AWS OIDC auth
     uses: ./.github/workflows/component_prerelease_testing.yml
     with:
       PLATFORM: "linux"
@@ -204,6 +213,9 @@ jobs:
       
   canaries-linux:
     needs: [test-prerelease-linux]
+    permissions:
+      contents: read
+      id-token: write # calls component_canaries.yml which needs AWS OIDC auth
     uses: ./.github/workflows/component_canaries.yml
     with:
       PLATFORM: "linux"
@@ -225,6 +237,9 @@ jobs:
 
   prune-previous-canaries-linux:
     needs: [canaries-linux, get_previous_tag]
+    permissions:
+      contents: read
+      id-token: write # calls component_canaries_prune.yml which needs AWS OIDC auth
     uses: ./.github/workflows/component_canaries_prune.yml
     with:
       PLATFORM: "linux"

--- a/.github/workflows/prerelease_macos.yml
+++ b/.github/workflows/prerelease_macos.yml
@@ -16,6 +16,9 @@ jobs:
     uses: ./.github/workflows/component_macos_unit_test.yml
 
   canaries-macos:
+    permissions:
+      contents: read
+      id-token: write # calls component_canaries.yml which needs AWS OIDC auth
     uses: ./.github/workflows/component_canaries.yml
     with:
       PLATFORM: "macos"

--- a/.github/workflows/prerelease_windows.yml
+++ b/.github/workflows/prerelease_windows.yml
@@ -132,6 +132,9 @@ jobs:
 
   test-prerelease-windows:
     needs: [publishing-to-s3]
+    permissions:
+      contents: read
+      id-token: write # calls component_prerelease_testing.yml which needs AWS OIDC auth
     uses: ./.github/workflows/component_prerelease_testing.yml
     with:
       PLATFORM: "windows"
@@ -142,6 +145,9 @@ jobs:
 
   canaries-windows:
     needs: [test-prerelease-windows]
+    permissions:
+      contents: read
+      id-token: write # calls component_canaries.yml which needs AWS OIDC auth
     uses: ./.github/workflows/component_canaries.yml
     with:
       PLATFORM: "windows"
@@ -161,6 +167,9 @@ jobs:
 
   prune-canaries-windows:
     needs: [canaries-windows, get_previous_tag]
+    permissions:
+      contents: read
+      id-token: write # calls component_canaries_prune.yml which needs AWS OIDC auth
     uses: ./.github/workflows/component_canaries_prune.yml
     with:
       PLATFORM: "windows"


### PR DESCRIPTION
PR #2232 (least-privilege permissions) added explicit top-level 'permissions: contents: read' to prerelease_linux.yml, prerelease_windows.yml, and prerelease_macos.yml. Once a workflow declares any permissions block, every unlisted scope becomes 'none' instead of inheriting the org/repo default -- but several jobs in these files call reusable workflows that need more than contents:read:

- component_prerelease_testing.yml, component_canaries.yml, and component_canaries_prune.yml need id-token:write (AWS OIDC auth via aws-actions/configure-aws-credentials).
- component_trivy.yml needs security-events:write (SARIF upload), even though that specific job only runs on a schedule trigger and never executes on the release path -- GitHub validates the reusable workflow's declared permissions block statically, not by trigger reachability.

No release/prerelease had been attempted since #2232 merged until the 1.79.0 tag today, so this went unnoticed: all three prerelease pipelines failed immediately with conclusion=startup_failure (0 jobs created) the moment they were triggered.

Fixes 8 job call-sites across the 3 release-triggered pipelines (prerelease_linux.yml, prerelease_windows.yml, prerelease_macos.yml), mirroring the job-level permissions-escalation pattern already used correctly elsewhere in #2232 for the packaging/upload jobs. Also fixes the same latent bug in create_a2Q_canaries.yml (a manual workflow_dispatch tool, not release-blocking, but broken the same way).

Audited every reusable workflow called by all three pipelines against what its steps actually need (AWS OIDC, SARIF upload, Docker Hub push, static-key S3 publish, etc.) and cross-checked against the last known-good release (1.78.1) job list -- no other job is missing a required permission.

Screenshots of the issues we were getting for prerelease job for macos, windows and linux. They didn't even start and none of the jobs got executed due to startup failure

<img width="1723" height="945" alt="image" src="https://github.com/user-attachments/assets/86cb8cb4-035a-43e2-ab0b-9b88435ae6f2" />
<img width="1722" height="950" alt="image" src="https://github.com/user-attachments/assets/9c8efa9b-312d-498e-a43e-899922120b60" />
