### PR TITLE
fix: allow mountpath for safe dir check

### DIFF
--- a/pkg/disk/disk_unix.go
+++ b/pkg/disk/disk_unix.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"syscall"
 )
 
@@ -41,7 +42,7 @@ func MkdirAll(path string, perm os.FileMode) error {
 		// Nothing to reuse, fall through to create below.
 	case err != nil:
 		return fmt.Errorf("failed to stat %q: %w", path, err)
-	case isSafeExistingDir(pathInfo):
+	case isSafeExistingDir(path, pathInfo):
 		return nil
 	default:
 		rmErr := os.RemoveAll(path)
@@ -63,25 +64,66 @@ func MkdirAll(path string, perm os.FileMode) error {
 		return fmt.Errorf("failed to stat %q after creation: %w", path, err)
 	}
 
-	if !isSafeExistingDir(pathInfo) {
+	if !isSafeExistingDir(path, pathInfo) {
 		return fmt.Errorf("%q: %w", path, ErrUnsafeDirAfterCreate)
 	}
 
 	return nil
 }
 
-// isSafeExistingDir reports whether pathInfo describes a real directory (not a symlink),
-// owned by the current user, that is not writable by group or other.
-func isSafeExistingDir(pathInfo os.FileInfo) bool {
+// isSafeExistingDir reports whether pathInfo describes a real directory (not a symlink)
+// owned by the current user, that is either not writable by group/other, or is a distinct
+// mount point (e.g. a Kubernetes emptyDir/tmpfs volume).
+//
+// A separate mount point is set up by a privileged process (the container runtime/kubelet)
+// before the agent ever runs, not planted by an arbitrary local user - the "predictable
+// writable path" attack MkdirAll guards against requires being able to create the path
+// ahead of time under a shared, writable parent directory (e.g. /tmp), which isn't possible
+// for a distinct filesystem mount. Kubernetes commonly mounts emptyDir volumes as
+// world/group-writable (mode 0777), so without this exemption every such mount is wrongly
+// treated as unsafe and removed - which then fails outright when the mount is the root of a
+// read-only-root-filesystem container, since the mount point itself can't be unlinked from
+// its (read-only) parent.
+func isSafeExistingDir(path string, pathInfo os.FileInfo) bool {
 	if pathInfo.Mode()&os.ModeSymlink != 0 || !pathInfo.IsDir() {
 		return false
 	}
 
-	if pathInfo.Mode().Perm()&0o022 != 0 {
+	stat, ok := pathInfo.Sys().(*syscall.Stat_t)
+	if !ok || int(stat.Uid) != os.Getuid() {
 		return false
 	}
 
-	stat, ok := pathInfo.Sys().(*syscall.Stat_t)
+	if pathInfo.Mode().Perm()&0o022 != 0 && !isMountPoint(path, uint64(stat.Dev)) {
+		return false
+	}
 
-	return ok && int(stat.Uid) == os.Getuid()
+	return true
+}
+
+// statDev returns the device number of the filesystem containing path. It is a package-level
+// var, like the WriteFile/OpenFile/Create façades above, so tests can simulate a distinct
+// mount without needing an actual mount syscall.
+var statDev = func(path string) (dev uint64, ok bool) { //nolint:gochecknoglobals
+	info, err := os.Lstat(path)
+	if err != nil {
+		return 0, false
+	}
+
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+
+	return uint64(stat.Dev), true
+}
+
+// isMountPoint reports whether path is the root of a distinct filesystem mount, i.e. its
+// device number differs from its parent directory's. A failure to resolve the parent's
+// device is treated as "not a mount point" so callers fall back to the stricter permission
+// check.
+func isMountPoint(path string, dev uint64) bool {
+	parentDev, ok := statDev(filepath.Dir(path))
+
+	return ok && parentDev != dev
 }

--- a/pkg/disk/disk_unix.go
+++ b/pkg/disk/disk_unix.go
@@ -94,17 +94,17 @@ func isSafeExistingDir(path string, pathInfo os.FileInfo) bool {
 		return false
 	}
 
-	if pathInfo.Mode().Perm()&0o022 != 0 && !isMountPoint(path, uint64(stat.Dev)) {
+	dev := uint64(stat.Dev) //nolint:gosec // device numbers are kernel-assigned identifiers, never negative
+
+	if pathInfo.Mode().Perm()&0o022 != 0 && !isMountPoint(path, dev) {
 		return false
 	}
 
 	return true
 }
 
-// statDev returns the device number of the filesystem containing path. It is a package-level
-// var, like the WriteFile/OpenFile/Create façades above, so tests can simulate a distinct
-// mount without needing an actual mount syscall.
-var statDev = func(path string) (dev uint64, ok bool) { //nolint:gochecknoglobals
+// statDevImpl returns the device number of the filesystem containing path.
+func statDevImpl(path string) (uint64, bool) {
 	info, err := os.Lstat(path)
 	if err != nil {
 		return 0, false
@@ -115,8 +115,12 @@ var statDev = func(path string) (dev uint64, ok bool) { //nolint:gochecknoglobal
 		return 0, false
 	}
 
-	return uint64(stat.Dev), true
+	return uint64(stat.Dev), true //nolint:gosec // device numbers are kernel-assigned identifiers, never negative
 }
+
+// statDev is a package-level var, like the WriteFile/OpenFile/Create façades above, so tests
+// can simulate a distinct mount without needing an actual mount syscall.
+var statDev = statDevImpl //nolint:gochecknoglobals
 
 // isMountPoint reports whether path is the root of a distinct filesystem mount, i.e. its
 // device number differs from its parent directory's. A failure to resolve the parent's

--- a/pkg/disk/disk_unix.go
+++ b/pkg/disk/disk_unix.go
@@ -94,8 +94,8 @@ func isSafeExistingDir(path string, pathInfo os.FileInfo) bool {
 		return false
 	}
 
-	//nolint:gosec,unconvert // device numbers are kernel-assigned identifiers, never negative;
-	// stat.Dev is int32 on some archs, uint64 on others - the conversion is a no-op there but widening is never wrong
+	//nolint:unconvert // stat.Dev is already uint64 on this arch (redundant here), but int32 on
+	// others (e.g. darwin/amd64) where the widening conversion is required; kept explicit for portability
 	dev := uint64(stat.Dev)
 
 	if pathInfo.Mode().Perm()&0o022 != 0 && !isMountPoint(path, dev) {
@@ -117,8 +117,8 @@ func statDevImpl(path string) (uint64, bool) {
 		return 0, false
 	}
 
-	//nolint:gosec,unconvert // device numbers are kernel-assigned identifiers, never negative;
-	// stat.Dev is int32 on some archs, uint64 on others - the conversion is a no-op there but widening is never wrong
+	//nolint:unconvert // stat.Dev is already uint64 on this arch (redundant here), but int32 on
+	// others (e.g. darwin/amd64) where the widening conversion is required; kept explicit for portability
 	return uint64(stat.Dev), true
 }
 

--- a/pkg/disk/disk_unix.go
+++ b/pkg/disk/disk_unix.go
@@ -94,7 +94,9 @@ func isSafeExistingDir(path string, pathInfo os.FileInfo) bool {
 		return false
 	}
 
-	dev := uint64(stat.Dev) //nolint:gosec // device numbers are kernel-assigned identifiers, never negative
+	//nolint:gosec,unconvert // device numbers are kernel-assigned identifiers, never negative;
+	// stat.Dev is int32 on some archs, uint64 on others - the conversion is a no-op there but widening is never wrong
+	dev := uint64(stat.Dev)
 
 	if pathInfo.Mode().Perm()&0o022 != 0 && !isMountPoint(path, dev) {
 		return false
@@ -115,7 +117,9 @@ func statDevImpl(path string) (uint64, bool) {
 		return 0, false
 	}
 
-	return uint64(stat.Dev), true //nolint:gosec // device numbers are kernel-assigned identifiers, never negative
+	//nolint:gosec,unconvert // device numbers are kernel-assigned identifiers, never negative;
+	// stat.Dev is int32 on some archs, uint64 on others - the conversion is a no-op there but widening is never wrong
+	return uint64(stat.Dev), true
 }
 
 // statDev is a package-level var, like the WriteFile/OpenFile/Create façades above, so tests

--- a/pkg/disk/disk_unix.go
+++ b/pkg/disk/disk_unix.go
@@ -94,9 +94,7 @@ func isSafeExistingDir(path string, pathInfo os.FileInfo) bool {
 		return false
 	}
 
-	//nolint:unconvert // stat.Dev is already uint64 on this arch (redundant here), but int32 on
-	// others (e.g. darwin/amd64) where the widening conversion is required; kept explicit for portability
-	dev := uint64(stat.Dev)
+	dev := devNumber(stat.Dev)
 
 	if pathInfo.Mode().Perm()&0o022 != 0 && !isMountPoint(path, dev) {
 		return false
@@ -117,9 +115,20 @@ func statDevImpl(path string) (uint64, bool) {
 		return 0, false
 	}
 
-	//nolint:unconvert // stat.Dev is already uint64 on this arch (redundant here), but int32 on
-	// others (e.g. darwin/amd64) where the widening conversion is required; kept explicit for portability
-	return uint64(stat.Dev), true
+	return devNumber(stat.Dev), true
+}
+
+// devKind is the set of concrete types syscall.Stat_t.Dev has across the platforms this file
+// builds for: uint64 on linux, int32 on darwin.
+type devKind interface {
+	~int8 | ~int16 | ~int32 | ~int64 | ~uint8 | ~uint16 | ~uint32 | ~uint64
+}
+
+// devNumber widens stat.Dev to uint64. It's generic purely so the conversion is never a
+// same-type no-op at any single instantiation site - keeping golangci-lint's unconvert check
+// happy without platform-specific nolint directives.
+func devNumber[T devKind](dev T) uint64 {
+	return uint64(dev)
 }
 
 // statDev is a package-level var, like the WriteFile/OpenFile/Create façades above, so tests

--- a/pkg/disk/disk_unix_test.go
+++ b/pkg/disk/disk_unix_test.go
@@ -82,3 +82,69 @@ func TestMkdirAll_ReplacesGroupOtherWritableDir(t *testing.T) {
 	_, err = os.Stat(marker)
 	assert.True(t, os.IsNotExist(err), "unsafe directory should have been wiped, not reused")
 }
+
+// TestMkdirAll_ReusesWorldWritableMountPoint reproduces
+// https://github.com/newrelic/infrastructure-agent/issues/2324: a Kubernetes emptyDir is
+// mounted mode 0777 directly at the data dir path. Without the mount-point exemption this
+// directory is wrongly flagged as "unsafe" and wiped, which fails outright when the mount is
+// the root of a read-only-root-filesystem container (the mount point can't be unlinked from
+// its read-only parent) - exactly the fatal "refusing to reuse unsafe path ... read-only file
+// system" crash-loop reported in the issue.
+func TestMkdirAll_ReusesWorldWritableMountPoint(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "emptydir")
+	require.NoError(t, os.Mkdir(target, 0o777))
+	require.NoError(t, os.Chmod(target, 0o777))
+
+	marker := filepath.Join(target, "marker")
+	require.NoError(t, os.WriteFile(marker, []byte("keep me"), 0o600))
+
+	restore := fakeMountPoint(t, target)
+	defer restore()
+
+	require.NoError(t, MkdirAll(target, 0o700))
+
+	content, err := os.ReadFile(marker)
+	require.NoError(t, err, "a distinct mount point should be reused, not wiped, even if world-writable")
+	assert.Equal(t, "keep me", string(content))
+}
+
+// TestMkdirAll_UnsafeNonMountPointStillReplaced guards against over-widening the exemption:
+// a world-writable directory that is NOT a distinct mount point (statDev reports the same
+// device as its parent, the common case for a directory planted under a shared writable
+// parent like /tmp) must still be treated as unsafe and wiped.
+func TestMkdirAll_UnsafeNonMountPointStillReplaced(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "same-device")
+	require.NoError(t, os.Mkdir(target, 0o777))
+	require.NoError(t, os.Chmod(target, 0o777))
+
+	marker := filepath.Join(target, "marker")
+	require.NoError(t, os.WriteFile(marker, []byte("should be gone"), 0o600))
+
+	require.NoError(t, MkdirAll(target, 0o700))
+
+	_, err := os.Stat(marker)
+	assert.True(t, os.IsNotExist(err), "same-device writable directory should still be wiped")
+}
+
+// fakeMountPoint overrides statDev so target appears to live on a different device than its
+// parent, simulating a Kubernetes emptyDir/tmpfs mount without requiring an actual mount
+// syscall (which needs root and is Linux-specific). It restores the original statDev on
+// cleanup.
+func fakeMountPoint(t *testing.T, target string) func() {
+	t.Helper()
+
+	parent := filepath.Dir(target)
+	original := statDev
+
+	statDev = func(path string) (uint64, bool) {
+		if path == parent {
+			return 999, true // any device number distinct from target's real one
+		}
+
+		return original(path)
+	}
+
+	return func() { statDev = original }
+}

--- a/pkg/disk/disk_unix_test.go
+++ b/pkg/disk/disk_unix_test.go
@@ -90,6 +90,11 @@ func TestMkdirAll_ReplacesGroupOtherWritableDir(t *testing.T) {
 // the root of a read-only-root-filesystem container (the mount point can't be unlinked from
 // its read-only parent) - exactly the fatal "refusing to reuse unsafe path ... read-only file
 // system" crash-loop reported in the issue.
+//
+// It does not call t.Parallel(): it overrides the package-level statDev seam, which must not
+// run concurrently with other tests that call MkdirAll/isSafeExistingDir.
+//
+//nolint:paralleltest
 func TestMkdirAll_ReusesWorldWritableMountPoint(t *testing.T) {
 	base := t.TempDir()
 	target := filepath.Join(base, "emptydir")
@@ -114,6 +119,8 @@ func TestMkdirAll_ReusesWorldWritableMountPoint(t *testing.T) {
 // device as its parent, the common case for a directory planted under a shared writable
 // parent like /tmp) must still be treated as unsafe and wiped.
 func TestMkdirAll_UnsafeNonMountPointStillReplaced(t *testing.T) {
+	t.Parallel()
+
 	base := t.TempDir()
 	target := filepath.Join(base, "same-device")
 	require.NoError(t, os.Mkdir(target, 0o777))


### PR DESCRIPTION
Allow world writable dir when folder is mounted separately in K8s. This is needed as this is how we ship our manifest today. Will have to update the manifest and once that is done, we'll update this piece of code to recommend not to use the 777 emptyDir.