### PR TITLE
feat(canaries): fan out A2Q canaries to staging/EU/JP from one trigger

### DIFF
--- a/.github/workflows/component_canaries.yml
+++ b/.github/workflows/component_canaries.yml
@@ -17,6 +17,10 @@ on:
         required: false
         default: 'false'
         type: string
+      A2Q_ENV:
+        required: false
+        default: 'staging'
+        type: string
 
 env:
   AWS_ASSUME_ROLE: 'arn:aws:iam::971422713139:role/caos-pipeline-oidc-infra-agent'
@@ -92,9 +96,9 @@ jobs:
       - name: set vars for legibility (state, inventory ...)
         run: |
           if [[ "${{ inputs.A2Q }}" == "true" ]]; then
-              echo "PREVIOUS_TERRAFORM_STATE=a2q-canaries-${{ inputs.PLATFORM }}-${{ env.PREVIOUS_NR_VERSION }}"  >> $GITHUB_ENV
-              echo "TERRAFORM_STATE=a2q-canaries-${{ inputs.PLATFORM }}-${{ inputs.TAG }}"  >> $GITHUB_ENV
-              echo "INVENTORY_OUTPUT=/srv/runner/inventory/a2q-canary-${{ inputs.TAG }}-${{ inputs.PLATFORM }}-inventory.ec2"  >> $GITHUB_ENV
+              echo "PREVIOUS_TERRAFORM_STATE=a2q-canaries-${{ inputs.PLATFORM }}-${{ inputs.A2Q_ENV }}-${{ env.PREVIOUS_NR_VERSION }}"  >> $GITHUB_ENV
+              echo "TERRAFORM_STATE=a2q-canaries-${{ inputs.PLATFORM }}-${{ inputs.A2Q_ENV }}-${{ inputs.TAG }}"  >> $GITHUB_ENV
+              echo "INVENTORY_OUTPUT=/srv/runner/inventory/a2q-canary-${{ inputs.TAG }}-${{ inputs.PLATFORM }}-${{ inputs.A2Q_ENV }}-inventory.ec2"  >> $GITHUB_ENV
 
           else
               echo "PREVIOUS_TERRAFORM_STATE=canaries-${{ inputs.PLATFORM }}-${{ env.PREVIOUS_NR_VERSION }}"  >> $GITHUB_ENV
@@ -106,7 +110,7 @@ jobs:
         uses: newrelic/fargate-runner-action@main
         with:
           aws_region: us-east-2
-          container_make_target: "-C test/provision TERRAFORM_STATE_KEY=${{ env.TERRAFORM_STATE }} PREFIX=canary INVENTORY_OUTPUT=${{ env.INVENTORY_OUTPUT }} TAG_OR_UNIQUE_NAME=${{ inputs.TAG }} PLATFORM=${{ inputs.PLATFORM }} IS_A2Q=${{ inputs.A2Q }}"
+          container_make_target: "-C test/provision TERRAFORM_STATE_KEY=${{ env.TERRAFORM_STATE }} PREFIX=canary INVENTORY_OUTPUT=${{ env.INVENTORY_OUTPUT }} TAG_OR_UNIQUE_NAME=${{ inputs.TAG }} PLATFORM=${{ inputs.PLATFORM }} IS_A2Q=${{ inputs.A2Q }} A2Q_ENV=${{ inputs.A2Q_ENV }}"
           ecs_cluster_name: caos_infra_agent
           task_definition_name: infra-agent
           cloud_watch_logs_group_name: /ecs/test-prerelease-infra-agent
@@ -126,7 +130,7 @@ jobs:
         uses: newrelic/fargate-runner-action@main
         with:
           aws_region: us-east-2
-          container_make_target: "-C test/canaries terraform-canaries ANSIBLE_INVENTORY=${{ env.INVENTORY_OUTPUT }} PLATFORM=${{ inputs.PLATFORM }} ANSIBLE_FORKS=${{ env.ANSIBLE_FORKS }} VERSION=${{ env.NR_VERSION }} PREVIOUS_VERSION=${{ env.PREVIOUS_NR_VERSION }} IS_A2Q=${{ inputs.A2Q }}"
+          container_make_target: "-C test/canaries terraform-canaries ANSIBLE_INVENTORY=${{ env.INVENTORY_OUTPUT }} PLATFORM=${{ inputs.PLATFORM }} ANSIBLE_FORKS=${{ env.ANSIBLE_FORKS }} VERSION=${{ env.NR_VERSION }} PREVIOUS_VERSION=${{ env.PREVIOUS_NR_VERSION }} IS_A2Q=${{ inputs.A2Q }} A2Q_ENV=${{ inputs.A2Q_ENV }}"
           ecs_cluster_name: caos_infra_agent
           task_definition_name: infra-agent
           cloud_watch_logs_group_name: /ecs/test-prerelease-infra-agent
