### PR TITLE
chore(deps): bump Go to 1.26.6

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:16.04
 
 # Define Go version
-ARG GO_VERSION=1.26.5
+ARG GO_VERSION=1.26.6
 # Define build-time arguments for the GitHub CLI version and architecture
 ARG GH_VERSION='2.0.0'
 ARG GH_ARCH='amd64'

--- a/test/canaries/deploy_macos_canaries.yml
+++ b/test/canaries/deploy_macos_canaries.yml
@@ -30,7 +30,7 @@
             vars:
               self_instrumentation: true
               target_agent_version: "{{ current_version }}"
-              go_version: 1.26.5
+              go_version: 1.26.6
               display_name: "{{ inventory_hostname }}-current"
 
 - hosts: macos_previous
@@ -50,6 +50,6 @@
             vars:
               self_instrumentation: true
               target_agent_version: "{{ previous_version }}"
-              go_version: 1.26.5
+              go_version: 1.26.6
               display_name: "{{ inventory_hostname }}-previous"
 ...

--- a/test/databind/fargate/Dockerfile_test
+++ b/test/databind/fargate/Dockerfile_test
@@ -1,4 +1,4 @@
-FROM golang:1.26.5
+FROM golang:1.26.6
 
 WORKDIR /go/src/github.com/newrelic/infrastructure-agent/
 

--- a/test/proxy/Dockerfile_agent
+++ b/test/proxy/Dockerfile_agent
@@ -1,4 +1,4 @@
-FROM golang:1.26.5 as builder
+FROM golang:1.26.6 as builder
 
 ARG CGO_ENABLED=0
 WORKDIR /go/src/github.com/newrelic/infrastructure-agent

--- a/test/proxy/Dockerfile_collector
+++ b/test/proxy/Dockerfile_collector
@@ -1,4 +1,4 @@
-FROM golang:1.26.5 as builder
+FROM golang:1.26.6 as builder
 ARG CGO_ENABLED=0
 WORKDIR /go/src/github.com/newrelic/infrastructure-agent
 COPY . .

--- a/tools/cdn-purge/go.mod
+++ b/tools/cdn-purge/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/infrastructure-agent/tools/cdn-purge
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.5

--- a/tools/spin-ec2/go.mod
+++ b/tools/spin-ec2/go.mod
@@ -1,6 +1,6 @@
 module spin-ec2
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/spf13/cobra v1.10.1

--- a/tools/yamlgen/go.mod
+++ b/tools/yamlgen/go.mod
@@ -1,6 +1,6 @@
 module yamlgen
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
## What

Bumps the Go toolchain from 1.26.5 to 1.26.6 across all pinned locations:
- `build/Dockerfile` (`GO_VERSION`)
- `test/canaries/deploy_macos_canaries.yml` (both hosts)
- `test/databind/fargate/Dockerfile_test`
- `test/proxy/Dockerfile_agent`
- `test/proxy/Dockerfile_collector`
- `tools/{cdn-purge,spin-ec2,yamlgen}/go.mod`

Root `go.mod` stays at the bare `go 1.26` directive, unchanged (consistent with the previous patch bump in #2275).

## Why

[go1.26.6](https://go.dev/doc/devel/release#go1.26.6) ships stdlib security fixes for `CVE-2026-39821` and `CVE-2026-46600`, both HIGH severity.

## Verification

- `go build ./cmd/... ./pkg/... ./internal/...` under go1.26.6 — clean
- `go build ./...` in each of `tools/{cdn-purge,spin-ec2,yamlgen}` — clean
- `go mod tidy` in each of the three tools submodules — no changes (no dependency versions affected)

Assisted-by: Claude Sonnet 5