### PR TITLE
ci: fix publish_release_notes workflow

### DIFF
--- a/.github/workflows/publish_release_notes.yml
+++ b/.github/workflows/publish_release_notes.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   DESTINATION_REPO: newrelic/docs-website
-  DESTINATION_FOLDER: src/content/docs/release-notes/agent-release-notes/infrastructure-release-notes
+  DESTINATION_FOLDER: src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes
 
 jobs:
   publish-release-notes:
@@ -43,22 +43,65 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Copy file to docs-website branch
-        uses: dmnemec/copy_file_to_another_repo_action@c93037aa10fa8893de271f19978c980d0c1a9b37 # tag v1.1.1
+      - name: Append support statement
+        run: |
+          cat >> "${{ steps.meta.outputs.notes_file }}" << 'EOF'
+
+          ### Support statement:
+
+          A new version of the agent has been released. Follow standard procedures to [update the Infrastructure agent](/docs/infrastructure/install-configure-manage-infrastructure/update-or-uninstall/update-infrastructure-agent).
+
+          We recommend updating to the latest agent version as soon as it's available. If you can't upgrade to the latest version, update your agents to a version no more than 90 days old. Read more about [keeping agents up to date](https://docs.newrelic.com/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/).
+
+          See the [New Relic Infrastructure agent EOL policy](https://docs.newrelic.com/docs/infrastructure/infrastructure-agent/infrastructure-agent-eol-policy/) for information about agent releases and support dates.
+          EOF
+
+      - name: Push release notes to docs-website branch
         env:
-          API_TOKEN_GITHUB: ${{ secrets.OHAI_BOT_GITHUB_TOKEN }}
-        with:
-          source_file: "${{ steps.meta.outputs.notes_file }}"
-          destination_repo: "${{ env.DESTINATION_REPO }}"
-          destination_folder: "${{ env.DESTINATION_FOLDER }}"
-          user_email: "coreint-dev@newrelic.com"
-          user_name: "newrelic-coreint-bot"
-          destination_branch: "develop"
-          destination_branch_create: "${{ steps.meta.outputs.branch_name }}"
-          commit_message: "chore(infrastructure agent): add release notes for v${{ steps.meta.outputs.agent_tag }}"
+          GH_TOKEN: ${{ secrets.OHAI_BOT_GITHUB_TOKEN }}
+          REPO: "${{ env.DESTINATION_REPO }}"
+          FOLDER: "${{ env.DESTINATION_FOLDER }}"
+          BRANCH: "${{ steps.meta.outputs.branch_name }}"
+          NOTES_FILE: "${{ steps.meta.outputs.notes_file }}"
+          COMMIT_MESSAGE: "chore(infrastructure agent): add release notes for v${{ steps.meta.outputs.agent_tag }}"
+        run: |
+          set -e
+          NOTES_PATH="$(pwd)/${NOTES_FILE}"
+
+          git config --global user.email "coreint-dev@newrelic.com"
+          git config --global user.name "newrelic-coreint-bot"
+
+          CLONE_DIR="$(mktemp -d)"
+          git clone --single-branch --branch develop "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$CLONE_DIR"
+          cd "$CLONE_DIR"
+
+          if git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null 2>&1; then
+            echo "Branch $BRANCH already exists on remote — amending previous commit"
+            git fetch origin "$BRANCH"
+            git checkout -B "$BRANCH" FETCH_HEAD
+            mkdir -p "$FOLDER"
+            cp "$NOTES_PATH" "$FOLDER/"
+            git add .
+            git commit --amend --no-edit
+            git push --force origin "HEAD:$BRANCH"
+          else
+            echo "Branch $BRANCH does not exist — creating it"
+            git checkout -b "$BRANCH"
+            mkdir -p "$FOLDER"
+            cp "$NOTES_PATH" "$FOLDER/"
+            git add .
+            git commit --message "$COMMIT_MESSAGE"
+            git push -u origin "HEAD:$BRANCH"
+          fi
 
       - name: Create pull request
-        run: gh pr create --base "develop" --repo "$REPO" --head "$HEAD" --title "$TITLE" --body "$BODY"
+        run: |
+          existing_pr=$(gh pr list --repo "$REPO" --head "$HEAD" --state open --json number --jq 'length')
+          if [ "$existing_pr" != "0" ]; then
+            echo "Open PR already exists for branch $HEAD — skipping creation"
+          else
+            gh pr create --base "develop" --repo "$REPO" --head "$HEAD" --title "$TITLE" --body "$BODY"
+          fi
         env:
           GH_TOKEN: ${{ secrets.OHAI_BOT_GITHUB_TOKEN }}
           REPO: "https://github.com/${{ env.DESTINATION_REPO }}"

--- a/.github/workflows/scripts/generate_release_notes.sh
+++ b/.github/workflows/scripts/generate_release_notes.sh
@@ -5,18 +5,23 @@
 #
 # Expected GitHub release body format:
 #
-#   ### New features
-#   * Short description of feature one
-#   * Short description of feature two
+#   ### 🚀 Enhancements
+#   - Short description of feature one
 #
-#   ### Bug fixes
-#   * Short description of bug fix one
+#   ### 🐞 Bug fixes
+#   - Short description of bug fix one
 #
-#   ### Security
-#   * Short description of security fix (if any)
+#   ### 🛡️ Security notices
+#   - Short description of security fix (if any)
 #
-# Items under each heading populate the MDX frontmatter arrays used by
-# docs-website. Full markdown detail can follow each bullet on subsequent lines.
+# Heading matching is substring-based (case-insensitive) so emoji-prefixed
+# headers like "### 🚀 Enhancements" still match. Items under Enhancements /
+# Bug fixes / Security notices populate the MDX frontmatter arrays (features /
+# bugs / security) used by docs-website; trailing PR/commit refs (#123) and
+# any "in <path>" qualifier (common on dependency-bump lines) are stripped.
+# The full release body (with "## What's Changed" renamed to "## Notes" and
+# the "Full Changelog: ..." line removed) is still appended below the
+# frontmatter as-is.
 
 set -e
 
@@ -44,9 +49,12 @@ release_date = os.environ['RELEASE_DATE']
 output_file  = os.environ['OUTPUT_FILE']
 
 def extract_section(text, *headings):
-    """Return first-line bullet text from a named ### section."""
+    """Return bullet items from a ### section, matched by heading substring
+    (handles emoji-prefixed headers like '### 🚀 Enhancements')."""
     for heading in headings:
-        pattern = rf'###\s+{re.escape(heading)}\s*\n(.*?)(?=\n###|\Z)'
+        # stop at the next heading of ANY level (not just another ###), so a
+        # trailing "## Notes" / "## What's Changed" section can't be slurped in
+        pattern = rf'###[^\n]*{re.escape(heading)}[^\n]*\n(.*?)(?=\n#{{1,6}}\s|\Z)'
         match = re.search(pattern, text, re.DOTALL | re.IGNORECASE)
         if not match:
             continue
@@ -59,21 +67,76 @@ def extract_section(text, *headings):
             # strip trailing PR/commit refs: (#123) or (abc1234)
             item = re.sub(r'\s*\(#\d+\)\s*$', '', item)
             item = re.sub(r'\s*\([0-9a-f]{7,40}\)\s*$', '', item)
+            # drop trailing qualifiers like "in /some/path" (common on dependency bumps)
+            item = re.sub(r'\s+in\s+.*$', '', item, flags=re.IGNORECASE)
             item = item.strip()
             if item:
                 items.append(item)
         return items
     return []
 
-features = extract_section(body, 'New features', 'Features')
+features = extract_section(body, 'Enhancements', 'New features', 'Features')
 bugs      = extract_section(body, 'Bug fixes', 'Fixes', 'Bugfixes')
-security  = extract_section(body, 'Security')
+security  = extract_section(body, 'Security notices', 'Security')
 
 def yaml_list(items):
     if not items:
         return '[]'
     escaped = ["'" + item.replace("'", "''") + "'" for item in items]
     return '[' + ', '.join(escaped) + ']'
+
+def clean_body(text):
+    text = re.sub(r"^##\s*What's Changed\s*$", '## Notes', text, flags=re.MULTILINE | re.IGNORECASE)
+    lines = [
+        line for line in text.splitlines()
+        if not re.match(r'^\*{0,2}Full Changelog\*{0,2}:', line.strip(), re.IGNORECASE)
+    ]
+    return '\n'.join(lines)
+
+def normalize_spacing(text):
+    """Force exactly one blank line both before and after every heading
+    (regardless of how the release was authored — heading-into-content,
+    content-into-heading, or double blank lines between sections), while
+    leaving other paragraph spacing untouched."""
+    lines = text.splitlines()
+    heading_re = re.compile(r'^#{1,6}\s')
+    spaced = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        if heading_re.match(line):
+            if spaced and spaced[-1].strip() != '':
+                spaced.append('')
+            spaced.append(line)
+            j = i + 1
+            while j < n and lines[j].strip() == '':
+                j += 1
+            if j < n:
+                spaced.append('')
+            i = j
+            continue
+        spaced.append(line)
+        i += 1
+
+    collapsed = []
+    blank_run = 0
+    for line in spaced:
+        if line.strip() == '':
+            blank_run += 1
+            if blank_run <= 1:
+                collapsed.append(line)
+        else:
+            blank_run = 0
+            collapsed.append(line)
+    while collapsed and collapsed[0].strip() == '':
+        collapsed.pop(0)
+    while collapsed and collapsed[-1].strip() == '':
+        collapsed.pop()
+    return '\n'.join(collapsed)
+
+body = clean_body(body)
+body = normalize_spacing(body)
 
 with open(output_file, 'w') as f:
     f.write(f"""\


### PR DESCRIPTION
- Create a the new release notes in file `src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/` folder
- Update the publish_release_notes workflow to follow the template Node.js release notes.
- Make the publish_release_notes workflow idempotent. It should be able to generate PRs even if someone run the workflow for the same input tag.

Testing

- Workflow run - https://github.com/newrelic/infrastructure-agent/actions/runs/32962846773
- PR that got created - https://github.com/newrelic/docs-website/pull/25436/changes