@@ -163,10 +167,10 @@ jobs:
       - name: set vars for legibility (state, inventory ...)
         run: |
           if [[ "${{ inputs.A2Q }}" == "true" ]]; then
-              echo "TERRAFORM_STATE_PREVIOUS=a2q-canaries-${{ inputs.PLATFORM }}-${{ inputs.TAG }}-previous"  >> $GITHUB_ENV
-              echo "TERRAFORM_STATE_CURRENT=a2q-canaries-${{ inputs.PLATFORM }}-${{ inputs.TAG }}-current"  >> $GITHUB_ENV
-              echo "INVENTORY_PREVIOUS=/srv/runner/inventory/canary-${{ inputs.TAG }}-${{ inputs.PLATFORM }}-previous-inventory.ec2"  >> $GITHUB_ENV
-              echo "INVENTORY_CURRENT=/srv/runner/inventory/canary-${{ inputs.TAG }}-${{ inputs.PLATFORM }}-current-inventory.ec2"  >> $GITHUB_ENV
+              echo "TERRAFORM_STATE_PREVIOUS=a2q-canaries-${{ inputs.PLATFORM }}-${{ inputs.A2Q_ENV }}-${{ inputs.TAG }}-previous"  >> $GITHUB_ENV
+              echo "TERRAFORM_STATE_CURRENT=a2q-canaries-${{ inputs.PLATFORM }}-${{ inputs.A2Q_ENV }}-${{ inputs.TAG }}-current"  >> $GITHUB_ENV
+              echo "INVENTORY_PREVIOUS=/srv/runner/inventory/canary-${{ inputs.TAG }}-${{ inputs.PLATFORM }}-${{ inputs.A2Q_ENV }}-previous-inventory.ec2"  >> $GITHUB_ENV
+              echo "INVENTORY_CURRENT=/srv/runner/inventory/canary-${{ inputs.TAG }}-${{ inputs.PLATFORM }}-${{ inputs.A2Q_ENV }}-current-inventory.ec2"  >> $GITHUB_ENV
           else
               echo "TERRAFORM_STATE_PREVIOUS=canaries-${{ inputs.PLATFORM }}-${{ inputs.TAG }}-previous"  >> $GITHUB_ENV
               echo "TERRAFORM_STATE_CURRENT=canaries-${{ inputs.PLATFORM }}-${{ inputs.TAG }}-current"  >> $GITHUB_ENV
@@ -178,7 +182,7 @@ jobs:
         uses: newrelic/fargate-runner-action@main
         with:
           aws_region: us-east-2
-          container_make_target: "-C test/provision TERRAFORM_STATE_KEY=${{ env.TERRAFORM_STATE_PREVIOUS }} PREFIX=canary INVENTORY_OUTPUT=${{ env.INVENTORY_PREVIOUS }} TAG_OR_UNIQUE_NAME=${{ env.PREVIOUS_NR_VERSION }} PLATFORM=${{ inputs.PLATFORM }} IS_A2Q=${{ inputs.A2Q }}"
+          container_make_target: "-C test/provision TERRAFORM_STATE_KEY=${{ env.TERRAFORM_STATE_PREVIOUS }} PREFIX=canary INVENTORY_OUTPUT=${{ env.INVENTORY_PREVIOUS }} TAG_OR_UNIQUE_NAME=${{ env.PREVIOUS_NR_VERSION }} PLATFORM=${{ inputs.PLATFORM }} IS_A2Q=${{ inputs.A2Q }} A2Q_ENV=${{ inputs.A2Q_ENV }}"
           ecs_cluster_name: caos_infra_agent
           task_definition_name: infra-agent
           cloud_watch_logs_group_name: /ecs/test-prerelease-infra-agent
@@ -198,7 +202,7 @@ jobs:
         uses: newrelic/fargate-runner-action@main
         with:
           aws_region: us-east-2
