### PR TITLE
security: local unprivileged user able to execute arbitrary commands as root via reuse of a predictable Fluent Bit config directory

### DIFF
--- a/cmd/newrelic-infra/initialize/initialize_linux.go
+++ b/cmd/newrelic-infra/initialize/initialize_linux.go
@@ -8,13 +8,9 @@ package initialize
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
-	"os/user"
 	"path"
-	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/newrelic/infrastructure-agent/pkg/config"
 	"github.com/newrelic/infrastructure-agent/pkg/disk"
@@ -75,7 +71,7 @@ func verifySingularity(pidfile string) error {
 		}
 	}
 
-	pidBytes, err := ioutil.ReadFile(pidfile)
+	pidBytes, err := os.ReadFile(pidfile)
 	if err != nil {
 		// If the file does not exist, this is fine.
 		if pErr, ok := err.(*os.PathError); !ok || !os.IsNotExist(pErr.Err) {
@@ -98,48 +94,11 @@ func verifySingularity(pidfile string) error {
 }
 
 func assertTempFolderOwnership(config *config.Config) error {
-	// Folder already exists. Check ownership.
-	if fi, err := os.Stat(config.DefaultIntegrationsTempDir); !os.IsNotExist(err) {
-		var currentUserUID string
-		currentUser, err := user.Current()
-		if err != nil {
-			log.WithError(err).Warn("Failed to get current user. Assuming 'root (0)'.")
-			currentUserUID = "0"
-		} else {
-			currentUserUID = currentUser.Uid
-		}
-		UID, _ := strconv.Atoi(currentUserUID)
-
-		// Get UID and GID of a file. Solution inspired by https://stackoverflow.com/q/58179647
-		var folderUID int
-		if stat, ok := fi.Sys().(*syscall.Stat_t); ok {
-			folderUID = int(stat.Uid)
-		}
-
-		logEntry := log.WithField("user_id", UID).
-			WithField("folder_uid", folderUID).
-			WithField("folder", config.DefaultIntegrationsTempDir)
-
-		if folderUID == UID {
-			logEntry.
-				WithField("folder", config.DefaultIntegrationsTempDir).
-				Debug("Temp folder belongs to user running the agent. Continuing.")
-			return nil
-		}
-
-		logEntry.Warn("Temp folder belongs to a different user. Trying to recreate folder for security purposes...")
-		err = os.RemoveAll(config.DefaultIntegrationsTempDir)
-		if err != nil {
-			errLog := log.WithField("folder", config.DefaultIntegrationsTempDir).
-				WithError(err)
-			errLog.Warn("Failed to remove temp folder. Cannot continue until the folder is removed.")
-
-			return err
-		}
-	}
-
-	// If we got here, either the folder does not exist or we removed it, so let's create it.
-	err := os.MkdirAll(config.DefaultIntegrationsTempDir, integrationsDirPermissions)
+	// disk.MkdirAll refuses to reuse a pre-existing path that isn't a real directory
+	// owned by the user running the agent and free of group/other write access: if the
+	// temp folder doesn't meet that bar (e.g. planted by another local user, or a
+	// symlink), it is wiped and recreated fresh for security purposes.
+	err := disk.MkdirAll(config.DefaultIntegrationsTempDir, integrationsDirPermissions)
 	if err != nil {
 		log.WithField("folder", config.DefaultIntegrationsTempDir).
 			WithError(err).

--- a/pkg/disk/disk_unix.go
+++ b/pkg/disk/disk_unix.go
@@ -7,12 +7,14 @@
 package disk
 
 import (
-	"io/ioutil"
+	"errors"
+	"fmt"
 	"os"
+	"syscall"
 )
 
 // WriteFile is a façade to ioutil.WriteFile, which enforces safe disk access when the host configuration requires it
-var WriteFile = ioutil.WriteFile
+var WriteFile = os.WriteFile //nolint:gochecknoglobals
 
 // OpenFile is a façade to os.OpenFile, which enforces safe disk access when the host configuration requires it
 var OpenFile = os.OpenFile
@@ -20,5 +22,66 @@ var OpenFile = os.OpenFile
 // Create is a façade to os.Create, which enforces safe disk access when the host configuration requires it
 var Create = os.Create
 
-// MkdirAll is a façade to os.MkdirAll, which enforces safe disk access when the host configuration requires it
-var MkdirAll = os.MkdirAll
+// ErrUnsafeDirAfterCreate is returned by MkdirAll when the target path is not safe to use
+// right after being (re)created, most likely because another local user won the narrow
+// remove-then-create race window.
+var ErrUnsafeDirAfterCreate = errors.New("path is not safe to use after creation, possibly due to a race")
+
+// MkdirAll creates a directory path along with any necessary parents, like os.MkdirAll.
+// Unlike os.MkdirAll, it never blindly reuses a pre-existing path: if path already exists
+// but is not a real directory owned by the current user, or is writable by group/other, it
+// is removed and recreated fresh. This prevents a local attacker from planting (or
+// symlinking) a predictable path - e.g. under a world-writable /tmp - that a privileged
+// process would otherwise pick up and reuse without noticing.
+func MkdirAll(path string, perm os.FileMode) error {
+	pathInfo, err := os.Lstat(path)
+
+	switch {
+	case os.IsNotExist(err):
+		// Nothing to reuse, fall through to create below.
+	case err != nil:
+		return fmt.Errorf("failed to stat %q: %w", path, err)
+	case isSafeExistingDir(pathInfo):
+		return nil
+	default:
+		rmErr := os.RemoveAll(path)
+		if rmErr != nil {
+			return fmt.Errorf("refusing to reuse unsafe path %q, and failed to remove it: %w", path, rmErr)
+		}
+	}
+
+	err = os.MkdirAll(path, perm)
+	if err != nil {
+		return fmt.Errorf("failed to create %q: %w", path, err)
+	}
+
+	// Re-check after creation to close the remove-then-create race: if another local
+	// user won that narrow window, fail loudly instead of silently using a directory we
+	// don't actually own.
+	pathInfo, err = os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("failed to stat %q after creation: %w", path, err)
+	}
+
+	if !isSafeExistingDir(pathInfo) {
+		return fmt.Errorf("%q: %w", path, ErrUnsafeDirAfterCreate)
+	}
+
+	return nil
+}
+
+// isSafeExistingDir reports whether pathInfo describes a real directory (not a symlink),
+// owned by the current user, that is not writable by group or other.
+func isSafeExistingDir(pathInfo os.FileInfo) bool {
+	if pathInfo.Mode()&os.ModeSymlink != 0 || !pathInfo.IsDir() {
+		return false
+	}
+
+	if pathInfo.Mode().Perm()&0o022 != 0 {
+		return false
+	}
+
+	stat, ok := pathInfo.Sys().(*syscall.Stat_t)
+
+	return ok && int(stat.Uid) == os.Getuid()
+}

--- a/pkg/disk/disk_unix_test.go
+++ b/pkg/disk/disk_unix_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//go:build linux || darwin
+
+package disk
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMkdirAll_CreatesFreshDir(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	target := filepath.Join(base, "fresh")
+
+	require.NoError(t, MkdirAll(target, 0o700))
+
+	pathInfo, err := os.Lstat(target)
+	require.NoError(t, err)
+	assert.True(t, pathInfo.IsDir())
+	assert.Equal(t, os.FileMode(0o700), pathInfo.Mode().Perm())
+}
+
+func TestMkdirAll_LeavesSafeExistingDirUntouched(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	target := filepath.Join(base, "existing")
+	require.NoError(t, os.Mkdir(target, 0o700))
+
+	marker := filepath.Join(target, "marker")
+	require.NoError(t, os.WriteFile(marker, []byte("keep me"), 0o600))
+
+	require.NoError(t, MkdirAll(target, 0o700))
+
+	content, err := os.ReadFile(marker)
+	require.NoError(t, err, "marker file should survive a call over a safe, already-owned directory")
+	assert.Equal(t, "keep me", string(content))
+}
+
+func TestMkdirAll_ReplacesSymlink(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	realDir := filepath.Join(base, "real-target")
+	require.NoError(t, os.Mkdir(realDir, 0o700))
+
+	target := filepath.Join(base, "link")
+	require.NoError(t, os.Symlink(realDir, target))
+
+	require.NoError(t, MkdirAll(target, 0o700))
+
+	pathInfo, err := os.Lstat(target)
+	require.NoError(t, err)
+	assert.Zero(t, pathInfo.Mode()&os.ModeSymlink, "symlink should have been replaced with a real directory")
+	assert.True(t, pathInfo.IsDir())
+}
+
+func TestMkdirAll_ReplacesGroupOtherWritableDir(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	target := filepath.Join(base, "loose")
+	require.NoError(t, os.Mkdir(target, 0o777))
+	require.NoError(t, os.Chmod(target, 0o777)) // bypass umask to guarantee group/other write bits
+
+	marker := filepath.Join(target, "marker")
+	require.NoError(t, os.WriteFile(marker, []byte("should be gone"), 0o600))
+
+	require.NoError(t, MkdirAll(target, 0o700))
+
+	pathInfo, err := os.Lstat(target)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), pathInfo.Mode().Perm())
+
+	_, err = os.Stat(marker)
+	assert.True(t, os.IsNotExist(err), "unsafe directory should have been wiped, not reused")
+}

--- a/pkg/integrations/v4/supervisor_fb.go
+++ b/pkg/integrations/v4/supervisor_fb.go
@@ -19,6 +19,7 @@ import (
 	"github.com/newrelic/infrastructure-agent/internal/agent/id"
 	"github.com/newrelic/infrastructure-agent/internal/feature_flags"
 	"github.com/newrelic/infrastructure-agent/internal/integrations/v4/executor"
+	"github.com/newrelic/infrastructure-agent/pkg/disk"
 	"github.com/newrelic/infrastructure-agent/pkg/entity"
 	"github.com/newrelic/infrastructure-agent/pkg/integrations/v4/logs"
 	"github.com/newrelic/infrastructure-agent/pkg/log"
@@ -28,7 +29,7 @@ import (
 
 const (
 	FbConfTempFolderNameDefault      = "fb"
-	temporaryFolderPermissions       = 0o755
+	temporaryFolderPermissions       = 0o700
 	MaxNumberOfFbConfigTempFiles int = 50
 )
 
@@ -233,8 +234,8 @@ func buildFbExecutor(fbIntCfg fBSupervisorConfig, cfgLoader *logs.CfgLoader) fun
 
 // returns the file name
 func saveToTempFile(tempDir string, config []byte) (string, error) {
-	// ensure that tempdir exits
-	err := os.MkdirAll(tempDir, temporaryFolderPermissions)
+	// ensure that tempdir exists and is safe to reuse
+	err := disk.MkdirAll(tempDir, temporaryFolderPermissions)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create temporary folder for fluent-bit")
 	}

--- a/pkg/integrations/v4/supervisor_fb_test.go
+++ b/pkg/integrations/v4/supervisor_fb_test.go
@@ -103,7 +103,7 @@ func TestFBSupervisorConfig_IsLogForwarderAvailable(t *testing.T) {
 func TestFBSupervisorConfig_LicenseKeyShouldBePassedAsEnvVar(t *testing.T) {
 	t.Parallel()
 
-	fbConf := fBSupervisorConfig{ConfTemporaryFolder: os.TempDir()}
+	fbConf := fBSupervisorConfig{ConfTemporaryFolder: t.TempDir()} //nolint:exhaustruct
 	bypassIsLogForwarderAvailable(t, &fbConf)
 
 	agentIdentity := func() entity.Identity {


### PR DESCRIPTION
The agent's Fluent Bit config temp folder and the integrations temp folder were created with plain `os.MkdirAll`, which silently reuses whatever already exists at that path including a symlink or a pre-existing directory planted by another local user. Since both paths are predictable, a local attacker on a shared host could pre-create them to intercept or tamper with Fluent Bit's config.

* Added `disk.MkdirAll (unix)`, which refuses to blindly reuse an existing path: if it's not a real directory owned by the current user and free of group/other write access, it's wiped and recreated fresh, with a re-check after creation to close the remove-then-create race.
* Switched `assertTempFolderOwnership (initialize_linux.go)` and Fluent Bit's `saveToTempFile (supervisor_fb.go)` to use it, tightening both folders' permissions from `0o755` to `0o700`.
* Fixed a test that broke under the new check: it pointed ConfTemporaryFolder at the shared `os.TempDir()` (`/tmp` on Linux) instead of a private subfolder, so the safety check correctly flagged it as unsafe and failed trying to recreate `/tmp`. Switched it to `t.TempDir()`.