### PR TITLE
fix: update publish release notes workflow

### DIFF
--- a/.github/workflows/publish_release_notes.yml
+++ b/.github/workflows/publish_release_notes.yml
@@ -34,9 +34,10 @@ jobs:
         run: |
           TAG="${{ github.event.release.tag_name || inputs.tag }}"
           cleaned=$(echo "$TAG" | sed 's/\./-/g')
+          version_nodots=$(echo "$TAG" | tr -d '.')
           echo "agent_tag=$TAG" >> $GITHUB_OUTPUT
           echo "branch_name=infra-agent-release-notes-${cleaned}" >> $GITHUB_OUTPUT
-          echo "notes_file=infrastructure-agent-${cleaned}.mdx" >> $GITHUB_OUTPUT
+          echo "notes_file=new-relic-infrastructure-agent-${version_nodots}.mdx" >> $GITHUB_OUTPUT
 
       - name: Generate release notes file
         run: .github/workflows/scripts/generate_release_notes.sh "${{ steps.meta.outputs.agent_tag }}"
@@ -76,23 +77,17 @@ jobs:
           cd "$CLONE_DIR"
 
           if git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null 2>&1; then
-            echo "Branch $BRANCH already exists on remote — amending previous commit"
-            git fetch origin "$BRANCH"
-            git checkout -B "$BRANCH" FETCH_HEAD
-            mkdir -p "$FOLDER"
-            cp "$NOTES_PATH" "$FOLDER/"
-            git add .
-            git commit --amend --no-edit
-            git push --force origin "HEAD:$BRANCH"
-          else
-            echo "Branch $BRANCH does not exist — creating it"
-            git checkout -b "$BRANCH"
-            mkdir -p "$FOLDER"
-            cp "$NOTES_PATH" "$FOLDER/"
-            git add .
-            git commit --message "$COMMIT_MESSAGE"
-            git push -u origin "HEAD:$BRANCH"
+            echo "Branch $BRANCH already exists on remote — deleting it so it's recreated fresh from develop"
+            git push origin --delete "$BRANCH"
           fi
+
+          echo "Creating branch $BRANCH from develop"
+          git checkout -b "$BRANCH"
+          mkdir -p "$FOLDER"
+          cp "$NOTES_PATH" "$FOLDER/"
+          git add .
+          git commit --message "$COMMIT_MESSAGE"
+          git push -u origin "HEAD:$BRANCH"
 
       - name: Create pull request
         run: |

--- a/.github/workflows/scripts/generate_release_notes.sh
+++ b/.github/workflows/scripts/generate_release_notes.sh
@@ -31,8 +31,8 @@ if [ -z "$TAG" ]; then
   exit 1
 fi
 
-CLEANED_VERSION=$(echo "$TAG" | sed 's/\./-/g')
-OUTPUT_FILE="infrastructure-agent-${CLEANED_VERSION}.mdx"
+VERSION_NODOTS=$(echo "$TAG" | tr -d '.')
+OUTPUT_FILE="new-relic-infrastructure-agent-${VERSION_NODOTS}.mdx"
 
 RELEASE_INFO=$(gh release view "$TAG" --json publishedAt,body)
 RELEASE_DATE=$(echo "$RELEASE_INFO" | jq -r '.publishedAt | split("T")[0]')
@@ -93,6 +93,12 @@ def clean_body(text):
     ]
     return '\n'.join(lines)
 
+def linkify_pr_urls(text):
+    """Turn a bare PR URL (as GitHub's auto-generated 'in <url>' references
+    render) into a markdown link showing just #NNNN as the visible text."""
+    pattern = re.compile(r'https://github\.com/[\w.-]+/[\w.-]+/pull/(\d+)')
+    return pattern.sub(lambda m: f'[#{m.group(1)}]({m.group(0)})', text)
+
 def normalize_spacing(text):
     """Force exactly one blank line both before and after every heading
     (regardless of how the release was authored — heading-into-content,
@@ -136,6 +142,7 @@ def normalize_spacing(text):
     return '\n'.join(collapsed)
 
 body = clean_body(body)
+body = linkify_pr_urls(body)
 body = normalize_spacing(body)
 
 with open(output_file, 'w') as f:


### PR DESCRIPTION
Update publish_release_notes workflow to

- Create release notes with file name `new-relic-infrastructure-agent-version_with_no_dots.mdx`
- Delete a branch if a branch already exists and recreate to make the workflow idempotent instead of doing amend commit.


Testing 

- Workflow run - https://github.com/newrelic/infrastructure-agent/actions/runs/33063497877
- docs-website PR - https://github.com/newrelic/docs-website/pull/25448
<img width="3344" height="1924" alt="image" src="https://github.com/user-attachments/assets/4e6dd198-9bd3-4fa8-afb1-c17f0003ebe8" />