-          container_make_target: "-C test/provision TERRAFORM_STATE_KEY=${{ env.TERRAFORM_STATE_CURRENT }} PREFIX=canary INVENTORY_OUTPUT=${{ env.INVENTORY_CURRENT }} TAG_OR_UNIQUE_NAME=${{ env.NR_VERSION }} PLATFORM=${{ inputs.PLATFORM }} IS_A2Q=${{ inputs.A2Q }}"
+          container_make_target: "-C test/provision TERRAFORM_STATE_KEY=${{ env.TERRAFORM_STATE_CURRENT }} PREFIX=canary INVENTORY_OUTPUT=${{ env.INVENTORY_CURRENT }} TAG_OR_UNIQUE_NAME=${{ env.NR_VERSION }} PLATFORM=${{ inputs.PLATFORM }} IS_A2Q=${{ inputs.A2Q }} A2Q_ENV=${{ inputs.A2Q_ENV }}"
           ecs_cluster_name: caos_infra_agent
           task_definition_name: infra-agent
           cloud_watch_logs_group_name: /ecs/test-prerelease-infra-agent
@@ -218,7 +222,7 @@ jobs:
         uses: newrelic/fargate-runner-action@main
         with:
           aws_region: us-east-2
-          container_make_target: "-C test/canaries terraform-canaries ANSIBLE_INVENTORY=${{ env.INVENTORY_PREVIOUS }} PLATFORM=${{ inputs.PLATFORM }} ANSIBLE_FORKS=${{ env.ANSIBLE_FORKS }} VERSION=${{ env.PREVIOUS_NR_VERSION }} PREVIOUS_VERSION='NOT_USED_VALUE' IS_A2Q=${{ inputs.A2Q }} IS_PREVIOUS=true"
+          container_make_target: "-C test/canaries terraform-canaries ANSIBLE_INVENTORY=${{ env.INVENTORY_PREVIOUS }} PLATFORM=${{ inputs.PLATFORM }} ANSIBLE_FORKS=${{ env.ANSIBLE_FORKS }} VERSION=${{ env.PREVIOUS_NR_VERSION }} PREVIOUS_VERSION='NOT_USED_VALUE' IS_A2Q=${{ inputs.A2Q }} A2Q_ENV=${{ inputs.A2Q_ENV }} IS_PREVIOUS=true"
           ecs_cluster_name: caos_infra_agent
           task_definition_name: infra-agent
           cloud_watch_logs_group_name: /ecs/test-prerelease-infra-agent
@@ -231,7 +235,7 @@ jobs:
         uses: newrelic/fargate-runner-action@main
         with:
           aws_region: us-east-2
-          container_make_target: "-C test/canaries terraform-canaries ANSIBLE_INVENTORY=${{ env.INVENTORY_CURRENT }} PLATFORM=${{ inputs.PLATFORM }} ANSIBLE_FORKS=${{ env.ANSIBLE_FORKS }} VERSION=${{ env.NR_VERSION }} PREVIOUS_VERSION='NOT_USED_VALUE' IS_A2Q=${{ inputs.A2Q }} IS_PREVIOUS=false"
+          container_make_target: "-C test/canaries terraform-canaries ANSIBLE_INVENTORY=${{ env.INVENTORY_CURRENT }} PLATFORM=${{ inputs.PLATFORM }} ANSIBLE_FORKS=${{ env.ANSIBLE_FORKS }} VERSION=${{ env.NR_VERSION }} PREVIOUS_VERSION='NOT_USED_VALUE' IS_A2Q=${{ inputs.A2Q }} A2Q_ENV=${{ inputs.A2Q_ENV }} IS_PREVIOUS=false"
           ecs_cluster_name: caos_infra_agent
           task_definition_name: infra-agent
           cloud_watch_logs_group_name: /ecs/test-prerelease-infra-agent

--- a/.github/workflows/create_a2Q_canaries.yml
+++ b/.github/workflows/create_a2Q_canaries.yml
@@ -24,6 +24,7 @@ permissions:
 
 jobs:
   A2Q-canaries-windows:
+    # EU/JP only provision config1+config2 (both Linux) - no windows fan-out for those envs.
     if: ${{ github.event.inputs.windows == 'true' }}
     permissions:
       contents: read
@@ -33,10 +34,14 @@ jobs:
       PLATFORM: "windows"
       TAG: ${{ github.event.inputs.tag }}
       A2Q: true
