### PR TITLE
fix: extend the WMI fallback to retrieve Queue Length

### DIFF
--- a/pkg/metrics/storage/storage_sampler_wmi_windows.go
+++ b/pkg/metrics/storage/storage_sampler_wmi_windows.go
@@ -32,10 +32,14 @@ type Win32_PerfRawData_PerfDisk_LogicalDisk struct {
 }
 
 type Win32_PerfFormattedData_PerfDisk_LogicalDisk struct {
-	Name                 string
-	PercentDiskTime      uint64
-	PercentDiskReadTime  uint64
-	PercentDiskWriteTime uint64
+	Name                    string
+	PercentDiskTime         uint64
+	PercentDiskReadTime     uint64
+	PercentDiskWriteTime    uint64
+	AvgDiskQueueLength      uint64
+	AvgDiskReadQueueLength  uint64
+	AvgDiskWriteQueueLength uint64
+	CurrentDiskQueueLength  uint64
 }
 
 func (d *WmiIoCountersStat) String() string {
@@ -90,9 +94,20 @@ func CalculateWmiSampleValues(counter *WmiIoCountersStat, lastStats *WmiIoCounte
 	result.ReadUtilizationPercent = &read
 	result.WriteUtilizationPercent = &write
 
+	avgQueueLen := float64(counter.Formatted.AvgDiskQueueLength)
+	avgReadQueueLen := float64(counter.Formatted.AvgDiskReadQueueLength)
+	avgWriteQueueLen := float64(counter.Formatted.AvgDiskWriteQueueLength)
+	currentQueueLen := float64(counter.Formatted.CurrentDiskQueueLength)
+
+	result.AvgQueueLen = &avgQueueLen
+	result.AvgReadQueueLen = &avgReadQueueLen
+	result.AvgWriteQueueLen = &avgWriteQueueLen
+	result.CurrentQueueLen = &currentQueueLen
+
 	vlog.
 		WithField("ReadUtilizationPercent", *result.ReadUtilizationPercent).
 		WithField("WriteUtilizationPercent", *result.WriteUtilizationPercent).
+		WithField("CurrentQueueLen", *result.CurrentQueueLen).
 		Debug("CalculateWmiSampleValues")
 
 	return result

--- a/pkg/metrics/storage/storage_sampler_wmi_windows_test.go
+++ b/pkg/metrics/storage/storage_sampler_wmi_windows_test.go
@@ -42,10 +42,14 @@ func TestWmiCalculateBytesRate(t *testing.T) {
 			Timestamp_PerfTime:   1000,
 		},
 		Formatted: Win32_PerfFormattedData_PerfDisk_LogicalDisk{
-			Name:                 "nameeee",
-			PercentDiskTime:      100,
-			PercentDiskReadTime:  90,
-			PercentDiskWriteTime: 80,
+			Name:                    "nameeee",
+			PercentDiskTime:         100,
+			PercentDiskReadTime:     90,
+			PercentDiskWriteTime:    80,
+			AvgDiskQueueLength:      4,
+			AvgDiskReadQueueLength:  3,
+			AvgDiskWriteQueueLength: 2,
+			CurrentDiskQueueLength:  1,
 		},
 	}
 	elapsedMS := int64(1500)
@@ -59,6 +63,11 @@ func TestWmiCalculateBytesRate(t *testing.T) {
 	assert.InEpsilon(t, 100, *ioSample.TotalUtilizationPercent, 0.01)
 	assert.InEpsilon(t, 90, *ioSample.ReadUtilizationPercent, 0.01)
 	assert.InEpsilon(t, 80, *ioSample.WriteUtilizationPercent, 0.01)
+
+	assert.InEpsilon(t, 4, *ioSample.AvgQueueLen, 0.01)
+	assert.InEpsilon(t, 3, *ioSample.AvgReadQueueLen, 0.01)
+	assert.InEpsilon(t, 2, *ioSample.AvgWriteQueueLen, 0.01)
+	assert.InEpsilon(t, 1, *ioSample.CurrentQueueLen, 0.01)
 }
 
 func TestWmiMarshallableSamples(t *testing.T) {


### PR DESCRIPTION
Test results:

// Config option legacy_storage_sampler: true testing

2026-08-18T13:36:32Z" level=info msg="Using Legacy WMI Storage Sampler" component=StorageSampler
time="2026-08-18T13:36:32Z" level=debug msg="Prewarming Sampler Cache." component=Plugins
time="2026-08-18T13:36:32Z" level=debug msg="Refreshing partitions cache." component=StorageSampler
time="2026-08-18T13:36:32Z" level=debug msg="Received sampler payload" component=StorageSampler location=raw structure=Partition supported=true
time="2026-08-18T13:36:32Z" level=debug msg="Received sampler payload" component=StorageSampler location=raw structure=PartitionUsage
time="2026-08-18T13:36:32Z" level=debug msg=WmiIoCounters PerfDisk_LogicalDisk_Values="[{C: 0 0 0 0 0 0 0} {_Total 0 0 0 0 0 0 0}]" component="VMI Windows"
time="2026-08-18T13:36:32Z" level=debug msg="Received sampler payload" component=StorageSampler location=raw structure=DiskIOCounters
time="2026-08-18T13:36:32Z" level=debug msg="Received sampler payload" component=StorageSampler location=final structure=StorageSample
time="2026-08-18T13:36:32Z" level=debug msg="Prewarming NetworkSampler Cache." component=Plugins


//White box testing

time="2026-08-18T14:45:47Z" level=debug msg="Creating partition queries." component="PDH Windows" partition="storage.PartitionStat{Device:\"C:\", Mountpoint:\"C:\", Fstype:\"NTFS\", Opts:\"rw.compress\"}"
time="2026-08-18T14:45:48Z" level=debug msg="NewPdhPoll failed" component="PDH Windows" error="with path \"\\\\LogicalDiskTEST607678(C:)\\\\Disk Reads/sec\" (error 0xc0000bb8)"
time="2026-08-18T14:45:48Z" level=debug msg="PDH IoCounters failed. Falling back to WMI" component=StorageSampler error="with path \"\\\\LogicalDiskTEST607678(C:)\\\\Disk Reads/sec\" (error 0xc0000bb8)"
time="2026-08-18T14:45:48Z" level=debug msg=WmiIoCounters PerfDisk_LogicalDisk_Values="[{C: 0 0 0 0 0 0 0} {_Total 0 0 0 0 0 0 0}]" component="VMI Windows"
time="2026-08-18T14:45:48Z" level=debug msg="Received sampler payload" component=StorageSampler location=raw structure=DiskIOCounters
time="2026-08-18T14:45:48Z" level=debug msg="Received sampler payload" component=StorageSampler location=final structure=StorageSample
