### PR TITLE
chore: bump embedded OHI versions to fix CVEs (nri-docker, nri-flex, nri-prometheus)

### DIFF
--- a/build/embed/integrations.version
+++ b/build/embed/integrations.version
@@ -1,5 +1,5 @@
 #ohi-repo-name,version
-nri-docker,v2.8.2
-nri-flex,v1.18.10
-nri-winservices,v1.5.3
-nri-prometheus,v2.30.2
+nri-docker,v2.8.3
+nri-flex,v1.18.11
+nri-winservices,v1.5.4
+nri-prometheus,v2.30.3


### PR DESCRIPTION
## Summary
Bumps the embedded OHI versions pinned in `build/embed/integrations.version` to the latest releases, each of which fixes the Go stdlib HIGH-severity CVEs (CVE-2026-33818, 39821, 46600, 56853/58/59/60/62) flagged by the Trivy scan on the infrastructure-bundle image:

- `nri-docker`: v2.8.2 -> v2.8.3
- `nri-flex`: v1.18.10 -> v1.18.11
- `nri-winservices`: v1.5.3 -> v1.5.4 (also fixes CVE-2026-46600 in golang.org/x/net and GHSA-hrxh-6v49-42gf in google.golang.org/grpc)
- `nri-prometheus`: v2.30.2 -> v2.30.3

Follows the same pattern as #2302.