+      A2Q_ENV: staging
     secrets:
       AWS_VPC_SUBNET: ${{secrets.AWS_VPC_SUBNET}}
   A2Q-canaries-linux:
     if: ${{ github.event.inputs.linux == 'true' }}
+    strategy:
+      matrix:
+        env: [staging, eu, jp]
     permissions:
       contents: read
       id-token: write # calls component_canaries.yml which needs AWS OIDC auth
@@ -45,5 +50,6 @@ jobs:
       PLATFORM: "linux"
       TAG: ${{ github.event.inputs.tag }}
       A2Q: true
+      A2Q_ENV: ${{ matrix.env }}
     secrets:
       AWS_VPC_SUBNET: ${{secrets.AWS_VPC_SUBNET}}

--- a/test/automated/terraform/fargate/main.tf
+++ b/test/automated/terraform/fargate/main.tf
@@ -2,6 +2,14 @@ provider "aws" {
   region = "us-east-2"
 }
 
+locals {
+  license_secret_name_a2q = (
+    var.a2q_env == "eu" ? var.secret_name_license_keys_canaries_A2Q_eu :
+    var.a2q_env == "jp" ? var.secret_name_license_keys_canaries_A2Q_jp :
+    var.secret_name_license_keys_canaries_A2Q
+  )
+}
+
 #########################################
 # State Backend
 #########################################
