### PR TITLE
feat(renovate): auto-bump nrjmx version pin

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,6 +31,18 @@
       "matchStrings": [
         "(?<integrationName>.+),(?<currentValue>v.+)"
       ]
+    },
+    {
+      // Parse version of nrjmx, bundled only into the Agent Control OCI package
+      // (kept separate from integrations.version on purpose, see build/embed/nrjmx.mk).
+      "fileMatch": [
+        "build/embed/nrjmx.version$"
+      ],
+      "depNameTemplate": "newrelic/nrjmx",
+      "datasourceTemplate": "github-releases", // Version info is fetched from GitHub.
+      "matchStrings": [
+        "(?<currentValue>v.+)"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a `regexManager` entry in `.github/renovate.json5` watching `build/embed/nrjmx.version$`, so Renovate opens a PR whenever `newrelic/nrjmx` cuts a new release — mirroring the existing `integrations.version` regexManager.
- Uses a static `depNameTemplate: "newrelic/nrjmx"` since the pin file is a plain single-line version (no CSV name column to template from).

## Depends on
#2309 (needs `build/embed/nrjmx.version` to exist for the regex to match anything).

## Test plan
- [x] JSON5 parses correctly after the change
- [x] New regexManager's `fileMatch` doesn't overlap the existing `integrations.version` one