@@ -54,7 +62,7 @@ module "otel_infra" {
         },
         {
           "name" : "NR_LICENSE_KEYS_CANARIES_A2Q",
-          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_license_keys_canaries_A2Q}"
+          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${local.license_secret_name_a2q}"
         },
         {
           "name" : "NEW_RELIC_ACCOUNT_ID",
@@ -103,6 +111,8 @@ module "otel_infra" {
                   "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_license_canaries_A2Q_1}",
                   "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_license_canaries_A2Q_2}",
                   "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_license_keys_canaries_A2Q}",
+                  "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_license_keys_canaries_A2Q_eu}",
+                  "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_license_keys_canaries_A2Q_jp}",
                   "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_account}",
                   "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_api}",
                   "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_windows_password}",

--- a/test/automated/terraform/fargate/main.tf
+++ b/test/automated/terraform/fargate/main.tf
@@ -2,14 +2,6 @@ provider "aws" {
   region = "us-east-2"
 }
 
-locals {
-  license_secret_name_a2q = (
-    var.a2q_env == "eu" ? var.secret_name_license_keys_canaries_A2Q_eu :
-    var.a2q_env == "jp" ? var.secret_name_license_keys_canaries_A2Q_jp :
-    var.secret_name_license_keys_canaries_A2Q
-  )
-}
-
 #########################################
 # State Backend
 #########################################
@@ -62,7 +54,15 @@ module "otel_infra" {
         },
         {
           "name" : "NR_LICENSE_KEYS_CANARIES_A2Q",
-          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${local.license_secret_name_a2q}"
+          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_license_keys_canaries_A2Q}"
+        },
+        {
+          "name" : "NR_LICENSE_KEYS_CANARIES_A2Q_EU",
+          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_license_keys_canaries_A2Q_eu}"
+        },
+        {
+          "name" : "NR_LICENSE_KEYS_CANARIES_A2Q_JP",
+          "valueFrom" : "arn:aws:secretsmanager:${var.region}:${var.accountId}:secret:${var.secret_name_license_keys_canaries_A2Q_jp}"
         },
         {
           "name" : "NEW_RELIC_ACCOUNT_ID",

--- a/test/automated/terraform/fargate/vars.tf
+++ b/test/automated/terraform/fargate/vars.tf
@@ -86,10 +86,6 @@ variable "secret_name_license_keys_canaries_A2Q_jp" {
   default = "caos/canaries/license_keys_canaries_A2Q_jp-Dx4cAw"
 }
 
-variable "a2q_env" {
-  default = "staging"
-}
-
 variable "secret_name_account" {
   default = "caos/canaries/account-EOzJkq"
 }

--- a/test/automated/terraform/fargate/vars.tf
+++ b/test/automated/terraform/fargate/vars.tf
@@ -78,6 +78,18 @@ variable "secret_name_license_keys_canaries_A2Q" {
   default = "caos/canaries/license_keys_canaries_A2Q-ozAvrS"
 }
 
+variable "secret_name_license_keys_canaries_A2Q_eu" {
+  default = "caos/canaries/license_keys_canaries_A2Q_eu-hoGJtf"
+}
+
+variable "secret_name_license_keys_canaries_A2Q_jp" {
+  default = "caos/canaries/license_keys_canaries_A2Q_jp-Dx4cAw"
+}
+
+variable "a2q_env" {
+  default = "staging"
+}
+
 variable "secret_name_account" {
   default = "caos/canaries/account-EOzJkq"
 }

--- a/test/canaries/Makefile
+++ b/test/canaries/Makefile
@@ -1,5 +1,6 @@
 ANSIBLE_FOLDER := $(CURDIR)
 ANSIBLE_FORKS ?= 20
+A2Q_ENV ?= staging
 
 .DEFAULT_GOAL := canaries
 
@@ -26,7 +27,13 @@ endif
 
 ## Conditional Canary Deployment
 ifeq ($(IS_A2Q),true)
+ifeq ($(A2Q_ENV),eu)
+	    NR_KEYS_JSON='$(NR_LICENSE_KEYS_CANARIES_A2Q_EU)' ansible-playbook -f $(ANSIBLE_FORKS) -i $(ANSIBLE_INVENTORY) "$(ANSIBLE_FOLDER)/deploy_a2q_canaries.yml" -e "current_version=$(VERSION) previous_version=$(PREVIOUS_VERSION) nr_license_key_a2q_1=$(NR_LICENSE_KEY_CANARIES_A2Q_1) nr_license_key_a2q_2=$(NR_LICENSE_KEY_CANARIES_A2Q_2) docker_username=$(DOCKER_USERNAME) docker_password=$(DOCKER_PASSWORD) is_previous=${IS_PREVIOUS} a2q_staging=false nr_license_keys_a2q={{ lookup('env','NR_KEYS_JSON') | from_json }}"
+else ifeq ($(A2Q_ENV),jp)
+	    NR_KEYS_JSON='$(NR_LICENSE_KEYS_CANARIES_A2Q_JP)' ansible-playbook -f $(ANSIBLE_FORKS) -i $(ANSIBLE_INVENTORY) "$(ANSIBLE_FOLDER)/deploy_a2q_canaries.yml" -e "current_version=$(VERSION) previous_version=$(PREVIOUS_VERSION) nr_license_key_a2q_1=$(NR_LICENSE_KEY_CANARIES_A2Q_1) nr_license_key_a2q_2=$(NR_LICENSE_KEY_CANARIES_A2Q_2) docker_username=$(DOCKER_USERNAME) docker_password=$(DOCKER_PASSWORD) is_previous=${IS_PREVIOUS} a2q_staging=false nr_license_keys_a2q={{ lookup('env','NR_KEYS_JSON') | from_json }}"
+else
 	    NR_KEYS_JSON='$(NR_LICENSE_KEYS_CANARIES_A2Q)' ansible-playbook -f $(ANSIBLE_FORKS) -i $(ANSIBLE_INVENTORY) "$(ANSIBLE_FOLDER)/deploy_a2q_canaries.yml" -e "current_version=$(VERSION) previous_version=$(PREVIOUS_VERSION) nr_license_key_a2q_1=$(NR_LICENSE_KEY_CANARIES_A2Q_1) nr_license_key_a2q_2=$(NR_LICENSE_KEY_CANARIES_A2Q_2) docker_username=$(DOCKER_USERNAME) docker_password=$(DOCKER_PASSWORD) is_previous=${IS_PREVIOUS} nr_license_keys_a2q={{ lookup('env','NR_KEYS_JSON') | from_json }}"
+endif
 else
 	    ansible-playbook -f $(ANSIBLE_FORKS) -i $(ANSIBLE_INVENTORY) "$(ANSIBLE_FOLDER)/deploy_canaries.yml" -e "current_version=$(VERSION) previous_version=$(PREVIOUS_VERSION) nr_license_key=$(NR_LICENSE_KEY_CANARIES) docker_username=$(DOCKER_USERNAME) docker_password=$(DOCKER_PASSWORD)"
 endif

--- a/test/canaries/deploy_a2q_canaries.yml
+++ b/test/canaries/deploy_a2q_canaries.yml
@@ -20,6 +20,7 @@
             name: caos.ansible_roles.infra_agent
           vars:
             is_containerized: true
+            staging: "{{ a2q_staging | default('true') | bool }}"
             target_version: "{{ current_version }}-rc"
             display_name: "{{ inventory_hostname }}-current"
             nr_license_key: "{{ nr_license_keys_a2q[((config_num | int) - 1) * 2] }}"
@@ -29,6 +30,7 @@
             name: caos.ansible_roles.infra_agent
           vars:
             is_containerized: true
+            staging: "{{ a2q_staging | default('true') | bool }}"
             target_version: "{{ previous_version }}"
             display_name: "{{ inventory_hostname }}-previous"
             nr_license_key: "{{ nr_license_keys_a2q[((config_num | int) - 1) * 2 + 1] }}"
@@ -54,6 +56,7 @@
           include_role:
             name: caos.ansible_roles.infra_agent
           vars:
+            staging: "{{ a2q_staging | default('true') | bool }}"
             target_version: "{{ current_version }}"
             repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
             nr_license_key: "{{ nr_license_keys_a2q[((config_num | int) - 1) * 2 + (1 if is_previous == 'true' else 0)] }}"

--- a/test/provision/Makefile
+++ b/test/provision/Makefile
@@ -19,6 +19,8 @@ endif
 	sed -i -e "s/PREFIX/$(PREFIX)/g" "$(TERRAFORM_DIR)/caos.auto.tfvars"
 	sed -i -e "s/TAG_OR_UNIQUE_NAME/$(TAG_OR_UNIQUE_NAME)/g" "$(TERRAFORM_DIR)/caos.auto.tfvars"
 
+A2Q_ENV ?= staging
+
 .PHONY: provision
 provision: terraform/backend
 ifndef PLATFORM
@@ -44,6 +46,7 @@ endif
 	TF_VAR_nr_license_key="$(NR_LICENSE_KEY)" \
 	TF_VAR_inventory_output="$(INVENTORY_OUTPUT)" \
 	TF_VAR_is_A2Q="$(IS_A2Q)" \
+	TF_VAR_a2q_env="$(A2Q_ENV)" \
 	terraform -chdir=$(TERRAFORM_DIR) apply -auto-approve
 
 .PHONY: clean

--- a/test/provision/terraform/main.tf
+++ b/test/provision/terraform/main.tf
@@ -54,8 +54,17 @@ variable "is_A2Q" {
   default = false
 }
 
+variable "a2q_env" {
+  default = "staging"
+}
+
 locals {
-    filtered_ec2 = var.platform == "windows" ? var.windows_ec2 : flatten([var.linux_ec2_amd, var.linux_ec2_arm])
+    a2q_limited_ec2_filters = ["A2Q_config1_", "A2Q_config2_"]
+    filtered_ec2 = (
+      var.is_A2Q && contains(["eu", "jp"], var.a2q_env)
+      ? local.a2q_limited_ec2_filters
+      : (var.platform == "windows" ? var.windows_ec2 : flatten([var.linux_ec2_amd, var.linux_ec2_arm]))
+    )
 }
 
 module "env-provisioner" {


### PR DESCRIPTION
## Summary

Enables a single `workflow_dispatch` trigger to stand up A2Q canaries across three environments — staging, EU, and JP.

### What changed

- **`A2Q_ENV` axis** (`staging` | `eu` | `jp`): selects which license-key secret the agent uses and whether it runs against New Relic staging or production infra (the `staging` flag). Region routing happens entirely through the license key + that flag — the role has no concept of region-specific collector/identity/command-channel URLs, so none were added.
- **One-trigger fan-out**: `create_a2Q_canaries.yml`'s linux job now matrixes over `[staging, eu, jp]`, so a single dispatch runs all three in parallel. The windows job stays staging-only.
- **Reduced scope for EU/JP**: those two environments only provision `config1`+`config2` (both Linux) instead of the full 8 configs staging uses.
- **Shared ECS task definition** (`infra-agent`, used by all canary runs) now exposes all three license-key secrets as permanent, separate environment variables, since that infra is applied once as shared state rather than per CI run — the per-run environment selection has to happen in the Makefile, not in which secret Terraform wires up.
- **New EU secret** created in Secrets Manager with the required license key, matching the existing secret format.

### Net effect

Triggering the workflow once now provisions and installs canaries for all three environments concurrently, each isolated by its own Terraform state/inventory naming.

### Testing

https://github.com/newrelic/infrastructure-agent/actions/runs/32988525966
